### PR TITLE
Spike: Dynamic codesandbox use in playground

### DIFF
--- a/packages/widget-playground/src/components/DrawerControls/CodeControls.tsx
+++ b/packages/widget-playground/src/components/DrawerControls/CodeControls.tsx
@@ -7,7 +7,7 @@ import {
   tooltipPopperZIndex,
 } from './DrawerControls.style';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
-import { WidgetConfig } from '@lifi/widget';
+import type { WidgetConfig } from '@lifi/widget';
 import { useConfig } from '../../store';
 import { getValueFromPath } from '../../utils';
 import { Box, Tooltip, Typography } from '@mui/material';
@@ -80,6 +80,7 @@ export const CodeControls = () => {
         aria-label="tabs"
         indicatorColor="primary"
         onChange={(_, value) => setCodeTabsState(value)}
+        sx={{ maxWidth: 326 }}
       >
         <Tab label={'Config'} value="config" disableRipple />
         <Tab label={'React'} value="react" disableRipple />

--- a/packages/widget-playground/src/components/DrawerControls/CodeControls.tsx
+++ b/packages/widget-playground/src/components/DrawerControls/CodeControls.tsx
@@ -10,9 +10,24 @@ import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import { WidgetConfig } from '@lifi/widget';
 import { useConfig } from '../../store';
 import { getValueFromPath } from '../../utils';
-import { Tooltip } from '@mui/material';
+import { Box, Tooltip, Typography } from '@mui/material';
+import { Tab, Tabs } from '../Tabs';
+import React, { useState } from 'react';
 
-// TODO: this should probable be done on config rehdration as well
+const reactTemplate = (config?: string) =>
+  config
+    ? `import { LiFiWidget } from '@lifi/widget';
+
+export function Widget() {
+  const config = ${config.replace(/\n/g, '\n  ')}
+
+  return (
+      <LiFiWidget config={config} integrator="li.fi-playground" open />
+  );
+}
+  `
+    : null;
+
 const substitions = {
   walletConfig: {
     '"walletConfig": {}': '"walletConfig": { async onConnect() {} }',
@@ -38,8 +53,20 @@ const configToStringWithSubstitions = (
 
 export const CodeControls = () => {
   const { config } = useConfig();
+  const [codeTabsState, setCodeTabsState] = useState<'config' | 'react'>(
+    'config',
+  );
 
-  const code = configToStringWithSubstitions(config);
+  const code =
+    codeTabsState === 'config'
+      ? configToStringWithSubstitions(config)
+      : reactTemplate(configToStringWithSubstitions(config));
+
+  const message =
+    codeTabsState === 'config'
+      ? 'Add this configuration to your widget'
+      : 'Ensure that @lifi/widget is installed in your project';
+
   const handleCopyCode = () => {
     if (code) {
       navigator.clipboard.writeText(code);
@@ -48,21 +75,33 @@ export const CodeControls = () => {
 
   return (
     <Card sx={{ p: 1 }}>
+      <Tabs
+        value={codeTabsState}
+        aria-label="tabs"
+        indicatorColor="primary"
+        onChange={(_, value) => setCodeTabsState(value)}
+      >
+        <Tab label={'Config'} value="config" disableRipple />
+        <Tab label={'React'} value="react" disableRipple />
+      </Tabs>
       {code ? (
-        <CodeContainer>
-          <Tooltip
-            title="Copy code"
-            PopperProps={{ style: { zIndex: tooltipPopperZIndex } }}
-            arrow
-          >
-            <CodeCopyButton onClick={handleCopyCode}>
-              <ContentCopyIcon fontSize={'small'} />
-            </CodeCopyButton>
-          </Tooltip>
-          <Pre>
-            <Code>{code}</Code>
-          </Pre>
-        </CodeContainer>
+        <Box sx={{ marginTop: 1 }}>
+          <Typography variant="caption">{message}</Typography>
+          <CodeContainer>
+            <Tooltip
+              title="Copy code"
+              PopperProps={{ style: { zIndex: tooltipPopperZIndex } }}
+              arrow
+            >
+              <CodeCopyButton onClick={handleCopyCode}>
+                <ContentCopyIcon fontSize={'small'} />
+              </CodeCopyButton>
+            </Tooltip>
+            <Pre>
+              <Code>{code}</Code>
+            </Pre>
+          </CodeContainer>
+        </Box>
       ) : null}
     </Card>
   );

--- a/packages/widget-playground/src/components/DrawerControls/CodeControls.tsx
+++ b/packages/widget-playground/src/components/DrawerControls/CodeControls.tsx
@@ -1,0 +1,69 @@
+import { Card } from '../Card';
+import {
+  Code,
+  CodeContainer,
+  CodeCopyButton,
+  Pre,
+  tooltipPopperZIndex,
+} from './DrawerControls.style';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import { WidgetConfig } from '@lifi/widget';
+import { useConfig } from '../../store';
+import { getValueFromPath } from '../../utils';
+import { Tooltip } from '@mui/material';
+
+// TODO: this should probable be done on config rehdration as well
+const substitions = {
+  walletConfig: {
+    '"walletConfig": {}': '"walletConfig": { async onConnect() {} }',
+  },
+};
+const configToStringWithSubstitions = (
+  config?: Partial<WidgetConfig>,
+): string | undefined => {
+  if (!config) {
+    return undefined;
+  }
+  let stringifiedConfig = JSON.stringify(config, null, 2);
+
+  Object.entries(substitions).forEach(([property, substition]) => {
+    if (getValueFromPath(config, property)) {
+      const [[find, replace]] = Object.entries(substition);
+      stringifiedConfig = stringifiedConfig.replace(find, replace);
+    }
+  });
+
+  return stringifiedConfig.replace(/"([^"]+)":/g, '$1:');
+};
+
+export const CodeControls = () => {
+  const { config } = useConfig();
+
+  const code = configToStringWithSubstitions(config);
+  const handleCopyCode = () => {
+    if (code) {
+      navigator.clipboard.writeText(code);
+    }
+  };
+
+  return (
+    <Card sx={{ p: 1 }}>
+      {code ? (
+        <CodeContainer>
+          <Tooltip
+            title="Copy code"
+            PopperProps={{ style: { zIndex: tooltipPopperZIndex } }}
+            arrow
+          >
+            <CodeCopyButton onClick={handleCopyCode}>
+              <ContentCopyIcon fontSize={'small'} />
+            </CodeCopyButton>
+          </Tooltip>
+          <Pre>
+            <Code>{code}</Code>
+          </Pre>
+        </CodeContainer>
+      ) : null}
+    </Card>
+  );
+};

--- a/packages/widget-playground/src/components/DrawerControls/CodeControls.tsx
+++ b/packages/widget-playground/src/components/DrawerControls/CodeControls.tsx
@@ -4,15 +4,19 @@ import {
   CodeContainer,
   CodeCopyButton,
   Pre,
+  TabContentContainer,
   tooltipPopperZIndex,
+  Modal,
 } from './DrawerControls.style';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import type { WidgetConfig } from '@lifi/widget';
 import { useConfig } from '../../store';
 import { getValueFromPath } from '../../utils';
-import { Box, Tooltip, Typography } from '@mui/material';
+import { Box, Button, Tooltip, Typography } from '@mui/material';
 import { Tab, Tabs } from '../Tabs';
 import React, { useState } from 'react';
+import TabContext from '@mui/lab/TabContext';
+import { CodesandBoxEmbed } from './CodesandBoxEmbed';
 
 const reactTemplate = (config?: string) =>
   config
@@ -73,6 +77,18 @@ export const CodeControls = () => {
     }
   };
 
+  const [codeSandboxExample, setCodeSandboxExample] = useState<
+    'vite' | undefined
+  >();
+
+  const handleReactExampleClick = () => {
+    setCodeSandboxExample('vite');
+  };
+
+  const handleCloseCodeSandbox = () => {
+    setCodeSandboxExample(undefined);
+  };
+
   return (
     <Card sx={{ p: 1 }}>
       <Tabs
@@ -83,27 +99,43 @@ export const CodeControls = () => {
         sx={{ maxWidth: 326 }}
       >
         <Tab label={'Config'} value="config" disableRipple />
-        <Tab label={'React'} value="react" disableRipple />
+        <Tab label={'CodeSandbox'} value="react" disableRipple />
       </Tabs>
-      {code ? (
-        <Box sx={{ marginTop: 1 }}>
-          <Typography variant="caption">{message}</Typography>
-          <CodeContainer>
-            <Tooltip
-              title="Copy code"
-              PopperProps={{ style: { zIndex: tooltipPopperZIndex } }}
-              arrow
-            >
-              <CodeCopyButton onClick={handleCopyCode}>
-                <ContentCopyIcon fontSize={'small'} />
-              </CodeCopyButton>
-            </Tooltip>
-            <Pre>
-              <Code>{code}</Code>
-            </Pre>
-          </CodeContainer>
-        </Box>
-      ) : null}
+      <TabContext value={codeTabsState}>
+        <TabContentContainer value="config">
+          {code ? (
+            <Box sx={{ marginTop: 1 }}>
+              <Typography variant="caption">{message}</Typography>
+              <CodeContainer>
+                <Tooltip
+                  title="Copy code"
+                  PopperProps={{ style: { zIndex: tooltipPopperZIndex } }}
+                  arrow
+                >
+                  <CodeCopyButton onClick={handleCopyCode}>
+                    <ContentCopyIcon fontSize={'small'} />
+                  </CodeCopyButton>
+                </Tooltip>
+                <Pre>
+                  <Code>{code}</Code>
+                </Pre>
+              </CodeContainer>
+            </Box>
+          ) : null}
+        </TabContentContainer>
+        <TabContentContainer value="react">
+          <Button
+            variant="contained"
+            sx={{ marginTop: 2 }}
+            onClick={handleReactExampleClick}
+          >
+            React Example
+          </Button>
+          <Modal open={!!codeSandboxExample}>
+            <CodesandBoxEmbed onClose={handleCloseCodeSandbox} />
+          </Modal>
+        </TabContentContainer>
+      </TabContext>
     </Card>
   );
 };

--- a/packages/widget-playground/src/components/DrawerControls/CodesandBoxEmbed.tsx
+++ b/packages/widget-playground/src/components/DrawerControls/CodesandBoxEmbed.tsx
@@ -1,0 +1,41 @@
+import { Header, HeaderRow, tooltipPopperZIndex } from './DrawerControls.style';
+import { IconButton, Tooltip } from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
+import React, { useEffect } from 'react';
+import { createCodesandbox } from './createCodesandbox';
+
+interface CodesandBoxEmbedProps {
+  onClose: () => void;
+}
+export const CodesandBoxEmbed = ({ onClose }: CodesandBoxEmbedProps) => {
+  const [iframeData, setIframeData] = React.useState({});
+
+  const embedCodesandbox = React.useCallback(async () => {
+    const data = await createCodesandbox();
+    setIframeData(data);
+  }, []);
+
+  useEffect(() => {
+    embedCodesandbox();
+  }, []);
+
+  return (
+    <>
+      <HeaderRow sx={{ paddingX: 2 }}>
+        <Header as="h2" sx={{ fontSize: '1.2rem' }}>
+          LI.FI Widget - React Example
+        </Header>
+        <Tooltip
+          title="Close"
+          PopperProps={{ style: { zIndex: tooltipPopperZIndex } }}
+          arrow
+        >
+          <IconButton onClick={onClose}>
+            <CloseIcon />
+          </IconButton>
+        </Tooltip>
+      </HeaderRow>
+      {iframeData ? <iframe title="vite-example" {...iframeData} /> : null}
+    </>
+  );
+};

--- a/packages/widget-playground/src/components/DrawerControls/DrawerControls.style.ts
+++ b/packages/widget-playground/src/components/DrawerControls/DrawerControls.style.ts
@@ -1,4 +1,4 @@
-import { Box, Drawer as MuiDrawer, styled } from '@mui/material';
+import { Box, Drawer as MuiDrawer, IconButton, styled } from '@mui/material';
 import TabPanel from '@mui/lab/TabPanel';
 export const drawerWidth = 392;
 export const drawerZIndex = 1501;
@@ -40,4 +40,30 @@ export const TabContentContainer = styled(TabPanel)(({ theme }) => ({
   alignItems: 'stretch',
   gap: theme.spacing(2),
   padding: 0,
+}));
+
+export const CodeContainer = styled(Box)(({ theme }) => ({
+  position: 'relative',
+}));
+
+export const CodeCopyButton = styled(IconButton)(({ theme }) => ({
+  position: 'absolute',
+  right: '4px',
+  top: '4px',
+}));
+
+export const Pre = styled('pre')(({ theme }) => ({
+  backgroundColor:
+    theme.palette.mode === 'light'
+      ? theme.palette.grey[200]
+      : theme.palette.grey[800],
+  margin: 0,
+  padding: theme.spacing(1),
+  borderRadius: theme.shape.borderRadius - 4,
+  overflowX: 'scroll',
+}));
+
+export const Code = styled('code')(({ theme }) => ({
+  fontFamily: 'Courier, monospace',
+  fontSize: '0.9em',
 }));

--- a/packages/widget-playground/src/components/DrawerControls/DrawerControls.style.ts
+++ b/packages/widget-playground/src/components/DrawerControls/DrawerControls.style.ts
@@ -40,16 +40,30 @@ export const TabContentContainer = styled(TabPanel)(({ theme }) => ({
   alignItems: 'stretch',
   gap: theme.spacing(2),
   padding: 0,
+  '&[hidden]': {
+    display: 'none',
+  },
 }));
 
 export const CodeContainer = styled(Box)(({ theme }) => ({
   position: 'relative',
+  marginTop: theme.spacing(1),
 }));
 
 export const CodeCopyButton = styled(IconButton)(({ theme }) => ({
   position: 'absolute',
   right: '4px',
   top: '4px',
+  background:
+    theme.palette.mode === 'light'
+      ? theme.palette.grey[200]
+      : theme.palette.grey[800],
+  '&:hover': {
+    background:
+      theme.palette.mode === 'light'
+        ? theme.palette.grey[300]
+        : theme.palette.grey[700],
+  },
 }));
 
 export const Pre = styled('pre')(({ theme }) => ({
@@ -65,5 +79,5 @@ export const Pre = styled('pre')(({ theme }) => ({
 
 export const Code = styled('code')(({ theme }) => ({
   fontFamily: 'Courier, monospace',
-  fontSize: '0.9em',
+  fontSize: '0.8em',
 }));

--- a/packages/widget-playground/src/components/DrawerControls/DrawerControls.style.tsx
+++ b/packages/widget-playground/src/components/DrawerControls/DrawerControls.style.tsx
@@ -7,11 +7,13 @@ import {
   ButtonBase,
   Drawer as MuiDrawer,
   IconButton,
+  Modal as MuiModal,
   styled,
 } from '@mui/material';
 import TabPanel from '@mui/lab/TabPanel';
 export const drawerZIndex = 1501;
 export const autocompletePopperZIndex = drawerZIndex + 1;
+export const modalZIndex = drawerZIndex + 1;
 export const tooltipPopperZIndex = drawerZIndex + 2;
 
 interface DrawerProps extends MuiDrawerProps {
@@ -125,4 +127,16 @@ export const DrawerHandleButton = styled(
   transform: 'translateX(-8px)',
   left: drawerWidth,
   zIndex: drawerZIndex + 1,
+}));
+
+export const Modal = styled(MuiModal)(({ theme }) => ({
+  display: 'flex',
+  flexDirection: 'column',
+  width: '95%',
+  height: '95%',
+  zIndex: modalZIndex,
+  backgroundColor: theme.palette.background.paper,
+  top: '50%',
+  left: '50%',
+  transform: 'translate(-50%, -50%)',
 }));

--- a/packages/widget-playground/src/components/DrawerControls/DrawerControls.style.tsx
+++ b/packages/widget-playground/src/components/DrawerControls/DrawerControls.style.tsx
@@ -1,14 +1,28 @@
-import { Box, Drawer as MuiDrawer, IconButton, styled } from '@mui/material';
+import type {
+  ButtonBaseProps,
+  DrawerProps as MuiDrawerProps,
+} from '@mui/material';
+import {
+  Box,
+  ButtonBase,
+  Drawer as MuiDrawer,
+  IconButton,
+  styled,
+} from '@mui/material';
 import TabPanel from '@mui/lab/TabPanel';
-export const drawerWidth = 392;
 export const drawerZIndex = 1501;
 export const autocompletePopperZIndex = drawerZIndex + 1;
 export const tooltipPopperZIndex = drawerZIndex + 2;
 
-export const Drawer = styled(MuiDrawer)(({ open }) => ({
+interface DrawerProps extends MuiDrawerProps {
+  drawerWidth: number;
+}
+export const Drawer = styled(MuiDrawer, {
+  shouldForwardProp: (prop) => !['drawerWidth'].includes(prop as string),
+})<DrawerProps>(({ open, drawerWidth }) => ({
   width: drawerWidth,
   // NOTE: setting the zIndex seems to prevent clicks underneath where the
-  //  draw was when closed - so we ony want to set eh zIndex when its open
+  //  draw was when closed - so we ony want to se the zIndex when its open
   ...(open ? { zIndex: drawerZIndex } : {}),
 }));
 
@@ -24,7 +38,11 @@ export const HeaderRow = styled(Box)({
   alignItems: 'center',
 });
 
-export const DrawerContentContainer = styled(Box)(({ theme }) => ({
+export const DrawerContentContainer = styled(Box, {
+  shouldForwardProp: (prop) => !['drawerWidth'].includes(prop as string),
+})<{
+  drawerWidth: number;
+}>(({ theme, drawerWidth }) => ({
   display: 'flex',
   width: drawerWidth,
   padding: theme.spacing(3),
@@ -80,4 +98,31 @@ export const Pre = styled('pre')(({ theme }) => ({
 export const Code = styled('code')(({ theme }) => ({
   fontFamily: 'Courier, monospace',
   fontSize: '0.8em',
+}));
+
+interface DrawerHandleProps extends ButtonBaseProps {
+  drawerWidth: number;
+}
+export const DrawerHandleButton = styled(
+  (props: DrawerHandleProps) => (
+    <ButtonBase {...props} disableRipple>
+      &nbsp;
+    </ButtonBase>
+  ),
+  {
+    shouldForwardProp: (prop) => !['drawerWidth'].includes(prop as string),
+  },
+)(({ theme, drawerWidth }) => ({
+  background: 'none',
+  color: 'inherit',
+  border: 'none',
+  font: 'inherit',
+  outline: 'inherit',
+  height: '100%',
+  width: theme.spacing(1.75),
+  cursor: 'col-resize',
+  position: 'absolute',
+  transform: 'translateX(-8px)',
+  left: drawerWidth,
+  zIndex: drawerZIndex + 1,
 }));

--- a/packages/widget-playground/src/components/DrawerControls/DrawerControls.tsx
+++ b/packages/widget-playground/src/components/DrawerControls/DrawerControls.tsx
@@ -30,6 +30,7 @@ import {
   TabContentContainer,
   tooltipPopperZIndex,
 } from './DrawerControls.style';
+import { CodeControls } from './CodeControls';
 
 export const DrawerControls = () => {
   const [controlsTabsState, setControlsTabsState] = useState<'design' | 'code'>(
@@ -84,7 +85,6 @@ export const DrawerControls = () => {
             label={'Code'}
             value="code"
             disableRipple
-            disabled
           />
         </Tabs>
         <TabContext value={controlsTabsState}>
@@ -101,7 +101,7 @@ export const DrawerControls = () => {
             </ExpandableCardAccordion>
           </TabContentContainer>
           <TabContentContainer value="code">
-            <p>TODO: code controls</p>
+            <CodeControls />
           </TabContentContainer>
         </TabContext>
       </DrawerContentContainer>

--- a/packages/widget-playground/src/components/DrawerControls/DrawerControls.tsx
+++ b/packages/widget-playground/src/components/DrawerControls/DrawerControls.tsx
@@ -3,7 +3,7 @@ import DesignServicesIcon from '@mui/icons-material/DesignServices';
 import IntegrationInstructionsIcon from '@mui/icons-material/IntegrationInstructions';
 import RestartAltIcon from '@mui/icons-material/RestartAlt';
 import TabContext from '@mui/lab/TabContext';
-import { Box, IconButton, Tooltip } from '@mui/material';
+import { Box, IconButton, Tooltip, Typography, Link } from '@mui/material';
 import { useState } from 'react';
 import {
   useConfigActions,
@@ -101,6 +101,15 @@ export const DrawerControls = () => {
             </ExpandableCardAccordion>
           </TabContentContainer>
           <TabContentContainer value="code">
+            <Typography variant="body2">
+              More examples of how to use the widget can be found in our{' '}
+              <Link
+                href="https://github.com/lifinance/widget/tree/main/examples"
+                rel="nofollow"
+              >
+                github repo
+              </Link>
+            </Typography>
             <CodeControls />
           </TabContentContainer>
         </TabContext>

--- a/packages/widget-playground/src/components/DrawerControls/DrawerControls.tsx
+++ b/packages/widget-playground/src/components/DrawerControls/DrawerControls.tsx
@@ -31,6 +31,7 @@ import {
   tooltipPopperZIndex,
 } from './DrawerControls.style';
 import { CodeControls } from './CodeControls';
+import { FontEmbedPrompt } from './FontEmbedPrompt';
 
 export const DrawerControls = () => {
   const [controlsTabsState, setControlsTabsState] = useState<'design' | 'code'>(

--- a/packages/widget-playground/src/components/DrawerControls/DrawerControls.tsx
+++ b/packages/widget-playground/src/components/DrawerControls/DrawerControls.tsx
@@ -86,7 +86,7 @@ export const DrawerControls = () => {
             aria-label="tabs"
             indicatorColor="primary"
             onChange={(_, value) => setVisibleControls(value)}
-            sx={{ maxWidth: 336 }}
+            sx={{ maxWidth: 348 }}
           >
             <Tab
               icon={<DesignServicesIcon />}
@@ -117,15 +117,6 @@ export const DrawerControls = () => {
               </ExpandableCardAccordion>
             </TabContentContainer>
             <TabContentContainer value="code">
-              <Typography variant="body2">
-                More examples of how to use the widget can be found in our{' '}
-                <Link
-                  href="https://github.com/lifinance/widget/tree/main/examples"
-                  rel="nofollow"
-                >
-                  github repo
-                </Link>
-              </Typography>
               <CodeControls />
             </TabContentContainer>
           </TabContext>

--- a/packages/widget-playground/src/components/DrawerControls/DrawerControls.tsx
+++ b/packages/widget-playground/src/components/DrawerControls/DrawerControls.tsx
@@ -4,8 +4,8 @@ import IntegrationInstructionsIcon from '@mui/icons-material/IntegrationInstruct
 import RestartAltIcon from '@mui/icons-material/RestartAlt';
 import TabContext from '@mui/lab/TabContext';
 import { Box, IconButton, Tooltip, Typography, Link } from '@mui/material';
-import { useState } from 'react';
 import {
+  defaultDrawerWidth,
   useConfigActions,
   useEditToolsActions,
   useEditToolsValues,
@@ -31,90 +31,106 @@ import {
   tooltipPopperZIndex,
 } from './DrawerControls.style';
 import { CodeControls } from './CodeControls';
-import { FontEmbedPrompt } from './FontEmbedPrompt';
+import { DrawerHandle } from './DrawerHandle';
 
 export const DrawerControls = () => {
-  const [controlsTabsState, setControlsTabsState] = useState<'design' | 'code'>(
-    'design',
-  );
-  const { isDrawerOpen } = useEditToolsValues();
-  const { setDrawerOpen } = useEditToolsActions();
+  const { isDrawerOpen, visibleControls, codeDrawerWidth } =
+    useEditToolsValues();
+  const { setDrawerOpen, setVisibleControls, resetEditTools } =
+    useEditToolsActions();
   const { resetConfig } = useConfigActions();
 
+  const handleReset = () => {
+    resetConfig();
+    resetEditTools();
+  };
+
+  const drawerWidth =
+    visibleControls === 'code' ? codeDrawerWidth : defaultDrawerWidth;
+
   return (
-    <Drawer variant="persistent" anchor="left" open={isDrawerOpen}>
-      <DrawerContentContainer>
-        <HeaderRow>
-          <Header>LI.FI Widget</Header>
-          <Box>
-            <Tooltip
-              title="Reset config"
-              PopperProps={{ style: { zIndex: tooltipPopperZIndex } }}
-              arrow
-            >
-              <IconButton onClick={() => resetConfig()}>
-                <RestartAltIcon />
-              </IconButton>
-            </Tooltip>
-            <Tooltip
-              title="Close tools"
-              PopperProps={{ style: { zIndex: tooltipPopperZIndex } }}
-              arrow
-            >
-              <IconButton onClick={() => setDrawerOpen(!isDrawerOpen)}>
-                <CloseIcon />
-              </IconButton>
-            </Tooltip>
-          </Box>
-        </HeaderRow>
-        <Tabs
-          value={controlsTabsState}
-          aria-label="tabs"
-          indicatorColor="primary"
-          onChange={(_, value) => setControlsTabsState(value)}
-        >
-          <Tab
-            icon={<DesignServicesIcon />}
-            iconPosition="start"
-            label={'Design'}
-            value="design"
-            disableRipple
-          />
-          <Tab
-            icon={<IntegrationInstructionsIcon />}
-            iconPosition="start"
-            label={'Code'}
-            value="code"
-            disableRipple
-          />
-        </Tabs>
-        <TabContext value={controlsTabsState}>
-          <TabContentContainer value="design">
-            <ExpandableCardAccordion>
-              <VariantControl />
-              <SubvariantControl />
-              <AppearanceControl />
-              <ColorControl />
-              <FontsControl />
-              <CardRadiusControl />
-              <ButtonRadiusControl />
-              <WalletManagementControl />
-            </ExpandableCardAccordion>
-          </TabContentContainer>
-          <TabContentContainer value="code">
-            <Typography variant="body2">
-              More examples of how to use the widget can be found in our{' '}
-              <Link
-                href="https://github.com/lifinance/widget/tree/main/examples"
-                rel="nofollow"
+    <>
+      <DrawerHandle />
+      <Drawer
+        variant="persistent"
+        anchor="left"
+        open={isDrawerOpen}
+        drawerWidth={drawerWidth}
+      >
+        <DrawerContentContainer drawerWidth={drawerWidth}>
+          <HeaderRow>
+            <Header>LI.FI Widget</Header>
+            <Box>
+              <Tooltip
+                title="Reset config"
+                PopperProps={{ style: { zIndex: tooltipPopperZIndex } }}
+                arrow
               >
-                github repo
-              </Link>
-            </Typography>
-            <CodeControls />
-          </TabContentContainer>
-        </TabContext>
-      </DrawerContentContainer>
-    </Drawer>
+                <IconButton onClick={handleReset}>
+                  <RestartAltIcon />
+                </IconButton>
+              </Tooltip>
+              <Tooltip
+                title="Close tools"
+                PopperProps={{ style: { zIndex: tooltipPopperZIndex } }}
+                arrow
+              >
+                <IconButton onClick={() => setDrawerOpen(!isDrawerOpen)}>
+                  <CloseIcon />
+                </IconButton>
+              </Tooltip>
+            </Box>
+          </HeaderRow>
+          <Tabs
+            value={visibleControls}
+            aria-label="tabs"
+            indicatorColor="primary"
+            onChange={(_, value) => setVisibleControls(value)}
+            sx={{ maxWidth: 336 }}
+          >
+            <Tab
+              icon={<DesignServicesIcon />}
+              iconPosition="start"
+              label={'Design'}
+              value="design"
+              disableRipple
+            />
+            <Tab
+              icon={<IntegrationInstructionsIcon />}
+              iconPosition="start"
+              label={'Code'}
+              value="code"
+              disableRipple
+            />
+          </Tabs>
+          <TabContext value={visibleControls}>
+            <TabContentContainer value="design">
+              <ExpandableCardAccordion>
+                <VariantControl />
+                <SubvariantControl />
+                <AppearanceControl />
+                <ColorControl />
+                <FontsControl />
+                <CardRadiusControl />
+                <ButtonRadiusControl />
+                <WalletManagementControl />
+              </ExpandableCardAccordion>
+            </TabContentContainer>
+            <TabContentContainer value="code">
+              <Typography variant="body2">
+                More examples of how to use the widget can be found in our{' '}
+                <Link
+                  href="https://github.com/lifinance/widget/tree/main/examples"
+                  rel="nofollow"
+                >
+                  github repo
+                </Link>
+              </Typography>
+              <CodeControls />
+            </TabContentContainer>
+          </TabContext>
+        </DrawerContentContainer>
+      </Drawer>
+    </>
   );
 };

--- a/packages/widget-playground/src/components/DrawerControls/DrawerHandle.tsx
+++ b/packages/widget-playground/src/components/DrawerControls/DrawerHandle.tsx
@@ -1,0 +1,56 @@
+import type { MouseEventHandler } from 'react';
+import { useEffect, useState } from 'react';
+import { DrawerHandleButton } from './DrawerControls.style';
+import {
+  defaultDrawerWidth,
+  useEditToolsValues,
+  useEditToolsActions,
+} from '../../store';
+
+export const DrawerHandle = () => {
+  const [isDrawerResizing, setIsDrawerResizing] = useState(false);
+  const [drawResizeStartX, setDrawResizeStartX] = useState(0);
+
+  const { isDrawerOpen, visibleControls, codeDrawerWidth } =
+    useEditToolsValues();
+  const { setCodeDrawerWidth } = useEditToolsActions();
+
+  const drawerWidth =
+    visibleControls === 'code' ? codeDrawerWidth : defaultDrawerWidth;
+
+  const drawerHandleOnMouseDown: MouseEventHandler<HTMLButtonElement> = (e) => {
+    setIsDrawerResizing(true);
+    setDrawResizeStartX(e.clientX);
+  };
+
+  const drawerHandleOnMouseUp = () => {
+    setIsDrawerResizing(false);
+    setDrawResizeStartX(0);
+  };
+
+  useEffect(() => {
+    const handleMousemove = (e: MouseEvent) => {
+      if (!isDrawerResizing) {
+        return;
+      }
+
+      const newDrawerWidth = drawResizeStartX + (e.clientX - drawResizeStartX);
+      if (newDrawerWidth >= defaultDrawerWidth) {
+        setCodeDrawerWidth(drawResizeStartX + (e.clientX - drawResizeStartX));
+      }
+    };
+    document.addEventListener('mousemove', handleMousemove);
+    document.addEventListener('mouseup', drawerHandleOnMouseUp);
+    return () => {
+      document.removeEventListener('mousemove', handleMousemove);
+      document.removeEventListener('mouseup', drawerHandleOnMouseUp);
+    };
+  }, [isDrawerResizing, drawResizeStartX, setCodeDrawerWidth]);
+
+  return visibleControls === 'code' && isDrawerOpen ? (
+    <DrawerHandleButton
+      drawerWidth={drawerWidth}
+      onMouseDown={drawerHandleOnMouseDown}
+    />
+  ) : null;
+};

--- a/packages/widget-playground/src/components/DrawerControls/FontEmbedPrompt.tsx
+++ b/packages/widget-playground/src/components/DrawerControls/FontEmbedPrompt.tsx
@@ -1,0 +1,27 @@
+import InfoIcon from '@mui/icons-material/Info';
+import { Card } from '../Card';
+import { Alert } from './DesignControls';
+
+export const FontEmbedPrompt = () => {
+  const googleFontEmbedMessage = 'You need to embed the font';
+
+  return (
+    <Card
+      sx={{
+        paddingX: 2,
+        paddingY: 0.5,
+      }}
+    >
+      <Alert
+        icon={<InfoIcon fontSize="inherit" />}
+        severity="info"
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+        }}
+      >
+        {googleFontEmbedMessage}
+      </Alert>
+    </Card>
+  );
+};

--- a/packages/widget-playground/src/components/DrawerControls/createCodesandbox.ts
+++ b/packages/widget-playground/src/components/DrawerControls/createCodesandbox.ts
@@ -1,0 +1,31 @@
+import { files } from './react-files';
+export async function createCodesandbox() {
+  return fetch('https://codesandbox.io/api/v1/sandboxes/define?json=1', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    },
+    body: JSON.stringify({
+      files,
+    }),
+  })
+    .then((x) => x.json())
+    .then((data) => generateIframeData(data.sandbox_id));
+}
+
+function generateIframeData(sandbox_id: string) {
+  const url = `https://codesandbox.io/embed/${sandbox_id}?fontsize=14&file=%2Fconfig.ts`;
+  return {
+    src: url,
+    style: {
+      width: '100%',
+      height: '100%',
+      border: 0,
+      borderRadius: '4px',
+      overflow: 'hidden',
+    },
+    sandbox:
+      'allow-modals allow-forms allow-popups allow-scripts allow-same-origin',
+  };
+}

--- a/packages/widget-playground/src/components/DrawerControls/react-files.ts
+++ b/packages/widget-playground/src/components/DrawerControls/react-files.ts
@@ -1,0 +1,43 @@
+export const files = {
+  'package.json': {
+    content: {
+      name: 'simple-widget-react',
+      dependencies: {
+        '@lifi/widget': '^3.0.0-alpha.31',
+        '@tanstack/react-query': '^5.17.0',
+        react: '^18.2.0',
+        'react-dom': '^18.2.0',
+        wagmi: '2.5.7',
+      },
+      devDependencies: {
+        '@types/react': '^18.2.56',
+        '@types/react-dom': '^18.2.19',
+        typescript: '^5.2.2',
+      },
+    },
+  },
+  'tsconfig.node.json': {
+    content:
+      '{\n  "compilerOptions": {\n    "composite": true,\n    "skipLibCheck": true,\n    "module": "ESNext",\n    "moduleResolution": "bundler",\n    "allowSyntheticDefaultImports": true,\n    "strict": true\n  },\n  "include": ["vite.config.ts"]\n}\n',
+  },
+  'tsconfig.json': {
+    content:
+      '{\n  "compilerOptions": {\n    "target": "ES2020",\n    "useDefineForClassFields": true,\n    "lib": ["ES2020", "DOM", "DOM.Iterable"],\n    "module": "ESNext",\n    "skipLibCheck": true,\n\n    /* Bundler mode */\n    "moduleResolution": "bundler",\n    "allowImportingTsExtensions": true,\n    "resolveJsonModule": true,\n    "isolatedModules": true,\n    "noEmit": true,\n    "jsx": "react-jsx",\n\n    /* Linting */\n    "strict": true,\n    "noUnusedLocals": true,\n    "noUnusedParameters": true,\n    "noFallthroughCasesInSwitch": true\n  },\n  "include": ["src"],\n  "references": [{ "path": "./tsconfig.node.json" }]\n}\n',
+  },
+  'index.html': {
+    content:
+      '<!doctype html>\n<html lang="en">\n  <head>\n    <meta charset="UTF-8" />\n    <meta name="viewport" content="width=device-width, initial-scale=1.0" />\n    <title>Widget Example</title>\n  </head>\n  <body>\n    <div id="root"></div>\n  </body>\n</html>\n',
+  },
+  'index.tsx': {
+    content:
+      "import React from 'react';\nimport ReactDOM from 'react-dom/client';\nimport './index.css';\nimport { LiFiWidget } from '@lifi/widget';\nimport { config } from './config.ts';\n\nReactDOM.createRoot(document.getElementById('root')!).render(\n  <React.StrictMode>\n    <LiFiWidget config={config} integrator=\"li.fi-playground\" open />\n  </React.StrictMode>,\n);\n",
+  },
+  'index.css': {
+    content:
+      ':root {\n  font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;\n  line-height: 1.5;\n  font-weight: 400;\n\n  color-scheme: light dark;\n  color: rgba(255, 255, 255, 0.87);\n  background-color: #242424;\n\n  font-synthesis: none;\n  text-rendering: optimizeLegibility;\n  -webkit-font-smoothing: antialiased;\n  -moz-osx-font-smoothing: grayscale;\n}\n\n#root {\n    max-width: 1280px;\n    margin: 0 auto;\n    padding: 2rem;\n    text-align: center;\n}\n\nbody {\n  margin: 0;\n  display: flex;\n  place-items: center;\n  min-width: 320px;\n  min-height: 100vh;\n}\n',
+  },
+  'config.ts': {
+    content:
+      "import { WidgetConfig } from '@lifi/widget';\n\nexport const config = {\n  variant: 'expandable',\n  integrator: 'li.fi-playground',\n  buildUrl: true,\n  insurance: true,\n  sdkConfig: {\n    apiUrl: 'https://li.quest/v1',\n    rpcUrls: {\n      1151111081099710: [\n        'https://withered-lingering-frog.solana-mainnet.quiknode.pro/',\n      ],\n    },\n    routeOptions: {\n      maxPriceImpact: 0.4,\n    },\n  },\n  tokens: {\n    featured: [\n      {\n        address: '0x0000000000000000000000000000000000000000',\n        symbol: 'BNB',\n        decimals: 18,\n        chainId: 56,\n        name: 'BNB',\n        logoURI:\n          'https://bscscan.com/assets/bsc/images/svg/logos/token-light.svg',\n      },\n      {\n        address: '0x195e3087ea4d7eec6e9c37e9640162fe32433d5e',\n        symbol: '$ALTI',\n        decimals: 18,\n        chainId: 56,\n        name: 'Altimatum',\n        logoURI:\n          'https://s2.coinmarketcap.com/static/img/coins/64x64/21303.png',\n      },\n      {\n        address: '0x2fd6c9b869dea106730269e13113361b684f843a',\n        symbol: 'CHH',\n        decimals: 9,\n        chainId: 56,\n        name: 'Chihuahua',\n        logoURI:\n          'https://s2.coinmarketcap.com/static/img/coins/64x64/21334.png',\n      },\n    ],\n    popular: [\n      {\n        address: '0x0000000000000000000000000000000000000000',\n        symbol: 'BNB',\n        decimals: 18,\n        chainId: 56,\n        name: 'BNB',\n        logoURI:\n          'https://bscscan.com/assets/bsc/images/svg/logos/token-light.svg',\n      },\n      {\n        address: '0xCC42724C6683B7E57334c4E856f4c9965ED682bD',\n        symbol: 'MATIC',\n        decimals: 18,\n        chainId: 56,\n        name: 'Matic',\n        logoURI: 'https://bscscan.com/token/images/polygonmatic_new_32.png',\n      },\n      {\n        address: '0x947950BcC74888a40Ffa2593C5798F11Fc9124C4',\n        symbol: 'SUSHI',\n        decimals: 18,\n        chainId: 56,\n        name: 'Sushi',\n      },\n      {\n        address: '0x1AF3F329e8BE154074D8769D1FFa4eE058B1DBc3',\n        symbol: 'DAI',\n        decimals: 18,\n        chainId: 56,\n        name: 'DAI',\n        logoURI: 'https://bscscan.com/token/images/dai_32.png',\n      },\n      {\n        address: '0x2170Ed0880ac9A755fd29B2688956BD959F933F8',\n        symbol: 'WETH',\n        decimals: 18,\n        chainId: 56,\n        name: 'Wrapped ETH',\n        logoURI: 'https://bscscan.com/token/images/ethereum_32.png',\n      },\n      {\n        address: '0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c',\n        symbol: 'WBNB',\n        decimals: 18,\n        chainId: 56,\n        name: 'Wrapped BNB',\n        logoURI:\n          'https://bscscan.com/assets/bsc/images/svg/logos/token-light.svg',\n      },\n    ],\n    deny: [],\n    allow: [],\n  },\n  appearance: 'auto',\n  theme: {\n    palette: {\n      primary: {\n        main: '#5C67FF',\n      },\n      secondary: {\n        main: '#F5B5FF',\n      },\n    },\n    typography: {\n      fontFamily: 'Inter, sans-serif',\n    },\n  },\n  containerStyle: {\n    boxShadow: '0px 8px 32px rgba(0, 0, 0, 0.08)',\n    borderRadius: '16px',\n  },\n} as WidgetConfig;\n",
+  },
+};

--- a/packages/widget-playground/src/components/Widget/WidgetView.style.tsx
+++ b/packages/widget-playground/src/components/Widget/WidgetView.style.tsx
@@ -7,7 +7,7 @@ import {
 } from '@mui/material';
 import { buttonClasses } from '@mui/material/Button';
 import { alpha, styled } from '@mui/material/styles';
-import { drawerWidth, drawerZIndex } from '../DrawerControls';
+import { drawerZIndex } from '../DrawerControls';
 
 export const FloatingToolsContainer = styled(Box)(({ theme }) => ({
   display: 'flex',
@@ -61,10 +61,12 @@ export const ConnectionWalletButtonBase = styled(Button)(({ theme }) => ({
 }));
 
 export const Main = styled('main', {
-  shouldForwardProp: (prop) => prop !== 'open',
+  shouldForwardProp: (prop) =>
+    !['drawerWidth', 'open'].includes(prop as string),
 })<{
+  drawerWidth: number;
   open?: boolean;
-}>(({ theme, open }) => ({
+}>(({ theme, open, drawerWidth }) => ({
   display: 'flex',
   justifyContent: 'stretch',
   position: 'relative',

--- a/packages/widget-playground/src/components/Widget/WidgetView.tsx
+++ b/packages/widget-playground/src/components/Widget/WidgetView.tsx
@@ -17,6 +17,7 @@ export function WidgetView() {
       <LiFiWidget
         config={config}
         ref={drawerRef}
+        keyPrefix="c4443ab1e73b0457e3c9959cc5ca516e"
         integrator="li.fi-playground"
         open
       />

--- a/packages/widget-playground/src/components/Widget/WidgetViewContainer.tsx
+++ b/packages/widget-playground/src/components/Widget/WidgetViewContainer.tsx
@@ -4,6 +4,7 @@ import { ConnectButton } from '@rainbow-me/rainbowkit';
 import type { PropsWithChildren } from 'react';
 import { ExternalWalletProvider } from '../../providers';
 import {
+  defaultDrawerWidth,
   useConfig,
   useEditToolsActions,
   useEditToolsValues,
@@ -25,13 +26,16 @@ export function WidgetViewContainer({
   toggleDrawer,
 }: WidgetViewContainerProps) {
   const { config } = useConfig();
-  const { isDrawerOpen } = useEditToolsValues();
+  const { isDrawerOpen, codeDrawerWidth, visibleControls } =
+    useEditToolsValues();
   const { setDrawerOpen } = useEditToolsActions();
 
   const isWalletManagementExternal = !!config?.walletConfig;
+  const drawerWidth =
+    visibleControls === 'code' ? codeDrawerWidth : defaultDrawerWidth;
 
   return (
-    <Main open={isDrawerOpen}>
+    <Main open={isDrawerOpen} drawerWidth={drawerWidth}>
       <ExternalWalletProvider isExternalProvider={isWalletManagementExternal}>
         <FloatingToolsContainer>
           {!isDrawerOpen ? (

--- a/packages/widget-playground/src/store/editTools/constants.ts
+++ b/packages/widget-playground/src/store/editTools/constants.ts
@@ -1,0 +1,1 @@
+export const defaultDrawerWidth = 392;

--- a/packages/widget-playground/src/store/editTools/createEditToolsStore.ts
+++ b/packages/widget-playground/src/store/editTools/createEditToolsStore.ts
@@ -2,18 +2,47 @@ import type { StateCreator } from 'zustand';
 import { createWithEqualityFn } from 'zustand/traditional';
 import { persist } from 'zustand/middleware';
 import type { ToolsState } from './types';
+import { defaultDrawerWidth } from './constants';
 
 export const createEditToolsStore = () =>
   createWithEqualityFn<ToolsState>(
     persist(
-      (set) => ({
+      (set, get) => ({
         drawer: {
           open: true,
+          visibleControls: 'design',
+          codeDrawerWidth: defaultDrawerWidth,
         },
         setDrawerOpen: (open) => {
           set({
             drawer: {
+              ...get().drawer,
               open,
+            },
+          });
+        },
+        setCodeDrawerWidth: (codeDrawerWidth) => {
+          set({
+            drawer: {
+              ...get().drawer,
+              codeDrawerWidth,
+            },
+          });
+        },
+        setVisibleControls: (visibleControls) => {
+          set({
+            drawer: {
+              ...get().drawer,
+              visibleControls,
+            },
+          });
+        },
+        resetEditTools: () => {
+          set({
+            drawer: {
+              open: true,
+              visibleControls: 'design',
+              codeDrawerWidth: defaultDrawerWidth,
             },
           });
         },
@@ -24,6 +53,8 @@ export const createEditToolsStore = () =>
         partialize: (state) => ({
           drawer: {
             open: state.drawer.open,
+            codeDrawerWidth: state.drawer.codeDrawerWidth || defaultDrawerWidth,
+            visibleControls: state.drawer.visibleControls || 'design',
           },
         }),
       },

--- a/packages/widget-playground/src/store/editTools/index.ts
+++ b/packages/widget-playground/src/store/editTools/index.ts
@@ -1,3 +1,4 @@
 export * from './EditToolsProvider';
 export * from './useEditToolsValues';
 export * from './useEditToolsActions';
+export * from './constants';

--- a/packages/widget-playground/src/store/editTools/types.ts
+++ b/packages/widget-playground/src/store/editTools/types.ts
@@ -1,14 +1,20 @@
 import type { UseBoundStoreWithEqualityFn } from 'zustand/traditional';
 import type { StoreApi } from 'zustand';
 
+type ControlType = 'design' | 'code';
 export interface EditToolsValues {
   drawer: {
     open: boolean;
+    visibleControls: ControlType;
+    codeDrawerWidth: number;
   };
 }
 
 export interface EditToolsActions {
   setDrawerOpen: (open: boolean) => void;
+  setCodeDrawerWidth: (width: number) => void;
+  setVisibleControls: (controls: ControlType) => void;
+  resetEditTools: () => void;
 }
 
 export type ToolsState = EditToolsValues & EditToolsActions;

--- a/packages/widget-playground/src/store/editTools/useEditToolsActions.ts
+++ b/packages/widget-playground/src/store/editTools/useEditToolsActions.ts
@@ -5,6 +5,9 @@ export const useEditToolsActions = () => {
   const actions = useEditToolsStore(
     (state) => ({
       setDrawerOpen: state.setDrawerOpen,
+      setCodeDrawerWidth: state.setCodeDrawerWidth,
+      setVisibleControls: state.setVisibleControls,
+      resetEditTools: state.resetEditTools,
     }),
     shallow,
   );

--- a/packages/widget-playground/src/store/editTools/useEditToolsValues.ts
+++ b/packages/widget-playground/src/store/editTools/useEditToolsValues.ts
@@ -2,9 +2,18 @@ import { shallow } from 'zustand/shallow';
 import { useEditToolsStore } from './EditToolsProvider';
 
 export const useEditToolsValues = () => {
-  const [open] = useEditToolsStore((store) => [store.drawer?.open], shallow);
+  const [isDrawerOpen, codeDrawerWidth, visibleControls] = useEditToolsStore(
+    (store) => [
+      store.drawer.open,
+      store.drawer.codeDrawerWidth,
+      store.drawer.visibleControls,
+    ],
+    shallow,
+  );
 
   return {
-    isDrawerOpen: open,
+    isDrawerOpen,
+    codeDrawerWidth,
+    visibleControls,
   };
 };


### PR DESCRIPTION
Putting this spike up to share what I found.

This initially looked really promising, the ability to spin up an embedded CodeSandbox dynamically which would allow use drop the edited config into a working example.

Unfortunately it doesn't work for use with the widget from what I can tell. I initially hoped that I would be able to spin up a full Vite implementation using it. But it looks like the dynamic playgrounds are using create-react-app under the hood and I was getting . I then tried to just spin up a simple project from there example - a Typescript React "Hello world" example works fine but trying to introduce the Widget results in Babel errors like the one below. 

I've also put this into a playground to share with CodeSandbox as well - [Example here](https://codesandbox.io/p/sandbox/dynamically-create-codesandbox-forked-xnjrfy?file=%2Fsrc%2FcreateCodesandbox.ts%3A41%2C37)

![Screenshot 2024-03-01 at 19 18 42](https://github.com/lifinance/widget/assets/7836726/f35361b3-d49c-4ed4-ac9d-8d9189afd57c)
