### PR TITLE
feat: add name services support and improve bookmarks flow

### DIFF
--- a/packages/widget/src/components/SendToWallet/SendToWalletButton.tsx
+++ b/packages/widget/src/components/SendToWallet/SendToWalletButton.tsx
@@ -27,12 +27,16 @@ export const SendToWalletButton = () => {
   const { disabledUI, hiddenUI, toAddress, toAddresses } = useWidgetConfig();
   const { showSendToWallet, showSendToWalletDirty } = useSendToWalletStore();
   const { showDestinationWallet } = useSettings(['showDestinationWallet']);
-  const [toAddressFieldValue] = useFieldValues('toAddress');
+  const [toAddressFieldValue, toChainId, toTokenAddress] = useFieldValues(
+    'toAddress',
+    'toChain',
+    'toToken',
+  );
   const { selectedBookmark } = useBookmarks();
   const { accounts } = useAccount();
+  const { requiredToAddress } = useToAddressRequirements();
   const disabledToAddress = disabledUI?.includes(DisabledUI.ToAddress);
   const hiddenToAddress = hiddenUI?.includes(HiddenUI.ToAddress);
-  const { requiredToAddress } = useToAddressRequirements();
 
   const showInstantly =
     Boolean(
@@ -44,7 +48,9 @@ export const SendToWalletButton = () => {
 
   const address = toAddressFieldValue
     ? shortenAddress(toAddressFieldValue)
-    : t('sendToWallet.enterAddress');
+    : t('sendToWallet.enterAddress', {
+        context: 'short',
+      });
 
   const matchingConnectedAccount = accounts.find(
     (account) => account.address === toAddressFieldValue,
@@ -57,11 +63,14 @@ export const SendToWalletButton = () => {
         : undefined)
     : undefined;
 
-  const chainId = matchingConnectedAccount
-    ? matchingConnectedAccount.chainId
-    : chainType
-      ? defaultChainIdsByType[chainType]
-      : undefined;
+  const chainId =
+    toChainId && toTokenAddress
+      ? toChainId
+      : matchingConnectedAccount
+        ? matchingConnectedAccount.chainId
+        : chainType
+          ? defaultChainIdsByType[chainType]
+          : undefined;
 
   const headerTitle = selectedBookmark?.isConnectedAccount
     ? matchingConnectedAccount?.connector?.name || address

--- a/packages/widget/src/i18n/en.json
+++ b/packages/widget/src/i18n/en.json
@@ -139,7 +139,6 @@
       "unknown": "Please try again or contact support."
     },
     "title": {
-      "addressRequired": "Wallet address is required",
       "allowanceRequired": "Insufficient allowance",
       "balanceIsTooLow": "The balance is too low",
       "bookmarkAlreadyExists": "Wallet is already bookmarked as {{name}}",
@@ -155,9 +154,10 @@
       "transactionUnderpriced": "Transaction is underpriced",
       "transactionUnprepared": "Unable to prepare transaction",
       "unknown": "Something went wrong",
-      "walletAddressInvalid": "Wallet address or ENS is invalid, or the network doesn't support ENS.",
+      "walletAddressInvalid": "Wallet address or domain name is invalid",
       "walletAddressRequired": "Wallet address is required.",
-      "walletChainTypeInvalid": "Wallet address does not match the selected destination chain - {{chainName}}"
+      "walletAddressInvalid_chain": "Wallet address or domain name is invalid for selected destination chain {{chainName}}",
+      "walletChainTypeInvalid": "Wallet address doesn't match the selected destination chain {{chainName}}"
     }
   },
   "tooltip": {
@@ -284,7 +284,8 @@
     "resetSettings": "You're using custom setting limiting the number of available routes."
   },
   "sendToWallet": {
-    "enterAddress": "Enter address or ENS",
+    "enterAddress_short": "Enter wallet address",
+    "enterAddress_long": "Enter wallet address or domain name",
     "enterName": "Enter name",
     "confirmWalletAddress": "Confirm wallet address",
     "connectedWallets": "Connected wallets",

--- a/packages/widget/src/pages/SendToWallet/BookmarkAddressSheet.tsx
+++ b/packages/widget/src/pages/SendToWallet/BookmarkAddressSheet.tsx
@@ -1,8 +1,10 @@
-import { Error, TurnedIn } from '@mui/icons-material';
+import { Error, Info, TurnedIn } from '@mui/icons-material';
+import { LoadingButton } from '@mui/lab';
 import { Button, Typography } from '@mui/material';
 import type { ChangeEvent, MutableRefObject } from 'react';
 import { forwardRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { AlertMessage } from '../../components/AlertMessage/AlertMessage.js';
 import { BottomSheet } from '../../components/BottomSheet/BottomSheet.js';
 import type { BottomSheetBase } from '../../components/BottomSheet/types.js';
 import { Input } from '../../components/Input.js';
@@ -38,7 +40,7 @@ export const BookmarkAddressSheet = forwardRef<
   const { validateAddress, isValidating } = useAddressValidation();
   const { getBookmark } = useBookmarkActions();
 
-  const nameValue = name || validatedWallet?.name || '';
+  const nameValue = name.trim() || validatedWallet?.name || '';
   const addressValue = address || validatedWallet?.address || '';
 
   const handleCancel = () => {
@@ -47,14 +49,14 @@ export const BookmarkAddressSheet = forwardRef<
   };
 
   const validateWithAddressFromInput = async () => {
-    const validationResult = await validateAddress(address);
+    const validationResult = await validateAddress({ value: address });
     if (!validationResult.isValid) {
       setError({ type: 'address', message: validationResult.error });
       return;
     }
 
     return {
-      name: nameValue.trim(),
+      name: nameValue,
       address: validationResult.address,
       chainType: validationResult.chainType,
     };
@@ -65,7 +67,7 @@ export const BookmarkAddressSheet = forwardRef<
       setError(undefined);
     }
     return {
-      name: nameValue.trim(),
+      name: nameValue,
       address: validatedWallet!.address,
       chainType: validatedWallet!.chainType,
     };
@@ -85,7 +87,7 @@ export const BookmarkAddressSheet = forwardRef<
     if (!addressValue) {
       setError({
         type: 'address',
-        message: t('error.title.addressRequired'),
+        message: t('error.title.walletAddressRequired'),
       });
       return;
     }
@@ -129,7 +131,7 @@ export const BookmarkAddressSheet = forwardRef<
     if (error) {
       setError(undefined);
     }
-    setName((e.target as HTMLInputElement).value.trim());
+    setName((e.target as HTMLInputElement).value);
   };
 
   const resetValues = () => {
@@ -183,8 +185,12 @@ export const BookmarkAddressSheet = forwardRef<
                 spellCheck="false"
                 onChange={handleAddressInputChange}
                 value={address}
-                placeholder={t('sendToWallet.enterAddress')}
-                aria-label={t('sendToWallet.enterAddress')}
+                placeholder={t('sendToWallet.enterAddress', {
+                  context: 'long',
+                })}
+                aria-label={t('sendToWallet.enterAddress', {
+                  context: 'long',
+                })}
                 maxRows={2}
                 inputProps={{ maxLength: 128 }}
                 multiline
@@ -195,18 +201,28 @@ export const BookmarkAddressSheet = forwardRef<
             <ValidationAlert icon={<Error />}>{error.message}</ValidationAlert>
           ) : null}
         </BookmarkInputFields>
+        <AlertMessage
+          title={
+            <Typography variant="body2">
+              {t('info.message.fundsToExchange')}
+            </Typography>
+          }
+          icon={<Info />}
+        />
         <SendToWalletButtonRow>
           <Button variant="text" onClick={handleCancel} fullWidth>
             {t('button.cancel')}
           </Button>
-          <Button
+          <LoadingButton
             variant="contained"
             onClick={handleBookmark}
+            loading={isValidating}
+            loadingPosition="center"
             fullWidth
             focusRipple
           >
             {t('button.bookmark')}
-          </Button>
+          </LoadingButton>
         </SendToWalletButtonRow>
       </SendToWalletSheetContainer>
     </BottomSheet>

--- a/packages/widget/src/pages/SendToWallet/BookmarksPage.tsx
+++ b/packages/widget/src/pages/SendToWallet/BookmarksPage.tsx
@@ -8,6 +8,7 @@ import {
 import { Button, ListItemAvatar, ListItemText, MenuItem } from '@mui/material';
 import { useId, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
 import { AccountAvatar } from '../../components/AccountAvatar.js';
 import type { BottomSheetBase } from '../../components/BottomSheet/types.js';
 import { ListItemButton } from '../../components/ListItem//ListItemButton.js';
@@ -18,10 +19,12 @@ import { useToAddressRequirements } from '../../hooks/useToAddressRequirements.j
 import type { Bookmark } from '../../stores/bookmarks/types.js';
 import { useBookmarkActions } from '../../stores/bookmarks/useBookmarkActions.js';
 import { useBookmarks } from '../../stores/bookmarks/useBookmarks.js';
+import { useFieldActions } from '../../stores/form/useFieldActions.js';
+import { useSendToWalletActions } from '../../stores/settings/useSendToWalletStore.js';
 import { defaultChainIdsByType } from '../../utils/chainType.js';
+import { navigationRoutes } from '../../utils/navigationRoutes.js';
 import { shortenAddress } from '../../utils/wallet.js';
 import { BookmarkAddressSheet } from './BookmarkAddressSheet.js';
-import { ConfirmAddressSheet } from './ConfirmAddressSheet.js';
 import { EmptyListIndicator } from './EmptyListIndicator.js';
 import {
   BookmarkButtonContainer,
@@ -34,24 +37,26 @@ export const BookmarksPage = () => {
   const { t } = useTranslation();
   const [bookmark, setBookmark] = useState<Bookmark>();
   const bookmarkAddressSheetRef = useRef<BottomSheetBase>(null);
-  const confirmAddressSheetRef = useRef<BottomSheetBase>(null);
   const { bookmarks } = useBookmarks();
   const { requiredToChainType } = useToAddressRequirements();
   const { addBookmark, removeBookmark, setSelectedBookmark } =
     useBookmarkActions();
   const { getChainById } = useChains();
+  const navigate = useNavigate();
+  const { setFieldValue } = useFieldActions();
+  const { setSendToWallet } = useSendToWalletActions();
 
   const handleAddBookmark = () => {
     bookmarkAddressSheetRef.current?.open();
   };
 
   const handleBookmarkSelected = (bookmark: Bookmark) => {
-    setBookmark(bookmark);
-    confirmAddressSheetRef.current?.open();
-  };
-
-  const handleOnConfirm = (confirmedWallet: Bookmark) => {
-    setSelectedBookmark(confirmedWallet);
+    setFieldValue('toAddress', bookmark.address, {
+      isTouched: true,
+    });
+    setSelectedBookmark(bookmark);
+    setSendToWallet(true);
+    navigate(navigationRoutes.home);
   };
 
   const moreMenuId = useId();
@@ -177,11 +182,6 @@ export const BookmarksPage = () => {
       <BookmarkAddressSheet
         ref={bookmarkAddressSheetRef}
         onAddBookmark={addBookmark}
-      />
-      <ConfirmAddressSheet
-        ref={confirmAddressSheetRef}
-        validatedBookmark={bookmark}
-        onConfirm={handleOnConfirm}
       />
     </SendToWalletPageContainer>
   );

--- a/packages/widget/src/pages/SendToWallet/ConfirmAddressSheet.tsx
+++ b/packages/widget/src/pages/SendToWallet/ConfirmAddressSheet.tsx
@@ -9,7 +9,7 @@ import { BottomSheet } from '../../components/BottomSheet/BottomSheet.js';
 import type { BottomSheetBase } from '../../components/BottomSheet/types.js';
 import type { Bookmark } from '../../stores/bookmarks/types.js';
 import { useFieldActions } from '../../stores/form/useFieldActions.js';
-import { useSendToWalletStore } from '../../stores/settings/useSendToWalletStore.js';
+import { useSendToWalletActions } from '../../stores/settings/useSendToWalletStore.js';
 import { navigationRoutes } from '../../utils/navigationRoutes.js';
 import {
   IconContainer,
@@ -31,9 +31,7 @@ export const ConfirmAddressSheet = forwardRef<
   const { t } = useTranslation();
   const navigate = useNavigate();
   const { setFieldValue } = useFieldActions();
-  const setSendToWallet = useSendToWalletStore(
-    (state) => state.setSendToWallet,
-  );
+  const { setSendToWallet } = useSendToWalletActions();
 
   const handleClose = () => {
     (ref as MutableRefObject<BottomSheetBase>).current?.close();

--- a/packages/widget/src/pages/SendToWallet/RecentWalletsPage.tsx
+++ b/packages/widget/src/pages/SendToWallet/RecentWalletsPage.tsx
@@ -20,11 +20,12 @@ import { useToAddressRequirements } from '../../hooks/useToAddressRequirements.j
 import type { Bookmark } from '../../stores/bookmarks/types.js';
 import { useBookmarkActions } from '../../stores/bookmarks/useBookmarkActions.js';
 import { useBookmarks } from '../../stores/bookmarks/useBookmarks.js';
+import { useFieldActions } from '../../stores/form/useFieldActions.js';
+import { useSendToWalletActions } from '../../stores/settings/useSendToWalletStore.js';
 import { defaultChainIdsByType } from '../../utils/chainType.js';
 import { navigationRoutes } from '../../utils/navigationRoutes.js';
 import { shortenAddress } from '../../utils/wallet.js';
 import { BookmarkAddressSheet } from './BookmarkAddressSheet.js';
-import { ConfirmAddressSheet } from './ConfirmAddressSheet.js';
 import { EmptyListIndicator } from './EmptyListIndicator.js';
 import {
   ListContainer,
@@ -37,7 +38,6 @@ export const RecentWalletsPage = () => {
   const navigate = useNavigate();
   const [selectedRecent, setSelectedRecent] = useState<Bookmark>();
   const bookmarkAddressSheetRef = useRef<BottomSheetBase>(null);
-  const confirmAddressSheetRef = useRef<BottomSheetBase>(null);
   const { recentWallets } = useBookmarks();
   const { requiredToChainType } = useToAddressRequirements();
   const {
@@ -47,13 +47,20 @@ export const RecentWalletsPage = () => {
     addRecentWallet,
   } = useBookmarkActions();
   const { getChainById } = useChains();
+  const { setFieldValue } = useFieldActions();
+  const { setSendToWallet } = useSendToWalletActions();
   const moreMenuId = useId();
   const [moreMenuAnchorEl, setMenuAnchorEl] = useState<HTMLElement | null>();
   const open = Boolean(moreMenuAnchorEl);
 
   const handleRecentSelected = (recentWallet: Bookmark) => {
-    setSelectedRecent(recentWallet);
-    confirmAddressSheetRef.current?.open();
+    addRecentWallet(recentWallet);
+    setFieldValue('toAddress', recentWallet.address, {
+      isTouched: true,
+    });
+    setSelectedBookmark(recentWallet);
+    setSendToWallet(true);
+    navigate(navigationRoutes.home);
   };
 
   const handleAddBookmark = (bookmark: Bookmark) => {
@@ -62,11 +69,6 @@ export const RecentWalletsPage = () => {
       relative: 'path',
       replace: true,
     });
-  };
-
-  const handleOnConfirm = (confirmedBookmark: Bookmark) => {
-    setSelectedBookmark(confirmedBookmark);
-    addRecentWallet(confirmedBookmark);
   };
 
   const closeMenu = () => {
@@ -207,11 +209,6 @@ export const RecentWalletsPage = () => {
         ref={bookmarkAddressSheetRef}
         validatedWallet={selectedRecent}
         onAddBookmark={handleAddBookmark}
-      />
-      <ConfirmAddressSheet
-        ref={confirmAddressSheetRef}
-        validatedBookmark={selectedRecent}
-        onConfirm={handleOnConfirm}
       />
     </SendToWalletPageContainer>
   );

--- a/packages/widget/src/pages/SendToWallet/SendToWalletPage.style.tsx
+++ b/packages/widget/src/pages/SendToWallet/SendToWalletPage.style.tsx
@@ -1,8 +1,8 @@
+import { LoadingButton, loadingButtonClasses } from '@mui/lab';
 import type { Theme } from '@mui/material';
 import {
   Alert,
   Box,
-  Button,
   IconButton,
   List,
   Typography,
@@ -66,25 +66,28 @@ const tertiaryButtonStyles = (theme: Theme) => ({
     theme.palette.mode === 'light'
       ? theme.palette.grey[200]
       : theme.palette.grey[800],
-  '&:hover': {
+  '&:hover, &:active': {
     backgroundColor:
       theme.palette.mode === 'light'
         ? theme.palette.grey[300]
         : theme.palette.grey[700],
   },
-  '&:active': {
+  [`&.${loadingButtonClasses.loading}:disabled`]: {
     backgroundColor:
       theme.palette.mode === 'light'
-        ? theme.palette.grey[300]
-        : theme.palette.grey[700],
+        ? theme.palette.grey[200]
+        : theme.palette.grey[800],
+  },
+  [`.${loadingButtonClasses.loadingIndicator}`]: {
+    color: theme.palette.text.primary,
   },
 });
 
-export const SendToWalletButton = styled(Button)(({ theme }) => ({
+export const SendToWalletButton = styled(LoadingButton)(({ theme }) => ({
   ...tertiaryButtonStyles(theme),
 }));
 
-export const SendToWalletIconButton = styled(Button)(({ theme }) => ({
+export const SendToWalletIconButton = styled(LoadingButton)(({ theme }) => ({
   ...tertiaryButtonStyles(theme),
   padding: theme.spacing(1.25),
   minWidth: 40,

--- a/packages/widget/src/pages/SendToWallet/SendToWalletPage.tsx
+++ b/packages/widget/src/pages/SendToWallet/SendToWalletPage.tsx
@@ -7,7 +7,10 @@ import { useNavigate } from 'react-router-dom';
 import type { BottomSheetBase } from '../../components/BottomSheet/types.js';
 import { CardButton } from '../../components/Card/CardButton.js';
 import { useAccount } from '../../hooks/useAccount.js';
-import { useAddressValidation } from '../../hooks/useAddressValidation.js';
+import {
+  AddressType,
+  useAddressValidation,
+} from '../../hooks/useAddressValidation.js';
 import { useChain } from '../../hooks/useChain.js';
 import { useToAddressRequirements } from '../../hooks/useToAddressRequirements.js';
 import type { Bookmark } from '../../stores/bookmarks/types.js';
@@ -32,11 +35,18 @@ export const SendToWalletPage = () => {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const { bookmarks, recentWallets } = useBookmarks();
-  const { addBookmark, getBookmark, setSelectedBookmark, addRecentWallet } =
-    useBookmarkActions();
+  const {
+    addBookmark,
+    getBookmark,
+    setSelectedBookmark,
+    getSelectedBookmark,
+    addRecentWallet,
+  } = useBookmarkActions();
   const bookmarkAddressSheetRef = useRef<BottomSheetBase>(null);
   const confirmAddressSheetRef = useRef<BottomSheetBase>(null);
-  const [inputAddressValue, setInputAddressValue] = useState('');
+  const [inputAddressValue, setInputAddressValue] = useState(
+    () => getSelectedBookmark()?.address ?? '',
+  );
   const [validatedWallet, setValidatedWallet] = useState<Bookmark>();
   const [errorMessage, setErrorMessage] = useState('');
   const { validateAddress, isValidating } = useAddressValidation();
@@ -45,6 +55,8 @@ export const SendToWalletPage = () => {
   const { requiredToChainType } = useToAddressRequirements();
   const [toChainId] = useFieldValues('toChain');
   const { chain: toChain } = useChain(toChainId);
+  const [isDoneButtonLoading, setIsDoneButtonLoading] = useState(false);
+  const [isBookmarkButtonLoading, setIsBookmarkButtonLoading] = useState(false);
 
   const handleInputChange = (e: ChangeEvent) => {
     if (errorMessage) {
@@ -58,11 +70,16 @@ export const SendToWalletPage = () => {
       return;
     }
     if (!inputAddressValue) {
-      setErrorMessage(t('error.title.addressRequired'));
+      setErrorMessage(t('error.title.walletAddressRequired'));
       return;
     }
-
-    const validationResult = await validateAddress(inputAddressValue);
+    setIsDoneButtonLoading(true);
+    const validationResult = await validateAddress({
+      value: inputAddressValue,
+      chainType: requiredToChainType,
+      chain: toChain,
+    });
+    setIsDoneButtonLoading(false);
     if (!validationResult.isValid) {
       setErrorMessage(validationResult.error);
       return;
@@ -82,7 +99,9 @@ export const SendToWalletPage = () => {
 
     setValidatedWallet({
       name:
-        validationResult.addressType === 'ENS' ? inputAddressValue : undefined,
+        validationResult.addressType === AddressType.NameService
+          ? inputAddressValue
+          : undefined,
       address: validationResult.address,
       chainType: validationResult.chainType,
     });
@@ -94,7 +113,7 @@ export const SendToWalletPage = () => {
       return;
     }
     if (!inputAddressValue) {
-      setErrorMessage(t('error.title.addressRequired'));
+      setErrorMessage(t('error.title.walletAddressRequired'));
       return;
     }
 
@@ -107,13 +126,16 @@ export const SendToWalletPage = () => {
       );
       return;
     }
-
-    const validationResult = await validateAddress(inputAddressValue);
+    setIsBookmarkButtonLoading(true);
+    const validationResult = await validateAddress({
+      value: inputAddressValue,
+    });
+    setIsBookmarkButtonLoading(false);
 
     if (validationResult.isValid) {
       setValidatedWallet({
         name:
-          validationResult.addressType === 'ENS'
+          validationResult.addressType === AddressType.NameService
             ? inputAddressValue
             : undefined,
         address: validationResult.address,
@@ -146,6 +168,10 @@ export const SendToWalletPage = () => {
     addRecentWallet(confirmedWallet);
   };
 
+  const placeholder = t('sendToWallet.enterAddress', {
+    context: 'long',
+  });
+
   return (
     <SendToWalletPageContainer topBottomGutters>
       <SendToWalletCard mb={6} variant={errorMessage ? 'error' : 'default'}>
@@ -157,8 +183,8 @@ export const SendToWalletPage = () => {
           spellCheck="false"
           onChange={handleInputChange}
           value={inputAddressValue}
-          placeholder={t('sendToWallet.enterAddress')}
-          aria-label={t('sendToWallet.enterAddress')}
+          placeholder={placeholder}
+          aria-label={placeholder}
           maxRows={2}
           inputProps={{ maxLength: 128 }}
           multiline
@@ -172,12 +198,18 @@ export const SendToWalletPage = () => {
           <SendToWalletButton
             variant="text"
             onClick={handleDone}
+            loading={isDoneButtonLoading}
+            loadingPosition="center"
             sx={{ flexGrow: 1 }}
           >
             {t('button.done')}
           </SendToWalletButton>
           <Tooltip title={t('button.bookmark')} arrow>
-            <SendToWalletIconButton onClick={handleBookmarkAddress}>
+            <SendToWalletIconButton
+              onClick={handleBookmarkAddress}
+              loading={isBookmarkButtonLoading}
+              loadingPosition="center"
+            >
               <TurnedIn fontSize="small" />
             </SendToWalletIconButton>
           </Tooltip>

--- a/packages/widget/src/pages/SettingsPage/SendToWalletOptionSetting.tsx
+++ b/packages/widget/src/pages/SettingsPage/SendToWalletOptionSetting.tsx
@@ -9,7 +9,7 @@ import {
 } from '../../components/Card/CardButton.style.js';
 import { Switch } from '../../components/Switch.js';
 import { useWidgetConfig } from '../../providers/WidgetProvider/WidgetProvider.js';
-import { useSendToWalletStore } from '../../stores/settings/useSendToWalletStore.js';
+import { useSendToWalletActions } from '../../stores/settings/useSendToWalletStore.js';
 import { useSettings } from '../../stores/settings/useSettings.js';
 import { useSettingsStore } from '../../stores/settings/useSettingsStore.js';
 import { HiddenUI } from '../../types/widget.js';
@@ -17,9 +17,7 @@ import { HiddenUI } from '../../types/widget.js';
 export const SendToWalletOptionSetting = () => {
   const { t } = useTranslation();
   const { hiddenUI } = useWidgetConfig();
-  const setSendToWallet = useSendToWalletStore(
-    (state) => state.setSendToWallet,
-  );
+  const { setSendToWallet } = useSendToWalletActions();
   const setValue = useSettingsStore((state) => state.setValue);
   const { showDestinationWallet } = useSettings(['showDestinationWallet']);
 

--- a/packages/widget/src/providers/WalletProvider/EVMBaseProvider.tsx
+++ b/packages/widget/src/providers/WalletProvider/EVMBaseProvider.tsx
@@ -77,12 +77,6 @@ export const EVMBaseProvider: FC<PropsWithChildren> = ({ children }) => {
     const _chains: [Chain, ...Chain[]] = chains?.length
       ? (chains.map(formatChain) as [Chain, ...Chain[]])
       : [mainnet];
-    // Add ENS contracts
-    const _mainnet = _chains.find((chain) => chain.id === mainnet.id);
-    if (_mainnet) {
-      _mainnet.contracts = mainnet.contracts;
-    }
-
     if (!connectors['walletConnect']) {
       const params = walletConfig?.walletConnect ?? {
         projectId: defaultWalletConnectProjectId,

--- a/packages/widget/src/stores/bookmarks/createBookmarkStore.ts
+++ b/packages/widget/src/stores/bookmarks/createBookmarkStore.ts
@@ -33,6 +33,7 @@ export const createBookmarksStore = ({
             ),
           }));
         },
+        getSelectedBookmark: () => get().selectedBookmark,
         setSelectedBookmark: (bookmark) => {
           set((state) => ({
             selectedBookmark: bookmark,

--- a/packages/widget/src/stores/bookmarks/types.ts
+++ b/packages/widget/src/stores/bookmarks/types.ts
@@ -17,6 +17,7 @@ export interface BookmarkActions {
   addBookmark: (bookmark: Bookmark) => void;
   removeBookmark: (address: string) => void;
   setSelectedBookmark: (bookmark?: Bookmark) => void;
+  getSelectedBookmark: () => Bookmark | undefined;
   addRecentWallet: (bookmark: Bookmark) => void;
   removeRecentWallet: (address: string) => void;
 }

--- a/packages/widget/src/stores/bookmarks/useBookmarkActions.ts
+++ b/packages/widget/src/stores/bookmarks/useBookmarkActions.ts
@@ -9,6 +9,7 @@ export const useBookmarkActions = () => {
       addBookmark: store.addBookmark,
       removeBookmark: store.removeBookmark,
       setSelectedBookmark: store.setSelectedBookmark,
+      getSelectedBookmark: store.getSelectedBookmark,
       addRecentWallet: store.addRecentWallet,
       removeRecentWallet: store.removeRecentWallet,
     }),

--- a/packages/widget/src/stores/settings/useSendToWalletStore.ts
+++ b/packages/widget/src/stores/settings/useSendToWalletStore.ts
@@ -1,3 +1,4 @@
+import { shallow } from 'zustand/shallow';
 import { createWithEqualityFn } from 'zustand/traditional';
 import type { SendToWalletStore } from './types.js';
 
@@ -18,3 +19,15 @@ export const useSendToWalletStore = createWithEqualityFn<SendToWalletStore>(
   }),
   Object.is,
 );
+
+export const useSendToWalletActions = () => {
+  const actions = useSendToWalletStore(
+    (store) => ({
+      toggleSendToWallet: store.toggleSendToWallet,
+      setSendToWallet: store.setSendToWallet,
+    }),
+    shallow,
+  );
+
+  return actions;
+};


### PR DESCRIPTION
### Improvements

1. Add support for SNS and ENS from SDK (requires release of https://github.com/lifinance/sdk/pull/177)
2. Improve placeholder messages not to mention ENS, but instead use the general `domain name` term
3. Remove unnecessary confirmation bottom sheets
4. Fixed name trim when adding a bookmark
5. Put the address of the selected bookmark in the input field on SendToWalletPage to replace a placeholder if any
6. Change Send to wallet default chain icon to the destination chain icon if the destination token is selected