### PR TITLE
refactor: send only modified tools to backend and simplify tools handling

### DIFF
--- a/packages/widget/src/hooks/useSettingMonitor.ts
+++ b/packages/widget/src/hooks/useSettingMonitor.ts
@@ -8,17 +8,22 @@ import {
 import { useTools } from './useTools';
 
 export const useSettingMonitor = () => {
-  const [enabledBridges, enabledExchanges, routePriority, slippage, gasPrice] =
-    useSettingsStore(
-      (state) => [
-        state.enabledBridges,
-        state.enabledExchanges,
-        state.routePriority,
-        state.slippage,
-        state.gasPrice,
-      ],
-      shallow,
-    );
+  const [
+    disabledBridges,
+    disabledExchanges,
+    routePriority,
+    slippage,
+    gasPrice,
+  ] = useSettingsStore(
+    (state) => [
+      state.disabledBridges,
+      state.disabledExchanges,
+      state.routePriority,
+      state.slippage,
+      state.gasPrice,
+    ],
+    shallow,
+  );
   const { tools } = useTools();
   const resetSettings = useSettingsStore((state) => state.reset);
   const config = useWidgetConfig();
@@ -36,13 +41,8 @@ export const useSettingMonitor = () => {
 
   const isGasPriceChanged = gasPrice !== defaultConfigurableSettings.gasPrice;
 
-  const isBridgesChanged = tools?.bridges
-    ? tools.bridges.length !== enabledBridges.length
-    : false;
-
-  const isExchangesChanged = tools?.exchanges
-    ? tools.exchanges.length !== enabledExchanges.length
-    : false;
+  const isBridgesChanged = Boolean(disabledBridges.length);
+  const isExchangesChanged = Boolean(disabledExchanges.length);
 
   const isCustomRouteSettings =
     isBridgesChanged ||

--- a/packages/widget/src/hooks/useSettingMonitor.ts
+++ b/packages/widget/src/hooks/useSettingMonitor.ts
@@ -1,11 +1,11 @@
+import { shallow } from 'zustand/shallow';
+import { useWidgetConfig } from '../providers';
 import {
   defaultConfigurableSettings,
   setDefaultSettings,
   useSettingsStore,
 } from '../stores';
-import { shallow } from 'zustand/shallow';
 import { useTools } from './useTools';
-import { useWidgetConfig } from '../providers';
 
 export const useSettingMonitor = () => {
   const [enabledBridges, enabledExchanges, routePriority, slippage, gasPrice] =
@@ -37,11 +37,11 @@ export const useSettingMonitor = () => {
   const isGasPriceChanged = gasPrice !== defaultConfigurableSettings.gasPrice;
 
   const isBridgesChanged = tools?.bridges
-    ? tools?.bridges?.length !== enabledBridges?.length
+    ? tools.bridges.length !== enabledBridges.length
     : false;
 
   const isExchangesChanged = tools?.exchanges
-    ? tools?.exchanges?.length !== enabledExchanges?.length
+    ? tools.exchanges.length !== enabledExchanges.length
     : false;
 
   const isCustomRouteSettings =
@@ -56,7 +56,6 @@ export const useSettingMonitor = () => {
   const reset = () => {
     if (tools) {
       resetSettings(
-        config,
         tools.bridges.map((tool) => tool.key),
         tools.exchanges.map((tool) => tool.key),
       );

--- a/packages/widget/src/pages/SelectEnabledToolsPage/SelectEnabledToolsPage.tsx
+++ b/packages/widget/src/pages/SelectEnabledToolsPage/SelectEnabledToolsPage.tsx
@@ -55,52 +55,33 @@ export const SelectEnabledToolsPage: React.FC<{
 }> = ({ type }) => {
   const typeKey = type.toLowerCase() as 'bridges' | 'exchanges';
   const { tools } = useTools();
-  const [enabledTools, setTools] = useSettingsStore(
-    (state) => [state[`enabled${type}`], state.setTools],
-    shallow,
-  );
+  const [enabledTools, disabledTools, setToolValue, toggleTools] =
+    useSettingsStore(
+      (state) => [
+        state[`enabled${type}`],
+        state[`disabled${type}`],
+        state.setToolValue,
+        state.toggleTools,
+      ],
+      shallow,
+    );
   const headerStoreContext = useHeaderStoreContext();
 
   const handleClick = (key: string) => {
-    if (!tools) {
-      return;
-    }
-    const toolKeys = tools[typeKey].map((tool) => tool.key);
-    if (enabledTools?.includes(key)) {
-      setTools(
-        type,
-        enabledTools.filter((toolKey) => toolKey !== key),
-        toolKeys,
-      );
-    } else {
-      setTools(type, [...enabledTools, key], toolKeys);
-    }
+    setToolValue(type, key, !enabledTools[key]);
   };
 
   useEffect(() => {
-    const allToolsSelected = tools?.[typeKey].length === enabledTools.length;
-    const toggleCheckboxes = () => {
-      if (!tools) {
-        return;
-      }
-      const toolKeys = tools[typeKey].map((tool) => tool.key);
-      if (allToolsSelected) {
-        setTools(type, [], toolKeys);
-      } else {
-        setTools(type, toolKeys, toolKeys);
-      }
-    };
-
     return headerStoreContext
       .getState()
       .setAction(
         <SelectAllCheckbox
-          allCheckboxesSelected={allToolsSelected}
-          anyCheckboxesSelected={!!enabledTools.length}
-          onClick={toggleCheckboxes}
+          allCheckboxesSelected={!disabledTools.length}
+          anyCheckboxesSelected={Boolean(disabledTools.length)}
+          onClick={() => toggleTools(type)}
         />,
       );
-  }, [enabledTools.length, headerStoreContext, setTools, tools, type, typeKey]);
+  }, [disabledTools.length, headerStoreContext, toggleTools, type]);
 
   return (
     <PageContainer disableGutters>
@@ -121,7 +102,7 @@ export const SelectEnabledToolsPage: React.FC<{
               </Avatar>
             </ListItemAvatar>
             <ListItemText primary={tool.name} />
-            {enabledTools?.includes(tool.key) && <CheckIcon color="primary" />}
+            {enabledTools[tool.key] && <CheckIcon color="primary" />}
           </SettingsListItemButton>
         ))}
       </List>

--- a/packages/widget/src/pages/SettingsPage/BridgeAndExchangeSettings.tsx
+++ b/packages/widget/src/pages/SettingsPage/BridgeAndExchangeSettings.tsx
@@ -3,10 +3,10 @@ import SwapHorizIcon from '@mui/icons-material/SwapHoriz';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { shallow } from 'zustand/shallow';
+import { CardButton } from '../../components/Card';
 import { useSettingMonitor } from '../../hooks';
 import { useSettingsStore } from '../../stores';
 import { navigationRoutes } from '../../utils';
-import { CardButton } from '../../components/Card';
 import { BadgedValue } from './SettingsCard';
 
 const supportedIcons = {
@@ -21,7 +21,7 @@ export const BridgeAndExchangeSettings: React.FC<{
   const { t } = useTranslation();
   const navigate = useNavigate();
   const [enabledTools, tools] = useSettingsStore((state) => {
-    const enabledTools = Object.values(state[`_enabled${type}`] ?? {});
+    const enabledTools = Object.values(state[`enabled${type}`]);
     return [enabledTools.filter(Boolean).length, enabledTools.length];
   }, shallow);
 

--- a/packages/widget/src/stores/settings/types.ts
+++ b/packages/widget/src/stores/settings/types.ts
@@ -24,10 +24,10 @@ export interface SettingsProps {
   enabledAutoRefuel: boolean;
   showDestinationWallet: boolean;
   slippage?: string;
-  enabledBridges: string[];
-  _enabledBridges?: Record<string, boolean>;
-  enabledExchanges: string[];
-  _enabledExchanges?: Record<string, boolean>;
+  disabledBridges: string[];
+  enabledBridges: Record<string, boolean>;
+  disabledExchanges: string[];
+  enabledExchanges: Record<string, boolean>;
 }
 
 export interface SettingsState extends SettingsProps {
@@ -38,11 +38,8 @@ export interface SettingsState extends SettingsProps {
     tools: string[],
     reset?: boolean,
   ): void;
-  setTools(
-    toolType: SettingsToolType,
-    tools: string[],
-    availableTools: string[],
-  ): void;
+  setToolValue(toolType: SettingsToolType, tool: string, value: boolean): void;
+  toggleTools(toolType: SettingsToolType): void;
   reset(bridges: string[], exchanges: string[]): void;
 }
 

--- a/packages/widget/src/stores/settings/types.ts
+++ b/packages/widget/src/stores/settings/types.ts
@@ -2,7 +2,7 @@ import type { Order } from '@lifi/sdk';
 import type { PropsWithChildren } from 'react';
 import type { StoreApi } from 'zustand';
 import type { UseBoundStoreWithEqualityFn } from 'zustand/traditional';
-import type { Appearance, WidgetConfig } from '../../types';
+import type { Appearance } from '../../types';
 
 export type ValueSetter<S> = <K extends keyof S>(
   key: K,
@@ -13,8 +13,8 @@ export type ValuesSetter<S> = <K extends keyof S>(
   values: Record<K, S[Extract<K, string>]>,
 ) => void;
 
-export type SettingsToolType = 'Bridges' | 'Exchanges';
-export const SettingsToolTypes: SettingsToolType[] = ['Bridges', 'Exchanges'];
+export const SettingsToolTypes = ['Bridges', 'Exchanges'] as const;
+export type SettingsToolType = (typeof SettingsToolTypes)[number];
 
 export interface SettingsProps {
   appearance: Appearance;
@@ -43,7 +43,7 @@ export interface SettingsState extends SettingsProps {
     tools: string[],
     availableTools: string[],
   ): void;
-  reset(config: WidgetConfig, bridges: string[], exchanges: string[]): void;
+  reset(bridges: string[], exchanges: string[]): void;
 }
 
 export interface SendToWalletState {

--- a/packages/widget/src/stores/settings/useSettingsStore.ts
+++ b/packages/widget/src/stores/settings/useSettingsStore.ts
@@ -21,8 +21,10 @@ export const defaultSettings: SettingsProps = {
   gasPrice: 'normal',
   enabledAutoRefuel: true,
   showDestinationWallet: true,
-  enabledBridges: [],
-  enabledExchanges: [],
+  disabledBridges: [],
+  disabledExchanges: [],
+  enabledBridges: {},
+  enabledExchanges: {},
 };
 
 export const useSettingsStore = createWithEqualityFn<SettingsState>(
@@ -49,60 +51,57 @@ export const useSettingsStore = createWithEqualityFn<SettingsState>(
         }
         set((state) => {
           const updatedState = { ...state };
-          if (updatedState[`_enabled${toolType}`] && !reset) {
+          if (!reset) {
             // Add new tools
-            const enabledTools = tools
-              .filter(
-                (tool) =>
-                  !Object.hasOwn(
-                    updatedState[`_enabled${toolType}`] as object,
-                    tool,
-                  ),
-              )
-              .reduce(
-                (values, tool) => {
-                  values[tool] = true;
-                  return values;
-                },
-                updatedState[`_enabled${toolType}`] as Record<string, boolean>,
-              );
+            tools.forEach((tool) => {
+              if (!Object.hasOwn(updatedState[`enabled${toolType}`], tool)) {
+                updatedState[`enabled${toolType}`][tool] = true;
+              }
+            });
             // Filter tools we no longer have
-            updatedState[`_enabled${toolType}`] = Object.fromEntries(
-              Object.entries(enabledTools).filter(([key]) =>
-                tools.includes(key),
+            updatedState[`enabled${toolType}`] = Object.fromEntries(
+              Object.entries(updatedState[`enabled${toolType}`]).filter(
+                ([key]) => tools.includes(key),
               ),
             );
           } else {
-            updatedState[`_enabled${toolType}`] = tools.reduce(
-              (values, tool) => {
-                values[tool] = true;
-                return values;
-              },
-              {} as Record<string, boolean>,
-            );
+            tools.forEach((tool) => {
+              updatedState[`enabled${toolType}`][tool] = true;
+            });
           }
-          updatedState[`enabled${toolType}`] = Object.entries(
-            updatedState[`_enabled${toolType}`]!,
-          )
-            .filter(([_, value]) => value)
-            .map(([key]) => key);
+          updatedState[`disabled${toolType}`] = Object.keys(
+            updatedState[`enabled${toolType}`],
+          ).filter((key) => !updatedState[`enabled${toolType}`][key]);
           return updatedState;
         });
       },
-      setTools: (toolType, tools, availableTools) =>
-        set(() => ({
-          [`enabled${toolType}`]: tools,
-          [`_enabled${toolType}`]: availableTools.reduce(
-            (values, toolKey) => {
-              values[toolKey] = tools.includes(toolKey);
-              return values;
-            },
-            {} as Record<string, boolean>,
-          ),
-        })),
+      setToolValue: (toolType, tool, value) =>
+        set((state) => {
+          const enabledTools = {
+            ...state[`enabled${toolType}`],
+            [tool]: value,
+          };
+          return {
+            [`enabled${toolType}`]: enabledTools,
+            [`disabled${toolType}`]: Object.keys(enabledTools).filter(
+              (key) => !enabledTools[key],
+            ),
+          };
+        }),
+      toggleTools: (toolType) =>
+        set((state) => {
+          const enabledTools = { ...state[`enabled${toolType}`] };
+          const enableAll = Boolean(state[`disabled${toolType}`].length);
+          for (const toolKey in enabledTools) {
+            enabledTools[toolKey] = enableAll;
+          }
+          return {
+            [`enabled${toolType}`]: enabledTools,
+            [`disabled${toolType}`]: enableAll ? [] : Object.keys(enabledTools),
+          };
+        }),
       reset: (bridges, exchanges) => {
         const { appearance, ...restDefaultSettings } = defaultSettings;
-
         set(() => ({
           ...restDefaultSettings,
           ...defaultConfigurableSettings,
@@ -113,19 +112,18 @@ export const useSettingsStore = createWithEqualityFn<SettingsState>(
     }),
     {
       name: `li.fi-widget-settings`,
-      version: 2,
+      version: 3,
       partialize: (state) => {
-        const { enabledBridges, enabledExchanges, ...partializedState } = state;
+        const { disabledBridges, disabledExchanges, ...partializedState } =
+          state;
         return partializedState;
       },
       merge: (persistedState: any, currentState: SettingsState) => {
         const state = { ...currentState, ...persistedState };
         SettingsToolTypes.forEach((toolType) => {
-          state[`enabled${toolType}`] = Object.entries(
-            persistedState[`_enabled${toolType}`],
-          )
-            .filter(([_, value]) => value)
-            .map(([key]) => key);
+          state[`disabled${toolType}`] = Object.keys(
+            persistedState[`enabled${toolType}`],
+          ).filter((key) => !persistedState[`enabled${toolType}`][key]);
         });
         return state;
       },

--- a/packages/widget/src/stores/settings/useSettingsStore.ts
+++ b/packages/widget/src/stores/settings/useSettingsStore.ts
@@ -100,7 +100,7 @@ export const useSettingsStore = createWithEqualityFn<SettingsState>(
             {} as Record<string, boolean>,
           ),
         })),
-      reset: (config, bridges, exchanges) => {
+      reset: (bridges, exchanges) => {
         const { appearance, ...restDefaultSettings } = defaultSettings;
 
         set(() => ({


### PR DESCRIPTION
We would like to send only modified bridges/exchanges to the backend, so we need to switch from sending all of them in allow property to using deny property and sending only disabled ones.

### Before
<img width="678" alt="image" src="https://github.com/lifinance/widget/assets/18644653/f37ea5e8-9872-4e5b-99ca-856bd81a62cb">

### After
<img width="681" alt="image" src="https://github.com/lifinance/widget/assets/18644653/acd273a8-949f-4d27-a44e-78dd0d2648c0">
<img width="687" alt="image" src="https://github.com/lifinance/widget/assets/18644653/35888596-f787-4745-90d2-759485a74104">


## Testing considerations 

- Enable/disable bridges/exchanges and try to get a route
- Check what we send to the backend
- Check what we store in localStorage and whether those values are correctly hydrated after page refresh