### PR TITLE
Fix portuguese translation file name

### DIFF
--- a/packages/widget/src/i18n/pt.json
+++ b/packages/widget/src/i18n/pt.json
@@ -1,6 +1,6 @@
 {
   "language": {
-    "name": "Inglês",
+    "name": "Português",
     "title": "Idioma"
   },
   "format": {


### PR DESCRIPTION
The Portuguese language is listed as "Inglês" which means "English" in Portuguese. 

The person who created the translation file ended up getting confused and didn't change the word to Portuguese; instead, they translated the word "English" to Portuguese.

This PR fixes that by changing the value to "Português", which is "Portuguese" in Portuguese.