### PR TITLE
feat: changes to code section resizing

### DIFF
--- a/packages/widget-playground/src/components/DrawerControls/DrawerControls.style.tsx
+++ b/packages/widget-playground/src/components/DrawerControls/DrawerControls.style.tsx
@@ -9,6 +9,8 @@ import {
   IconButton,
   styled,
 } from '@mui/material';
+import KeyboardArrowRightIcon from '@mui/icons-material/KeyboardArrowRight';
+import KeyboardArrowLeftIcon from '@mui/icons-material/KeyboardArrowLeft';
 import TabPanel from '@mui/lab/TabPanel';
 export const drawerZIndex = 1501;
 export const autocompletePopperZIndex = drawerZIndex + 1;
@@ -40,10 +42,12 @@ export const HeaderRow = styled(Box)({
 });
 
 export const DrawerContentContainer = styled(Box, {
-  shouldForwardProp: (prop) => !['drawerWidth'].includes(prop as string),
+  shouldForwardProp: (prop) =>
+    !['drawerWidth', 'resizeableIndicator'].includes(prop as string),
 })<{
   drawerWidth: number;
-}>(({ theme, drawerWidth }) => ({
+  resizeableIndicator?: boolean;
+}>(({ theme, drawerWidth, resizeableIndicator }) => ({
   display: 'flex',
   width: drawerWidth,
   padding: theme.spacing(3),
@@ -51,6 +55,17 @@ export const DrawerContentContainer = styled(Box, {
   flexGrow: 1,
   gap: theme.spacing(2),
   zIndex: 1200,
+  ...(resizeableIndicator
+    ? {
+        borderRightStyle: 'solid',
+        borderRightWidth: theme.spacing(0.5),
+        borderRightColor:
+          theme.palette.mode === 'light'
+            ? theme.palette.grey[400]
+            : theme.palette.grey[500],
+        paddingRight: theme.spacing(2.5),
+      }
+    : {}),
 }));
 
 export const TabContentContainer = styled(TabPanel)(({ theme }) => ({
@@ -62,47 +77,6 @@ export const TabContentContainer = styled(TabPanel)(({ theme }) => ({
   '&[hidden]': {
     display: 'none',
   },
-}));
-
-export const CodeContainer = styled(Box)(({ theme }) => ({
-  position: 'relative',
-  marginTop: theme.spacing(1),
-  display: 'flex',
-  flexDirection: 'column',
-  flexGrow: 1,
-}));
-
-export const CodeCopyButton = styled(IconButton)(({ theme }) => ({
-  position: 'absolute',
-  right: theme.spacing(2),
-  top: theme.spacing(0.5),
-  background:
-    theme.palette.mode === 'light'
-      ? theme.palette.grey[200]
-      : theme.palette.grey[800],
-  '&:hover': {
-    background:
-      theme.palette.mode === 'light'
-        ? theme.palette.grey[300]
-        : theme.palette.grey[700],
-  },
-  zIndex: tooltipPopperZIndex,
-}));
-
-export const Pre = styled('pre')(({ theme }) => ({
-  backgroundColor:
-    theme.palette.mode === 'light'
-      ? theme.palette.grey[200]
-      : theme.palette.grey[800],
-  margin: 0,
-  padding: theme.spacing(1),
-  borderRadius: theme.shape.borderRadius - 4,
-  overflowX: 'scroll',
-}));
-
-export const Code = styled('code')(({ theme }) => ({
-  fontFamily: 'Courier, monospace',
-  fontSize: '0.8em',
 }));
 
 export const DrawerHandleButton = styled((props: ButtonBaseProps) => (
@@ -121,3 +95,27 @@ export const DrawerHandleButton = styled((props: ButtonBaseProps) => (
   transform: 'translateX(-8px)',
   zIndex: drawerZIndex + 1,
 });
+
+export const DrawerIconRight = styled(KeyboardArrowRightIcon)(({ theme }) => ({
+  color:
+    theme.palette.mode === 'light'
+      ? theme.palette.grey[500]
+      : theme.palette.grey[600],
+  position: 'fixed',
+  top: '50%',
+  transform: 'translateY(-50%)',
+  pointerEvents: 'none',
+  zIndex: drawerZIndex + 1,
+}));
+
+export const DrawerIconLeft = styled(KeyboardArrowLeftIcon)(({ theme }) => ({
+  color:
+    theme.palette.mode === 'light'
+      ? theme.palette.grey[500]
+      : theme.palette.grey[600],
+  position: 'fixed',
+  top: '50%',
+  transform: 'translate(-100%, -50%)',
+  pointerEvents: 'none',
+  zIndex: drawerZIndex + 1,
+}));

--- a/packages/widget-playground/src/components/DrawerControls/DrawerControls.style.tsx
+++ b/packages/widget-playground/src/components/DrawerControls/DrawerControls.style.tsx
@@ -2,13 +2,7 @@ import type {
   ButtonBaseProps,
   DrawerProps as MuiDrawerProps,
 } from '@mui/material';
-import {
-  Box,
-  ButtonBase,
-  Drawer as MuiDrawer,
-  IconButton,
-  styled,
-} from '@mui/material';
+import { Box, ButtonBase, Drawer as MuiDrawer, styled } from '@mui/material';
 import KeyboardArrowRightIcon from '@mui/icons-material/KeyboardArrowRight';
 import KeyboardArrowLeftIcon from '@mui/icons-material/KeyboardArrowLeft';
 import TabPanel from '@mui/lab/TabPanel';

--- a/packages/widget-playground/src/components/DrawerControls/DrawerControls.style.tsx
+++ b/packages/widget-playground/src/components/DrawerControls/DrawerControls.style.tsx
@@ -62,7 +62,7 @@ export const DrawerContentContainer = styled(Box, {
         borderRightColor:
           theme.palette.mode === 'light'
             ? theme.palette.grey[400]
-            : theme.palette.grey[500],
+            : theme.palette.grey[600],
         paddingRight: theme.spacing(2.5),
       }
     : {}),
@@ -99,7 +99,7 @@ export const DrawerHandleButton = styled((props: ButtonBaseProps) => (
 export const DrawerIconRight = styled(KeyboardArrowRightIcon)(({ theme }) => ({
   color:
     theme.palette.mode === 'light'
-      ? theme.palette.grey[500]
+      ? theme.palette.grey[400]
       : theme.palette.grey[600],
   position: 'fixed',
   top: '50%',
@@ -111,7 +111,7 @@ export const DrawerIconRight = styled(KeyboardArrowRightIcon)(({ theme }) => ({
 export const DrawerIconLeft = styled(KeyboardArrowLeftIcon)(({ theme }) => ({
   color:
     theme.palette.mode === 'light'
-      ? theme.palette.grey[500]
+      ? theme.palette.grey[400]
       : theme.palette.grey[600],
   position: 'fixed',
   top: '50%',

--- a/packages/widget-playground/src/components/DrawerControls/DrawerControls.style.tsx
+++ b/packages/widget-playground/src/components/DrawerControls/DrawerControls.style.tsx
@@ -42,12 +42,10 @@ export const HeaderRow = styled(Box)({
 });
 
 export const DrawerContentContainer = styled(Box, {
-  shouldForwardProp: (prop) =>
-    !['drawerWidth', 'resizeableIndicator'].includes(prop as string),
+  shouldForwardProp: (prop) => !['drawerWidth'].includes(prop as string),
 })<{
   drawerWidth: number;
-  resizeableIndicator?: boolean;
-}>(({ theme, drawerWidth, resizeableIndicator }) => ({
+}>(({ theme, drawerWidth }) => ({
   display: 'flex',
   width: drawerWidth,
   padding: theme.spacing(3),
@@ -55,17 +53,6 @@ export const DrawerContentContainer = styled(Box, {
   flexGrow: 1,
   gap: theme.spacing(2),
   zIndex: 1200,
-  ...(resizeableIndicator
-    ? {
-        borderRightStyle: 'solid',
-        borderRightWidth: theme.spacing(0.5),
-        borderRightColor:
-          theme.palette.mode === 'light'
-            ? theme.palette.grey[400]
-            : theme.palette.grey[600],
-        paddingRight: theme.spacing(2.5),
-      }
-    : {}),
 }));
 
 export const TabContentContainer = styled(TabPanel)(({ theme }) => ({
@@ -115,7 +102,7 @@ export const DrawerIconLeft = styled(KeyboardArrowLeftIcon)(({ theme }) => ({
       : theme.palette.grey[600],
   position: 'fixed',
   top: '50%',
-  transform: 'translate(-100%, -50%)',
+  transform: 'translate(-75%, -50%)',
   pointerEvents: 'none',
   zIndex: drawerZIndex + 1,
 }));

--- a/packages/widget-playground/src/components/DrawerControls/DrawerControls.tsx
+++ b/packages/widget-playground/src/components/DrawerControls/DrawerControls.tsx
@@ -42,9 +42,6 @@ export const DrawerControls = () => {
 
   useFontInitialisation();
 
-  const showResizeIndicator =
-    visibleControls === 'code' && codeControlTab === 'config';
-
   const handleReset = () => {
     resetConfig();
   };
@@ -58,10 +55,7 @@ export const DrawerControls = () => {
         open={isDrawerOpen}
         drawerWidth={drawerWidth}
       >
-        <DrawerContentContainer
-          drawerWidth={drawerWidth}
-          resizeableIndicator={showResizeIndicator}
-        >
+        <DrawerContentContainer drawerWidth={drawerWidth}>
           <HeaderRow>
             <Header>LI.FI Widget</Header>
             <Box>

--- a/packages/widget-playground/src/components/DrawerControls/DrawerControls.tsx
+++ b/packages/widget-playground/src/components/DrawerControls/DrawerControls.tsx
@@ -8,6 +8,7 @@ import {
   useConfigActions,
   useEditToolsActions,
   useDrawerToolValues,
+  useCodeToolValues,
 } from '../../store';
 import { ExpandableCardAccordion } from '../Card';
 import { Tab, Tabs } from '../Tabs';
@@ -35,10 +36,14 @@ import { useFontInitialisation } from '../../providers';
 
 export const DrawerControls = () => {
   const { isDrawerOpen, drawerWidth, visibleControls } = useDrawerToolValues();
+  const { codeControlTab } = useCodeToolValues();
   const { setDrawerOpen, setVisibleControls } = useEditToolsActions();
   const { resetConfig } = useConfigActions();
 
   useFontInitialisation();
+
+  const showResizeIndicator =
+    visibleControls === 'code' && codeControlTab === 'config';
 
   const handleReset = () => {
     resetConfig();
@@ -53,7 +58,10 @@ export const DrawerControls = () => {
         open={isDrawerOpen}
         drawerWidth={drawerWidth}
       >
-        <DrawerContentContainer drawerWidth={drawerWidth}>
+        <DrawerContentContainer
+          drawerWidth={drawerWidth}
+          resizeableIndicator={showResizeIndicator}
+        >
           <HeaderRow>
             <Header>LI.FI Widget</Header>
             <Box>

--- a/packages/widget-playground/src/components/DrawerControls/DrawerHandle.tsx
+++ b/packages/widget-playground/src/components/DrawerControls/DrawerHandle.tsx
@@ -6,7 +6,11 @@ import {
   useDrawerToolValues,
   useEditToolsActions,
 } from '../../store';
-import { DrawerHandleButton } from './DrawerControls.style';
+import {
+  DrawerHandleButton,
+  DrawerIconLeft,
+  DrawerIconRight,
+} from './DrawerControls.style';
 
 export const DrawerHandle = () => {
   const [isDrawerResizing, setIsDrawerResizing] = useState(false);
@@ -50,12 +54,26 @@ export const DrawerHandle = () => {
   return visibleControls === 'code' &&
     codeControlTab === 'config' &&
     isDrawerOpen ? (
-    <DrawerHandleButton
-      onMouseDown={drawerHandleOnMouseDown}
-      sx={{
-        width: isDrawerResizing ? 400 : 16,
-        left: isDrawerResizing ? drawerWidth - 200 : drawerWidth,
-      }}
-    />
+    <>
+      <DrawerHandleButton
+        onMouseDown={drawerHandleOnMouseDown}
+        sx={{
+          width: isDrawerResizing ? 400 : 16,
+          left: isDrawerResizing ? drawerWidth - 200 : drawerWidth,
+        }}
+      />
+      <DrawerIconRight
+        fontSize="small"
+        sx={{
+          left: drawerWidth - 4,
+        }}
+      />
+      <DrawerIconLeft
+        fontSize="small"
+        sx={{
+          left: drawerWidth,
+        }}
+      />
+    </>
   ) : null;
 };

--- a/packages/widget-playground/src/components/DrawerControls/DrawerHandle.tsx
+++ b/packages/widget-playground/src/components/DrawerControls/DrawerHandle.tsx
@@ -68,12 +68,14 @@ export const DrawerHandle = () => {
           left: drawerWidth - 4,
         }}
       />
-      <DrawerIconLeft
-        fontSize="small"
-        sx={{
-          left: drawerWidth,
-        }}
-      />
+      {drawerWidth !== defaultDrawerWidth ? (
+        <DrawerIconLeft
+          fontSize="small"
+          sx={{
+            left: drawerWidth,
+          }}
+        />
+      ) : null}
     </>
   ) : null;
 };

--- a/packages/widget-playground/src/store/editTools/createEditToolsStore.ts
+++ b/packages/widget-playground/src/store/editTools/createEditToolsStore.ts
@@ -42,6 +42,10 @@ export const createEditToolsStore = () =>
               visibleControls,
             },
           });
+
+          if (visibleControls !== 'code') {
+            get().setCodeDrawerWidth(defaultDrawerWidth);
+          }
         },
         setCodeControlTab: (openTab) => {
           set({
@@ -50,6 +54,10 @@ export const createEditToolsStore = () =>
               openTab,
             },
           });
+
+          if (openTab !== 'config') {
+            get().setCodeDrawerWidth(defaultDrawerWidth);
+          }
         },
         resetEditTools: () => {
           set({
@@ -73,11 +81,11 @@ export const createEditToolsStore = () =>
       }),
       {
         name: `'li.fi-playground-tools`,
-        version: 0,
+        version: 1,
         partialize: (state) => ({
           drawer: {
+            ...state.drawer,
             open: state.drawer.open,
-            codeDrawerWidth: state.drawer.codeDrawerWidth || defaultDrawerWidth,
             visibleControls: state.drawer.visibleControls || 'design',
           },
         }),


### PR DESCRIPTION
This PR is to ensure that the config section of the code section returns to the default size when a user navigates to other sections of the playground.

I've also added in an visual indicator to emphasize that the config section can be resized.

![light-resize-config](https://github.com/lifinance/widget/assets/7836726/0de7c7bb-360d-4da7-b851-954baad2c24a)


![dark-resize-config](https://github.com/lifinance/widget/assets/7836726/2e4d6b5d-6a53-4ae2-87f0-aada2262f766)
