### PR TITLE
feat: curated wallets for the destination address selection

### DIFF
--- a/packages/widget-playground/src/config.ts
+++ b/packages/widget-playground/src/config.ts
@@ -13,27 +13,27 @@ export const widgetBaseConfig: WidgetConfig = {
   // fromToken: '0x2791bca1f2de4661ed88a30c99a7a9449aa84174',
   // toToken: '0x7f5c764cbc14f9669b88837ca1490cca17c31607', // 0x0000000000000000000000000000000000000000
   // fromAmount: '20',
-  toAddress: {
-    name: 'Jenny',
-    address: '0x552008c0f6870c2f77e5cC1d2eb9bdff03e30Ea9',
-    chainType: ChainType.EVM,
-  },
-  toAddresses: [
-    {
-      name: 'Jenny',
-      address: '0x552008c0f6870c2f77e5cC1d2eb9bdff03e30Ea9',
-      chainType: ChainType.EVM,
-    },
-    {
-      address: '0x552008c0f6870c2f77e5cC1d2eb9bdff03e30Ea0',
-      chainType: ChainType.EVM,
-    },
-    {
-      name: 'Sol',
-      address: '6AUWsSCRFSCbrHKH9s84wfzJXtD6mNzAHs11x6pGEcmJ',
-      chainType: ChainType.SVM,
-    },
-  ],
+  // toAddress: {
+  //   name: 'Jenny',
+  //   address: '0xAB3Afc314e75dC1648A2E31c06861A07a048C050',
+  //   chainType: ChainType.EVM,
+  // },
+  // toAddresses: [
+  //   {
+  //     name: 'Lenny',
+  //     address: '0x552008c0f6870c2f77e5cC1d2eb9bdff03e30Ea9',
+  //     chainType: ChainType.EVM,
+  //   },
+  //   {
+  //     address: '0x552008c0f6870c2f77e5cC1d2eb9bdff03e30Ea0',
+  //     chainType: ChainType.EVM,
+  //   },
+  //   {
+  //     name: 'Sol',
+  //     address: '6AUWsSCRFSCbrHKH9s84wfzJXtD6mNzAHs11x6pGEcmJ',
+  //     chainType: ChainType.SVM,
+  //   },
+  // ],
   variant: 'expandable',
   // subvariant: 'split',
   integrator: 'li.fi-playground',

--- a/packages/widget-playground/src/config.ts
+++ b/packages/widget-playground/src/config.ts
@@ -13,7 +13,7 @@ export const widgetBaseConfig: WidgetConfig = {
   // fromToken: '0x2791bca1f2de4661ed88a30c99a7a9449aa84174',
   // toToken: '0x7f5c764cbc14f9669b88837ca1490cca17c31607', // 0x0000000000000000000000000000000000000000
   // fromAmount: '20',
-  // toAddress: '0x552008c0f6870c2f77e5cC1d2eb9bdff03e30Ea0',
+  toAddress: '0x552008c0f6870c2f77e5cC1d2eb9bdff03e30Ea0',
 
   variant: 'expandable',
   // subvariant: 'split',

--- a/packages/widget-playground/src/config.ts
+++ b/packages/widget-playground/src/config.ts
@@ -13,11 +13,11 @@ export const widgetBaseConfig: WidgetConfig = {
   // fromToken: '0x2791bca1f2de4661ed88a30c99a7a9449aa84174',
   // toToken: '0x7f5c764cbc14f9669b88837ca1490cca17c31607', // 0x0000000000000000000000000000000000000000
   // fromAmount: '20',
-  // toAddress: {
-  //   name: 'Jenny',
-  //   address: '0x552008c0f6870c2f77e5cC1d2eb9bdff03e30Ea9',
-  //   chainType: ChainType.EVM,
-  // },
+  toAddress: {
+    name: 'Jenny',
+    address: '0x552008c0f6870c2f77e5cC1d2eb9bdff03e30Ea9',
+    chainType: ChainType.EVM,
+  },
   toAddresses: [
     {
       name: 'Jenny',

--- a/packages/widget-playground/src/config.ts
+++ b/packages/widget-playground/src/config.ts
@@ -1,4 +1,4 @@
-import { ChainId } from '@lifi/sdk';
+import { ChainId, ChainType } from '@lifi/sdk';
 import type { WidgetConfig } from '@lifi/widget';
 import './fonts/inter.css';
 import './index.css';
@@ -13,8 +13,12 @@ export const widgetBaseConfig: WidgetConfig = {
   // fromToken: '0x2791bca1f2de4661ed88a30c99a7a9449aa84174',
   // toToken: '0x7f5c764cbc14f9669b88837ca1490cca17c31607', // 0x0000000000000000000000000000000000000000
   // fromAmount: '20',
-  toAddress: '0x552008c0f6870c2f77e5cC1d2eb9bdff03e30Ea0',
-
+  // toAddress: '0x552008c0f6870c2f77e5cC1d2eb9bdff03e30Ea0',
+  toAddress: {
+    name: 'Jenny',
+    address: '0x552008c0f6870c2f77e5cC1d2eb9bdff03e30Ea9',
+    chainType: ChainType.EVM,
+  },
   variant: 'expandable',
   // subvariant: 'split',
   integrator: 'li.fi-playground',

--- a/packages/widget-playground/src/config.ts
+++ b/packages/widget-playground/src/config.ts
@@ -13,12 +13,27 @@ export const widgetBaseConfig: WidgetConfig = {
   // fromToken: '0x2791bca1f2de4661ed88a30c99a7a9449aa84174',
   // toToken: '0x7f5c764cbc14f9669b88837ca1490cca17c31607', // 0x0000000000000000000000000000000000000000
   // fromAmount: '20',
-  // toAddress: '0x552008c0f6870c2f77e5cC1d2eb9bdff03e30Ea0',
-  toAddress: {
-    name: 'Jenny',
-    address: '0x552008c0f6870c2f77e5cC1d2eb9bdff03e30Ea9',
-    chainType: ChainType.EVM,
-  },
+  // toAddress: {
+  //   name: 'Jenny',
+  //   address: '0x552008c0f6870c2f77e5cC1d2eb9bdff03e30Ea9',
+  //   chainType: ChainType.EVM,
+  // },
+  toAddresses: [
+    {
+      name: 'Jenny',
+      address: '0x552008c0f6870c2f77e5cC1d2eb9bdff03e30Ea9',
+      chainType: ChainType.EVM,
+    },
+    {
+      address: '0x552008c0f6870c2f77e5cC1d2eb9bdff03e30Ea0',
+      chainType: ChainType.EVM,
+    },
+    {
+      name: 'Sol',
+      address: '6AUWsSCRFSCbrHKH9s84wfzJXtD6mNzAHs11x6pGEcmJ',
+      chainType: ChainType.SVM,
+    },
+  ],
   variant: 'expandable',
   // subvariant: 'split',
   integrator: 'li.fi-playground',

--- a/packages/widget/src/AppRoutes.tsx
+++ b/packages/widget/src/AppRoutes.tsx
@@ -14,6 +14,7 @@ import {
   ConnectedWalletsPage,
   RecentWalletsPage,
   SendToWalletPage,
+  SendToConfiguredWalletPage,
 } from './pages/SendToWallet';
 import { SettingsPage } from './pages/SettingsPage';
 import { TransactionDetailsPage } from './pages/TransactionDetailsPage';
@@ -96,6 +97,10 @@ const routes: RouteObject[] = [
   {
     path: `${navigationRoutes.sendToWallet}/${navigationRoutes.connectedWallets}`,
     element: <ConnectedWalletsPage />,
+  },
+  {
+    path: `${navigationRoutes.sendToWallet}/${navigationRoutes.configuredWallets}`,
+    element: <SendToConfiguredWalletPage />,
   },
   {
     path: navigationRoutes.transactionHistory,

--- a/packages/widget/src/AppRoutes.tsx
+++ b/packages/widget/src/AppRoutes.tsx
@@ -99,7 +99,7 @@ const routes: RouteObject[] = [
     element: <ConnectedWalletsPage />,
   },
   {
-    path: `${navigationRoutes.sendToWallet}/${navigationRoutes.configuredWallets}`,
+    path: navigationRoutes.configuredWallets,
     element: <SendToConfiguredWalletPage />,
   },
   {

--- a/packages/widget/src/components/Header/NavigationHeader.tsx
+++ b/packages/widget/src/components/Header/NavigationHeader.tsx
@@ -46,6 +46,7 @@ export const NavigationHeader: React.FC = () => {
       case navigationRoutes.exchanges:
         return t(`settings.enabledExchanges`);
       case navigationRoutes.sendToWallet:
+      case navigationRoutes.configuredWallets:
         return t(`header.sendToWallet`);
       case navigationRoutes.bookmarks:
         return t(`header.bookmarkedWallets`);

--- a/packages/widget/src/components/SendToWallet/SendToWalletButton.tsx
+++ b/packages/widget/src/components/SendToWallet/SendToWalletButton.tsx
@@ -24,7 +24,7 @@ import { SendToWalletCardHeader } from './SendToWallet.style';
 export const SendToWalletButton = () => {
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const { disabledUI, hiddenUI, toAddress } = useWidgetConfig();
+  const { disabledUI, hiddenUI, toAddress, toAddresses } = useWidgetConfig();
   const { showSendToWallet, showSendToWalletDirty, setSendToWallet } =
     useSendToWalletStore();
   const { showDestinationWallet } = useSettings(['showDestinationWallet']);
@@ -73,10 +73,10 @@ export const SendToWalletButton = () => {
     : !!selectedBookmark?.name && address;
 
   const handleOnClick = () => {
-    // TODO: add condition make the selection if curated wallets in config
-    // navigate(navigationRoutes.sendToWallet);
     navigate(
-      `${navigationRoutes.sendToWallet}/${navigationRoutes.configuredWallets}`,
+      toAddresses?.length
+        ? `${navigationRoutes.sendToWallet}/${navigationRoutes.configuredWallets}`
+        : navigationRoutes.sendToWallet,
     );
   };
 

--- a/packages/widget/src/components/SendToWallet/SendToWalletButton.tsx
+++ b/packages/widget/src/components/SendToWallet/SendToWalletButton.tsx
@@ -73,7 +73,11 @@ export const SendToWalletButton = () => {
     : !!selectedBookmark?.name && address;
 
   const handleOnClick = () => {
-    navigate(navigationRoutes.sendToWallet);
+    // TODO: add condition make the selection if curated wallets in config
+    // navigate(navigationRoutes.sendToWallet);
+    navigate(
+      `${navigationRoutes.sendToWallet}/${navigationRoutes.configuredWallets}`,
+    );
   };
 
   // Sync SendToWalletExpandButton state

--- a/packages/widget/src/components/SendToWallet/SendToWalletButton.tsx
+++ b/packages/widget/src/components/SendToWallet/SendToWalletButton.tsx
@@ -75,7 +75,7 @@ export const SendToWalletButton = () => {
   const handleOnClick = () => {
     navigate(
       toAddresses?.length
-        ? `${navigationRoutes.sendToWallet}/${navigationRoutes.configuredWallets}`
+        ? navigationRoutes.configuredWallets
         : navigationRoutes.sendToWallet,
     );
   };

--- a/packages/widget/src/components/Step/Step.tsx
+++ b/packages/widget/src/components/Step/Step.tsx
@@ -57,8 +57,9 @@ export const Step: React.FC<{
 
   const formattedToAddress = shortenAddress(toAddress);
   const toAddressLink = toAddress
-    ? `${getChainById(step.action.toChainId)?.metamask
-        .blockExplorerUrls[0]}address/${toAddress}`
+    ? `${
+        getChainById(step.action.toChainId)?.metamask.blockExplorerUrls[0]
+      }address/${toAddress}`
     : undefined;
 
   return (

--- a/packages/widget/src/hooks/useToAddressReset.ts
+++ b/packages/widget/src/hooks/useToAddressReset.ts
@@ -26,6 +26,9 @@ export const useToAddressReset = () => {
     // but it keeps toAddress value set for the previous chain pair.
     if (shouldResetToAddress) {
       setSelectedBookmark();
+      // TODO: question: this seems to be wiping the toAddress when selecting a chain
+      //  need to look at this and understand what the correct behaviour
+      //  for when the toAddress is set via config
       setFieldValue('toAddress', '');
     }
   };

--- a/packages/widget/src/hooks/useToAddressReset.ts
+++ b/packages/widget/src/hooks/useToAddressReset.ts
@@ -26,9 +26,6 @@ export const useToAddressReset = () => {
     // but it keeps toAddress value set for the previous chain pair.
     if (shouldResetToAddress) {
       setSelectedBookmark();
-      // TODO: question: this seems to be wiping the toAddress when selecting a chain
-      //  need to look at this and understand what the correct behaviour
-      //  for when the toAddress is set via config
       setFieldValue('toAddress', '');
     }
   };

--- a/packages/widget/src/pages/SendToWallet/ConfirmAddressSheet.tsx
+++ b/packages/widget/src/pages/SendToWallet/ConfirmAddressSheet.tsx
@@ -41,7 +41,9 @@ export const ConfirmAddressSheet = forwardRef<
 
   const handleConfirm = () => {
     if (validatedBookmark) {
-      setFieldValue('toAddress', validatedBookmark.address);
+      setFieldValue('toAddress', validatedBookmark.address, {
+        isTouched: true,
+      });
       onConfirm?.(validatedBookmark);
       setSendToWallet(true);
       handleClose();

--- a/packages/widget/src/pages/SendToWallet/SendToConfiguredWalletPage.tsx
+++ b/packages/widget/src/pages/SendToWallet/SendToConfiguredWalletPage.tsx
@@ -38,7 +38,7 @@ export const SendToConfiguredWalletPage = () => {
 
   const handleCuratedSelected = (toAddress: ToAddress) => {
     setSelectedBookmark(toAddress);
-    setFieldValue('toAddress', toAddress.address);
+    setFieldValue('toAddress', toAddress.address, { isTouched: true });
     navigate(navigationRoutes.home);
   };
 

--- a/packages/widget/src/pages/SendToWallet/SendToConfiguredWalletPage.tsx
+++ b/packages/widget/src/pages/SendToWallet/SendToConfiguredWalletPage.tsx
@@ -1,0 +1,152 @@
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import MoreHorizIcon from '@mui/icons-material/MoreHoriz';
+import OpenInNewIcon from '@mui/icons-material/OpenInNew';
+import { ListItemAvatar, ListItemText, MenuItem } from '@mui/material';
+import { useId, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
+import { AccountAvatar } from '../../components/AccountAvatar';
+import { ListItem, ListItemButton } from '../../components/ListItem';
+import { Menu } from '../../components/Menu';
+import { useChains, useToAddressRequirements } from '../../hooks';
+import type { Bookmark } from '../../stores';
+import { useBookmarkActions, useBookmarks } from '../../stores';
+import {
+  defaultChainIdsByType,
+  navigationRoutes,
+  shortenAddress,
+} from '../../utils';
+import {
+  ListContainer,
+  OptionsMenuButton,
+  SendToWalletPageContainer,
+} from './SendToWalletPage.style';
+
+export const SendToConfiguredWalletPage = () => {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const [selectedConfiguredWallet, setSelectedConfiguredWallet] =
+    useState<Bookmark>();
+  const { recentWallets: configuredWallets } = useBookmarks();
+  const { requiredToChainType } = useToAddressRequirements();
+  const { setSelectedBookmark } = useBookmarkActions();
+  const { getChainById } = useChains();
+  const moreMenuId = useId();
+  const [moreMenuAnchorEl, setMenuAnchorEl] = useState<HTMLElement | null>();
+  const open = Boolean(moreMenuAnchorEl);
+
+  const handleCuratedSelected = (configuredWallet: Bookmark) => {
+    setSelectedBookmark(configuredWallet);
+  };
+
+  const closeMenu = () => {
+    setMenuAnchorEl(null);
+  };
+
+  const handleMenuOpen = (el: HTMLElement, configuredWallet: Bookmark) => {
+    setMenuAnchorEl(el);
+    setSelectedConfiguredWallet(configuredWallet);
+  };
+
+  const handleCopyAddress = () => {
+    if (selectedConfiguredWallet) {
+      navigator.clipboard.writeText(selectedConfiguredWallet.address);
+    }
+    closeMenu();
+  };
+
+  const handleViewOnExplorer = () => {
+    if (selectedConfiguredWallet) {
+      const chain = getChainById(
+        defaultChainIdsByType[selectedConfiguredWallet.chainType],
+      );
+      window.open(
+        `${chain?.metamask.blockExplorerUrls[0]}address/${selectedConfiguredWallet.address}`,
+        '_blank',
+      );
+    }
+    closeMenu();
+  };
+
+  return (
+    <SendToWalletPageContainer disableGutters>
+      <ListContainer sx={{ minHeight: 418 }}>
+        {configuredWallets.map((configredWallet) => (
+          <ListItem key={configredWallet.address} sx={{ position: 'relative' }}>
+            <ListItemButton
+              disabled={
+                requiredToChainType &&
+                requiredToChainType !== configredWallet.chainType
+              }
+              onClick={() => handleCuratedSelected(configredWallet)}
+            >
+              <ListItemAvatar>
+                <AccountAvatar
+                  chainId={defaultChainIdsByType[configredWallet.chainType]}
+                />
+              </ListItemAvatar>
+              <ListItemText
+                primary={
+                  configredWallet.name ||
+                  shortenAddress(configredWallet.address)
+                }
+                secondary={
+                  configredWallet.name
+                    ? shortenAddress(configredWallet.address)
+                    : undefined
+                }
+              />
+            </ListItemButton>
+            <OptionsMenuButton
+              aria-label={t('button.options')}
+              aria-controls={
+                open &&
+                configredWallet.address === selectedConfiguredWallet?.address
+                  ? moreMenuId
+                  : undefined
+              }
+              aria-haspopup="true"
+              aria-expanded={open ? 'true' : undefined}
+              onClick={(e) =>
+                handleMenuOpen(e.target as HTMLElement, configredWallet)
+              }
+              sx={{
+                opacity:
+                  requiredToChainType &&
+                  requiredToChainType !== configredWallet.chainType
+                    ? 0.5
+                    : 1,
+              }}
+            >
+              <MoreHorizIcon fontSize="small" />
+            </OptionsMenuButton>
+          </ListItem>
+        ))}
+        <Menu
+          id={moreMenuId}
+          elevation={0}
+          anchorOrigin={{
+            vertical: 'bottom',
+            horizontal: 'right',
+          }}
+          transformOrigin={{
+            vertical: 'top',
+            horizontal: 'right',
+          }}
+          anchorEl={moreMenuAnchorEl}
+          open={open}
+          onClose={closeMenu}
+        >
+          <MenuItem onClick={handleCopyAddress}>
+            <ContentCopyIcon />
+            {t('button.copyAddress')}
+          </MenuItem>
+          <MenuItem onClick={handleViewOnExplorer}>
+            <OpenInNewIcon />
+            {t('button.viewOnExplorer')}
+          </MenuItem>
+        </Menu>
+      </ListContainer>
+    </SendToWalletPageContainer>
+  );
+};

--- a/packages/widget/src/pages/SendToWallet/index.ts
+++ b/packages/widget/src/pages/SendToWallet/index.ts
@@ -2,3 +2,4 @@ export * from './BookmarksPage';
 export * from './ConnectedWalletsPage';
 export * from './RecentWalletsPage';
 export * from './SendToWalletPage';
+export * from './SendToConfiguredWalletPage';

--- a/packages/widget/src/pages/TransactionDetailsPage/TransactionDetailsPage.tsx
+++ b/packages/widget/src/pages/TransactionDetailsPage/TransactionDetailsPage.tsx
@@ -1,4 +1,4 @@
-import { FullStatusData } from '@lifi/sdk';
+import type { FullStatusData } from '@lifi/sdk';
 import ContentCopyIcon from '@mui/icons-material/ContentCopyRounded';
 import { Box, IconButton, Typography } from '@mui/material';
 import { useEffect, useMemo } from 'react';

--- a/packages/widget/src/providers/WidgetProvider/WidgetProvider.tsx
+++ b/packages/widget/src/providers/WidgetProvider/WidgetProvider.tsx
@@ -2,7 +2,7 @@ import { config, createConfig, type SDKConfig } from '@lifi/sdk';
 import { createContext, useContext, useId, useMemo } from 'react';
 import { version } from '../../config/version';
 import { setDefaultSettings } from '../../stores';
-import { formatInputAmount } from '../../utils';
+import { formatInputAmount, getChainTypeFromAddress } from '../../utils';
 import type { WidgetContextProps, WidgetProviderProps } from './types';
 
 const initialContext: WidgetContextProps = {
@@ -60,7 +60,13 @@ export const WidgetProvider: React.FC<
           !isNaN(parseFloat(searchParams.fromAmount))
             ? formatInputAmount(searchParams.fromAmount)
             : widgetConfig.fromAmount,
-        toAddress: searchParams.toAddress || widgetConfig.toAddress,
+        // TODO: does this work? Never seen toAddress come in from the searchParams
+        toAddress: searchParams.toAddress
+          ? {
+              address: searchParams.toAddress,
+              chainType: getChainTypeFromAddress(searchParams.toAddress),
+            }
+          : widgetConfig.toAddress,
         integrator: widgetConfig.integrator,
         elementId,
       } as WidgetContextProps;
@@ -101,7 +107,6 @@ export const WidgetProvider: React.FC<
       };
     }
   }, [elementId, widgetConfig]);
-
   return (
     <WidgetContext.Provider value={value}>{children}</WidgetContext.Provider>
   );

--- a/packages/widget/src/providers/WidgetProvider/WidgetProvider.tsx
+++ b/packages/widget/src/providers/WidgetProvider/WidgetProvider.tsx
@@ -2,9 +2,9 @@ import { config, createConfig, type SDKConfig } from '@lifi/sdk';
 import { createContext, useContext, useId, useMemo } from 'react';
 import { version } from '../../config/version';
 import { setDefaultSettings } from '../../stores';
-import { formatInputAmount, getChainTypeFromAddress } from '../../utils';
+import { formatInputAmount } from '../../utils';
 import type { WidgetContextProps, WidgetProviderProps } from './types';
-import type { WidgetConfig } from '../../types';
+import { attemptToFindMatchingToAddressInConfig } from '../../providers/WidgetProvider/utils';
 
 const initialContext: WidgetContextProps = {
   elementId: '',
@@ -17,30 +17,6 @@ export const useWidgetConfig = (): WidgetContextProps =>
   useContext(WidgetContext);
 
 let sdkInitialized = false;
-
-const attemptToFindMatchingToAddressInConfig = (
-  address: string,
-  config: WidgetConfig,
-) => {
-  if (config.toAddress && config.toAddress.address === address) {
-    return config.toAddress;
-  }
-
-  if (config.toAddresses?.length) {
-    const matchingToAddress = config.toAddresses.find(
-      (toAddress) => toAddress.address === address,
-    );
-
-    if (matchingToAddress) {
-      return matchingToAddress;
-    }
-  }
-
-  return {
-    address: address,
-    chainType: getChainTypeFromAddress(address),
-  };
-};
 
 export const WidgetProvider: React.FC<
   React.PropsWithChildren<WidgetProviderProps>

--- a/packages/widget/src/providers/WidgetProvider/WidgetProvider.tsx
+++ b/packages/widget/src/providers/WidgetProvider/WidgetProvider.tsx
@@ -4,7 +4,7 @@ import { version } from '../../config/version';
 import { setDefaultSettings } from '../../stores';
 import { formatInputAmount } from '../../utils';
 import type { WidgetContextProps, WidgetProviderProps } from './types';
-import { attemptToFindMatchingToAddressInConfig } from '../../providers/WidgetProvider/utils';
+import { attemptToFindMatchingToAddressInConfig } from './utils';
 
 const initialContext: WidgetContextProps = {
   elementId: '',

--- a/packages/widget/src/providers/WidgetProvider/WidgetProvider.tsx
+++ b/packages/widget/src/providers/WidgetProvider/WidgetProvider.tsx
@@ -60,7 +60,8 @@ export const WidgetProvider: React.FC<
           !isNaN(parseFloat(searchParams.fromAmount))
             ? formatInputAmount(searchParams.fromAmount)
             : widgetConfig.fromAmount,
-        // TODO: does this work? Never seen toAddress come in from the searchParams
+        //  TODO: Question: is using getChainTypeFromAddress ok here? Or do we have to start output
+        //   the name and the chainType to the querystring?
         toAddress: searchParams.toAddress
           ? {
               address: searchParams.toAddress,

--- a/packages/widget/src/providers/WidgetProvider/utils.ts
+++ b/packages/widget/src/providers/WidgetProvider/utils.ts
@@ -1,4 +1,4 @@
-import { WidgetConfig } from '../../types';
+import type { WidgetConfig } from '../../types';
 import { getChainTypeFromAddress } from '../../utils';
 
 export const attemptToFindMatchingToAddressInConfig = (

--- a/packages/widget/src/providers/WidgetProvider/utils.ts
+++ b/packages/widget/src/providers/WidgetProvider/utils.ts
@@ -1,0 +1,26 @@
+import { WidgetConfig } from '../../types';
+import { getChainTypeFromAddress } from '../../utils';
+
+export const attemptToFindMatchingToAddressInConfig = (
+  address: string,
+  config: WidgetConfig,
+) => {
+  if (config.toAddress && config.toAddress.address === address) {
+    return config.toAddress;
+  }
+
+  if (config.toAddresses?.length) {
+    const matchingToAddress = config.toAddresses.find(
+      (toAddress) => toAddress.address === address,
+    );
+
+    if (matchingToAddress) {
+      return matchingToAddress;
+    }
+  }
+
+  return {
+    address: address,
+    chainType: getChainTypeFromAddress(address),
+  };
+};

--- a/packages/widget/src/stores/bookmarks/BookmarkStore.tsx
+++ b/packages/widget/src/stores/bookmarks/BookmarkStore.tsx
@@ -1,8 +1,9 @@
-import { createContext, useContext, useRef } from 'react';
+import { createContext, useContext, useEffect, useRef } from 'react';
 import { shallow } from 'zustand/shallow';
 import type { PersistStoreProviderProps } from '../types';
 import { createBookmarksStore } from './createBookmarkStore';
 import type { BookmarkState, BookmarkStore } from './types';
+import { useWidgetConfig } from '../../providers';
 
 export const BookmarkStoreContext = createContext<BookmarkStore | null>(null);
 
@@ -10,11 +11,18 @@ export const BookmarkStoreProvider: React.FC<PersistStoreProviderProps> = ({
   children,
   ...props
 }) => {
+  const { toAddress } = useWidgetConfig();
   const storeRef = useRef<BookmarkStore>();
 
   if (!storeRef.current) {
     storeRef.current = createBookmarksStore(props);
   }
+
+  useEffect(() => {
+    if (storeRef?.current) {
+      storeRef.current.getState().setSelectedBookmark(toAddress);
+    }
+  }, [toAddress, storeRef]);
 
   return (
     <BookmarkStoreContext.Provider value={storeRef.current}>

--- a/packages/widget/src/stores/bookmarks/BookmarkStore.tsx
+++ b/packages/widget/src/stores/bookmarks/BookmarkStore.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useEffect, useRef } from 'react';
+import { createContext, useContext, useRef } from 'react';
 import { shallow } from 'zustand/shallow';
 import type { PersistStoreProviderProps } from '../types';
 import { createBookmarksStore } from './createBookmarkStore';
@@ -15,14 +15,8 @@ export const BookmarkStoreProvider: React.FC<PersistStoreProviderProps> = ({
   const storeRef = useRef<BookmarkStore>();
 
   if (!storeRef.current) {
-    storeRef.current = createBookmarksStore(props);
+    storeRef.current = createBookmarksStore({ ...props, toAddress });
   }
-
-  useEffect(() => {
-    if (storeRef?.current) {
-      storeRef.current.getState().setSelectedBookmark(toAddress);
-    }
-  }, [toAddress, storeRef]);
 
   return (
     <BookmarkStoreContext.Provider value={storeRef.current}>

--- a/packages/widget/src/stores/bookmarks/types.ts
+++ b/packages/widget/src/stores/bookmarks/types.ts
@@ -1,11 +1,8 @@
-import type { ChainType } from '@lifi/sdk';
 import type { StoreApi } from 'zustand';
 import type { UseBoundStoreWithEqualityFn } from 'zustand/esm/traditional';
+import { ToAddress } from '../../types';
 
-export interface Bookmark {
-  address: string;
-  chainType: ChainType;
-  name?: string;
+export interface Bookmark extends ToAddress {
   isConnectedAccount?: boolean;
 }
 

--- a/packages/widget/src/stores/bookmarks/types.ts
+++ b/packages/widget/src/stores/bookmarks/types.ts
@@ -1,6 +1,6 @@
 import type { StoreApi } from 'zustand';
 import type { UseBoundStoreWithEqualityFn } from 'zustand/esm/traditional';
-import { ToAddress } from '../../types';
+import type { ToAddress } from '../../types';
 
 export interface Bookmark extends ToAddress {
   isConnectedAccount?: boolean;

--- a/packages/widget/src/stores/form/FormStore.tsx
+++ b/packages/widget/src/stores/form/FormStore.tsx
@@ -39,7 +39,7 @@ export const FormStoreProvider: React.FC<PropsWithChildren> = ({
       // Prevent setting address when the field is hidden
       toAddress: hiddenToAddress
         ? formDefaultValues.toAddress
-        : toAddress || formDefaultValues.toAddress,
+        : toAddress?.address || formDefaultValues.toAddress,
     }),
     [
       fromAmount,

--- a/packages/widget/src/stores/routes/utils.ts
+++ b/packages/widget/src/stores/routes/utils.ts
@@ -6,20 +6,14 @@ export const isRouteDone = (route: RouteExtended) => {
 };
 
 export const isRoutePartiallyDone = (route: RouteExtended) => {
-  return route.steps.some(
-    (step) =>
-      step.execution?.process.some(
-        (process) => process.substatus === 'PARTIAL',
-      ),
+  return route.steps.some((step) =>
+    step.execution?.process.some((process) => process.substatus === 'PARTIAL'),
   );
 };
 
 export const isRouteRefunded = (route: RouteExtended) => {
-  return route.steps.some(
-    (step) =>
-      step.execution?.process.some(
-        (process) => process.substatus === 'REFUNDED',
-      ),
+  return route.steps.some((step) =>
+    step.execution?.process.some((process) => process.substatus === 'REFUNDED'),
   );
 };
 

--- a/packages/widget/src/types/widget.ts
+++ b/packages/widget/src/types/widget.ts
@@ -101,12 +101,17 @@ export interface WidgetContract {
   fallbackAddress?: string;
 }
 
+export interface ToAddress {
+  name?: string;
+  address: string;
+  chainType: ChainType;
+}
 export interface WidgetConfig {
   fromChain?: number;
   toChain?: number;
   fromToken?: string;
   toToken?: string;
-  toAddress?: string;
+  toAddress?: ToAddress;
   fromAmount?: number | string;
   toAmount?: number | string;
 

--- a/packages/widget/src/types/widget.ts
+++ b/packages/widget/src/types/widget.ts
@@ -112,6 +112,7 @@ export interface WidgetConfig {
   fromToken?: string;
   toToken?: string;
   toAddress?: ToAddress;
+  toAddresses?: ToAddress[];
   fromAmount?: number | string;
   toAmount?: number | string;
 

--- a/packages/widget/src/utils/navigationRoutes.ts
+++ b/packages/widget/src/utils/navigationRoutes.ts
@@ -19,6 +19,7 @@ export const navigationRoutes = {
   bookmarks: 'bookmarks',
   recentWallets: 'recent-wallets',
   connectedWallets: 'connected-wallets',
+  configuredWallets: 'configured-wallets',
 };
 
 export const navigationRoutesValues = Object.values(navigationRoutes);
@@ -41,6 +42,7 @@ export const stickyHeaderRoutes = [
   navigationRoutes.bookmarks,
   navigationRoutes.recentWallets,
   navigationRoutes.connectedWallets,
+  navigationRoutes.configuredWallets,
 ];
 
 export const backButtonRoutes = [
@@ -63,6 +65,7 @@ export const backButtonRoutes = [
   navigationRoutes.bookmarks,
   navigationRoutes.recentWallets,
   navigationRoutes.connectedWallets,
+  navigationRoutes.configuredWallets,
 ];
 
 export type NavigationRouteType = keyof typeof navigationRoutes;


### PR DESCRIPTION
Jira: [LF-5324](https://lifi.atlassian.net/browse/LF-5324)

Introducing the Curated Wallets section that as a follow on to the bookmarked send to wallets work

### Testing

This heavy relies on changes to the widget config. You should see the entries below commented out in the widget-playground

```
toAddress: {
    name: 'Jenny',
    address: '0xAB3Afc314e75dC1648A2E31c06861A07a048C050',
    chainType: ChainType.EVM,
  },
toAddresses: [
  {
    name: 'Lenny',
    address: '0x552008c0f6870c2f77e5cC1d2eb9bdff03e30Ea9',
    chainType: ChainType.EVM,
  },
  {
    address: '0x552008c0f6870c2f77e5cC1d2eb9bdff03e30Ea0',
    chainType: ChainType.EVM,
  },
  {
    name: 'Sol',
    address: '6AUWsSCRFSCbrHKH9s84wfzJXtD6mNzAHs11x6pGEcmJ',
    chainType: ChainType.SVM,
  },
],
```
`toAddress` and `toAddresses` work independently of each other 

- adding `toAddresses` will be displayed as the default on the Main page
- adding `toAddresses` will enable the SendToConfiguredWallet page in place of SendToWallet page and display a selectable list of addresses that are featured in the `toAddresses` array - click these addresses should populate the toAddress field on the main page

As part of the this work `toAddress` as feature in the query string parameters will also be supported, for example

`http://localhost:3000/?toAddress=0x552008c0f6870c2f77e5cC1d2eb9bdff03e30Ea9`

This address should be displayed on the main page in the Send to Wallet section.

We do some checks to try and present a name for that address if we have it.

- Firstly we check to see if the address matches an address listed in the configs `toAddress`
- if that doesn't match we try to find a matching address in the `toAddresses` from the config
- if that doesn't match then we try to find a matching address from the users Bookmarks in localstorage

If non of those match we just display the address




[LF-5324]: https://lifi.atlassian.net/browse/LF-5324?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ