### PR TITLE
fix: restore bookmark name from connected wallet

### DIFF
--- a/packages/widget/src/components/SendToWallet/SendToWalletButton.tsx
+++ b/packages/widget/src/components/SendToWallet/SendToWalletButton.tsx
@@ -63,13 +63,16 @@ export const SendToWalletButton = () => {
       ? defaultChainIdsByType[chainType]
       : undefined;
 
-  const headerTitle = selectedBookmark?.isConnectedAccount
-    ? matchingConnectedAccount?.connector?.name || address
-    : selectedBookmark?.name || address;
+  const isConnectedAccount = selectedBookmark?.isConnectedAccount;
+  const connectedAccountName = matchingConnectedAccount?.connector?.name;
+  const bookmarkName = selectedBookmark?.name;
 
-  const headerSubheader = selectedBookmark?.isConnectedAccount
-    ? !!matchingConnectedAccount && address
-    : !!selectedBookmark?.name && address;
+  const headerTitle = isConnectedAccount
+    ? connectedAccountName || address
+    : bookmarkName || connectedAccountName || address;
+
+  const headerSubheader =
+    isConnectedAccount || bookmarkName || connectedAccountName ? address : null;
 
   const handleOnClick = () => {
     navigate(


### PR DESCRIPTION
## Testing

1. Go to Jumper staging env 
2. Connect your MetaMask
3. Select your wallet as the destination wallet from `Connected wallets` in the bookmarks
4. Refresh the page
5. Selected bookmark should restore the name from connected wallets, but it doesn't

This PR fixes this 🙂