### PR TITLE
support ed25519 address

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,5 +51,8 @@
     "react-dom": "^18.2.0",
     "standard-version": "^9.5.0",
     "typescript": "^5.1.3"
+  },
+  "dependencies": {
+    "@solana/web3.js": "^1.77.3"
   }
 }

--- a/packages/widget/src/components/SendToWallet/SendToWallet.tsx
+++ b/packages/widget/src/components/SendToWallet/SendToWallet.tsx
@@ -1,4 +1,3 @@
-import { isAddress } from '@ethersproject/address';
 import type { BoxProps } from '@mui/material';
 import { Collapse, FormHelperText } from '@mui/material';
 import { forwardRef, useEffect, useRef } from 'react';
@@ -9,6 +8,7 @@ import { useSendToWalletStore, useSettings } from '../../stores';
 import { DisabledUI, HiddenUI, RequiredUI } from '../../types';
 import { Card, CardTitle } from '../Card';
 import { FormControl, Input } from './SendToWallet.style';
+import { isLiFiAddress } from '@lifi/widget/utils/address';
 
 export const SendToWallet: React.FC<BoxProps> = forwardRef((props, ref) => {
   const { t } = useTranslation();
@@ -39,7 +39,7 @@ export const SendToWallet: React.FC<BoxProps> = forwardRef((props, ref) => {
           }
           const address = await account.signer?.provider?.resolveName(value);
           return (
-            isAddress(address || value) ||
+            isLiFiAddress(address || value) ||
             (t('swap.error.title.walletAddressInvalid') as string)
           );
         } catch {

--- a/packages/widget/src/hooks/useGetTokenBalancesWithRetry.ts
+++ b/packages/widget/src/hooks/useGetTokenBalancesWithRetry.ts
@@ -1,8 +1,8 @@
-import { isAddress } from '@ethersproject/address';
 import type { Provider } from '@ethersproject/providers';
 import type { Token, TokenAmount } from '@lifi/sdk';
 import { useCallback } from 'react';
 import { useLiFi } from '../providers';
+import { isLiFiAddress } from '../utils/address';
 
 export const useGetTokenBalancesWithRetry = (provider?: Provider) => {
   const lifi = useLiFi();
@@ -14,7 +14,7 @@ export const useGetTokenBalancesWithRetry = (provider?: Provider) => {
       depth = 0,
     ): Promise<TokenAmount[] | undefined> => {
       try {
-        const walletAddress = isAddress(accountAddress)
+        const walletAddress = isLiFiAddress(accountAddress)
           ? accountAddress
           : await provider?.resolveName(accountAddress);
 

--- a/packages/widget/src/hooks/useSwapRoutes.ts
+++ b/packages/widget/src/hooks/useSwapRoutes.ts
@@ -1,4 +1,3 @@
-import { isAddress } from '@ethersproject/address';
 import type { Route, RoutesResponse, Token } from '@lifi/sdk';
 import { LifiErrorCode } from '@lifi/sdk';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
@@ -9,6 +8,7 @@ import { useDebouncedWatch, useGasRefuel, useToken } from '.';
 import { SwapFormKey, useLiFi, useWallet, useWidgetConfig } from '../providers';
 import { useSettings } from '../stores';
 import { useSwapOnly } from './useSwapOnly';
+import { isLiFiAddress } from '../utils/address';
 
 const refetchTime = 60_000;
 
@@ -141,9 +141,9 @@ export const useSwapRoutes = ({ insurableRoute }: SwapRoutesProps = {}) => {
         try {
           toWalletAddress =
             (await account.signer?.provider?.resolveName(toAddress)) ??
-            (isAddress(toAddress) ? toAddress : fromAddress);
+            (isLiFiAddress(toAddress) ? toAddress : fromAddress);
         } catch {
-          toWalletAddress = isAddress(toAddress) ? toAddress : fromAddress;
+          toWalletAddress = isLiFiAddress(toAddress) ? toAddress : fromAddress;
         }
         const fromAmount = Big(fromTokenAmount || 0)
           .mul(10 ** (fromToken?.decimals ?? 0))

--- a/packages/widget/src/utils/address.ts
+++ b/packages/widget/src/utils/address.ts
@@ -1,0 +1,23 @@
+import * as web3 from '@solana/web3.js';
+import { isAddress } from '@ethersproject/address';
+
+/**
+ * isLiFiAddress checks if the address is a valid EVM or Solana address.
+ * @param address: string
+ * @returns
+ */
+export const isLiFiAddress = (address: string): boolean => {
+  // checks if the address is EVM
+  if (isAddress(address)) {
+    return true;
+  }
+
+  // checks if the address is a valid Solana PublicKey
+  try {
+    new web3.PublicKey(address);
+    return true;
+  } catch (_) {}
+
+  // exhausted, not a "valid" address
+  return false;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -3904,7 +3904,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@solana/web3.js@npm:^1.70.1":
+"@solana/web3.js@npm:^1.70.1, @solana/web3.js@npm:^1.77.3":
   version: 1.77.3
   resolution: "@solana/web3.js@npm:1.77.3"
   dependencies:
@@ -14290,6 +14290,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
+    "@solana/web3.js": ^1.77.3
     "@testing-library/dom": ^9.3.0
     "@testing-library/jest-dom": ^5.16.5
     "@testing-library/react": ^14.0.0


### PR DESCRIPTION
## Background

As of now the `toAddress` is required to be an EVM address. However, as we move towards new non-EVM ecosystems we would need to allow new types of addresses. The first one is to support public keys on the ed25519 elliptic curve. This would enable Solana addresses. 

This change request should serve as a point of discussion and should not be taken as the final solution. 

Additionally, it would make sense to automatically display the `toAddress` field if the `toChain` does not support the EVM address. 