### PR TITLE
feat: added action for widget.li.fi

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,4 +29,4 @@ jobs:
       - name: Deploy app build to S3 bucket
         run: |
           aws s3 sync ./packages/widget-playground/dist/ s3://playground.li.fi --delete
-          aws s3 sync ./packages/widget-embedded/dist/ s3://embedded.li.fi --delete
+          aws s3 sync ./packages/widget-embedded/dist/ s3://widget.li.fi --delete


### PR DESCRIPTION
Instead of creating a new action for [widget.li.fi](https://widget.li.fi), I’ve just “merged” it into the playground one in order to install and build only once and not waste time and resources, since the `build` cmd builds everything and the deployment action is basically the same apart of the folder name and bucket/endpoint (all of the other configurations are already configured: DNS, bucket, etc)