### PR TITLE
feat: start with playground tool drawer open

### DIFF
--- a/packages/widget-playground/src/store/editTools/createEditToolsStore.ts
+++ b/packages/widget-playground/src/store/editTools/createEditToolsStore.ts
@@ -8,7 +8,7 @@ export const createEditToolsStore = () =>
     persist(
       (set) => ({
         drawer: {
-          open: false,
+          open: true,
         },
         setDrawerOpen: (open) => {
           set({


### PR DESCRIPTION
Requested by Vilen

https://discord.com/channels/849912621360218112/1209523710558732358/1209532051888541716

When a user first lands on the playground the tool draw will be open