### PR TITLE
fix: expandable variant is not shown with a deep route tree

### DIFF
--- a/packages/widget/src/components/Routes/RoutesExpanded.tsx
+++ b/packages/widget/src/components/Routes/RoutesExpanded.tsx
@@ -1,8 +1,10 @@
 /* eslint-disable react/no-array-index-key */
 import type { Route } from '@lifi/sdk';
 import { Collapse, Grow, Stack, Typography } from '@mui/material';
+import { useRef } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useMatch, useNavigate } from 'react-router-dom';
+import type { RouteObject } from 'react-router-dom';
+import { useRoutes as useDOMRoutes, useNavigate } from 'react-router-dom';
 import { useRoutes } from '../../hooks';
 import { useWidgetConfig } from '../../providers';
 import { useSetExecutableRoute } from '../../stores';
@@ -19,12 +21,20 @@ import {
 
 const timeout = { enter: 225, exit: 225, appear: 0 };
 
+const routes: RouteObject[] = [
+  {
+    path: '/',
+    element: true,
+  },
+];
+
 export const RoutesExpanded = () => {
-  const element = useMatch('/');
+  const match = useDOMRoutes(routes);
+
   return (
     <CollapseContainer>
-      <Collapse timeout={timeout} in={!!element} orientation="horizontal">
-        <Grow timeout={timeout} in={!!element} mountOnEnter unmountOnExit>
+      <Collapse timeout={timeout} in={!!match} orientation="horizontal">
+        <Grow timeout={timeout} in={!!match} mountOnEnter unmountOnExit>
           <div>
             <RoutesExpandedElement />
           </div>
@@ -39,6 +49,8 @@ export const RoutesExpandedElement = () => {
   const navigate = useNavigate();
   const setExecutableRoute = useSetExecutableRoute();
   const { subvariant, containerStyle } = useWidgetConfig();
+  const routesRef = useRef<Route[]>();
+  const routesActiveRef = useRef(false);
   const {
     routes,
     isLoading,
@@ -49,8 +61,6 @@ export const RoutesExpandedElement = () => {
     refetch,
   } = useRoutes();
 
-  const currentRoute = routes?.[0];
-
   const handleRouteClick = (route: Route) => {
     setExecutableRoute(route);
     navigate(navigationRoutes.transactionExecution, {
@@ -58,14 +68,34 @@ export const RoutesExpandedElement = () => {
     });
   };
 
+  const onExit = () => {
+    // Clean routes cache on exit
+    routesRef.current = undefined;
+  };
+
+  // We cache routes results in ref for a better exit animation
+  if (routesRef.current && !routes?.length) {
+    routesActiveRef.current = false;
+  } else {
+    routesRef.current = routes;
+    routesActiveRef.current = Boolean(routes?.length);
+  }
+
+  const currentRoute = routesRef.current?.[0];
+
   const expanded = Boolean(
-    currentRoute || isLoading || isFetching || isFetched,
+    routesActiveRef.current || isLoading || isFetching || isFetched,
   );
 
   const routeNotFound = !currentRoute && !isLoading && !isFetching && expanded;
 
   return (
-    <Collapse timeout={timeout.enter} in={expanded} orientation="horizontal">
+    <Collapse
+      timeout={timeout.enter}
+      in={expanded}
+      orientation="horizontal"
+      onExited={onExit}
+    >
       <Grow timeout={timeout.enter} in={expanded} mountOnEnter unmountOnExit>
         <Container sx={containerStyle} enableColorScheme>
           <ScrollableContainer>
@@ -87,18 +117,18 @@ export const RoutesExpandedElement = () => {
               <Stack direction="column" spacing={2} flex={1} paddingBottom={3}>
                 {routeNotFound ? (
                   <RouteNotFoundCard />
-                ) : isLoading || (isFetching && !routes?.length) ? (
+                ) : isLoading || (isFetching && !routesRef.current?.length) ? (
                   Array.from({ length: 3 }).map((_, index) => (
                     <RouteCardSkeleton key={index} />
                   ))
                 ) : (
-                  routes?.map((route: Route, index: number) => (
+                  routesRef.current?.map((route: Route, index: number) => (
                     <RouteCard
                       key={index}
                       route={route}
                       onClick={() => handleRouteClick(route)}
                       active={index === 0}
-                      expanded={routes?.length === 1}
+                      expanded={routesRef.current?.length === 1}
                     />
                   ))
                 )}


### PR DESCRIPTION
It also improves exit animation by caching routes locally using refs. Part of #185 for v3.

### Before (in slow-mo)

https://github.com/lifinance/widget/assets/18644653/2bf39968-f7f8-4085-b70e-d3701babf5d2


### After (in slow-mo)

https://github.com/lifinance/widget/assets/18644653/2653892f-a2b2-447b-bc07-f2563d735190




