### PR TITLE
feat: improve chain selection

### DIFF
--- a/packages/widget/src/components/ChainSelect/ChainSelect.tsx
+++ b/packages/widget/src/components/ChainSelect/ChainSelect.tsx
@@ -38,12 +38,18 @@ export const ChainSelect = ({ formType }: FormTypeProps) => {
     navigate(navigationRoutes[`${formType}Chain`]);
   };
 
-  const chainsToHide = (chains?.length ?? 0) - maxChainToOrder;
+  // We check if we can accommodate all the chains on the grid
+  // If there are more chains we slice the last one to show the number of hidden chains
+  const chainsToHide =
+    chains?.length === maxChainToOrder
+      ? 0
+      : (chains?.length ?? 0) - (maxChainToOrder - 1);
+  const sliceValue = chainsToHide > 0 ? -1 : maxChainToOrder;
 
   return (
     <ChainContainer>
       {isLoading
-        ? Array.from({ length: maxChainToOrder + 1 }).map((_, index) => (
+        ? Array.from({ length: maxChainToOrder }).map((_, index) => (
             <Skeleton
               key={index}
               variant="rectangular"
@@ -52,32 +58,34 @@ export const ChainSelect = ({ formType }: FormTypeProps) => {
               sx={{ borderRadius: 1 }}
             />
           ))
-        : getChains().map((chain: EVMChain) => (
-            <Tooltip
-              key={chain.id}
-              title={chain.name}
-              placement="top"
-              enterDelay={400}
-              enterNextDelay={100}
-              disableInteractive
-              arrow
-            >
-              <ChainCard
-                component="button"
-                onClick={() => setCurrentChain(chain.id)}
-                type={chainId === chain.id ? 'selected' : 'default'}
-                selectionColor="primary"
+        : getChains()
+            .slice(0, sliceValue)
+            .map((chain: EVMChain) => (
+              <Tooltip
+                key={chain.id}
+                title={chain.name}
+                placement="top"
+                enterDelay={400}
+                enterNextDelay={100}
+                disableInteractive
+                arrow
               >
-                <Avatar
-                  src={chain.logoURI}
-                  alt={chain.key}
-                  sx={{ width: 40, height: 40 }}
+                <ChainCard
+                  component="button"
+                  onClick={() => setCurrentChain(chain.id)}
+                  type={chainId === chain.id ? 'selected' : 'default'}
+                  selectionColor="primary"
                 >
-                  {chain.name[0]}
-                </Avatar>
-              </ChainCard>
-            </Tooltip>
-          ))}
+                  <Avatar
+                    src={chain.logoURI}
+                    alt={chain.key}
+                    sx={{ width: 40, height: 40 }}
+                  >
+                    {chain.name[0]}
+                  </Avatar>
+                </ChainCard>
+              </Tooltip>
+            ))}
       {chainsToHide > 0 ? (
         <ChainCard component="button" onClick={showAllChains}>
           <Box

--- a/packages/widget/src/stores/chains/ChainOrderStore.tsx
+++ b/packages/widget/src/stores/chains/ChainOrderStore.tsx
@@ -58,19 +58,6 @@ export function ChainOrderStoreProvider({
   );
 }
 
-export function useChainOrderStore<T>(
-  selector: (state: ChainOrderState) => T,
-  equalityFn?: (left: T, right: T) => boolean,
-): T {
-  const useStore = useContext(ChainOrderStoreContext);
-  if (!useStore) {
-    throw new Error(
-      `You forgot to wrap your component in <${ChainOrderStoreProvider.name}>.`,
-    );
-  }
-  return useStore(selector, equalityFn);
-}
-
 export function useChainOrderStoreContext() {
   const useStore = useContext(ChainOrderStoreContext);
   if (!useStore) {
@@ -79,4 +66,12 @@ export function useChainOrderStoreContext() {
     );
   }
   return useStore;
+}
+
+export function useChainOrderStore<T>(
+  selector: (state: ChainOrderState) => T,
+  equalityFn?: (left: T, right: T) => boolean,
+): T {
+  const useStore = useChainOrderStoreContext();
+  return useStore(selector, equalityFn);
 }

--- a/packages/widget/src/stores/chains/createChainOrderStore.ts
+++ b/packages/widget/src/stores/chains/createChainOrderStore.ts
@@ -4,7 +4,7 @@ import { createWithEqualityFn } from 'zustand/traditional';
 import type { PersistStoreProps } from '../types.js';
 import type { ChainOrderState } from './types.js';
 
-export const maxChainToOrder = 9;
+export const maxChainToOrder = 10;
 const defaultChainState = {
   from: [],
   to: [],

--- a/packages/widget/src/stores/form/FormStore.tsx
+++ b/packages/widget/src/stores/form/FormStore.tsx
@@ -56,7 +56,8 @@ export const FormStoreProvider: React.FC<PropsWithChildren> = ({
 
   return (
     <FormStoreContext.Provider value={storeRef.current}>
-      <FormUpdater defaultValues={defaultValues}>{children}</FormUpdater>
+      {children}
+      <FormUpdater defaultValues={defaultValues} />
     </FormStoreContext.Provider>
   );
 };

--- a/packages/widget/src/stores/form/FormUpdater.tsx
+++ b/packages/widget/src/stores/form/FormUpdater.tsx
@@ -1,19 +1,17 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import type { PropsWithChildren } from 'react';
 import { useEffect, useRef } from 'react';
 import { useAccount } from '../../hooks/useAccount.js';
+import { useChains } from '../../hooks/useChains.js';
 import { useWidgetConfig } from '../../providers/WidgetProvider/WidgetProvider.js';
-import { isItemAllowed } from '../../utils/item.js';
 import type { DefaultValues, FormFieldNames } from './types.js';
 import { useFieldActions } from './useFieldActions.js';
 
-export const FormUpdater: React.FC<
-  PropsWithChildren<{
-    defaultValues: Partial<DefaultValues>;
-  }>
-> = ({ defaultValues, children }) => {
-  const { fromChain, toChain, chains } = useWidgetConfig();
+export const FormUpdater: React.FC<{
+  defaultValues: Partial<DefaultValues>;
+}> = ({ defaultValues }) => {
+  const { fromChain, toChain } = useWidgetConfig();
   const { account } = useAccount();
+  const { chains } = useChains();
   const { isTouched, resetField, setFieldValue, getFieldValues } =
     useFieldActions();
   const previousDefaultValues = useRef(defaultValues);
@@ -21,7 +19,7 @@ export const FormUpdater: React.FC<
   // Set wallet chain as default if no chains are provided by config and if they were not changed during widget usage
   useEffect(() => {
     const chainAllowed =
-      account.chainId && isItemAllowed(account.chainId, chains);
+      account.chainId && chains?.some((chain) => chain.id === account.chainId);
 
     if (!account.isConnected || !account.chainId || !chainAllowed) {
       return;
@@ -68,5 +66,5 @@ export const FormUpdater: React.FC<
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [defaultValues, getFieldValues, resetField, setFieldValue]);
 
-  return children;
+  return null;
 };

--- a/packages/widget/src/stores/header/useHeaderStore.tsx
+++ b/packages/widget/src/stores/header/useHeaderStore.tsx
@@ -20,16 +20,6 @@ export function HeaderStoreProvider({
   );
 }
 
-export function useHeaderStore<T>(selector: (state: HeaderState) => T): T {
-  const useStore = useContext(HeaderStoreContext);
-  if (!useStore) {
-    throw new Error(
-      `You forgot to wrap your component in <${HeaderStoreProvider.name}>.`,
-    );
-  }
-  return useStore(selector);
-}
-
 export function useHeaderStoreContext() {
   const useStore = useContext(HeaderStoreContext);
   if (!useStore) {
@@ -38,6 +28,11 @@ export function useHeaderStoreContext() {
     );
   }
   return useStore;
+}
+
+export function useHeaderStore<T>(selector: (state: HeaderState) => T): T {
+  const useStore = useHeaderStoreContext();
+  return useStore(selector);
 }
 
 export const createHeaderStore = ({ namePrefix }: PersistStoreProps) =>

--- a/packages/widget/src/stores/routes/RouteExecutionStore.tsx
+++ b/packages/widget/src/stores/routes/RouteExecutionStore.tsx
@@ -27,19 +27,6 @@ export function RouteExecutionStoreProvider({
   );
 }
 
-export function useRouteExecutionStore<T>(
-  selector: (state: RouteExecutionState) => T,
-  equalityFn?: (left: T, right: T) => boolean,
-): T {
-  const useStore = useContext(RouteExecutionStoreContext);
-  if (!useStore) {
-    throw new Error(
-      `You forgot to wrap your component in <${RouteExecutionStoreProvider.name}>.`,
-    );
-  }
-  return useStore(selector, equalityFn);
-}
-
 export function useRouteExecutionStoreContext() {
   const useStore = useContext(RouteExecutionStoreContext);
   if (!useStore) {
@@ -48,4 +35,12 @@ export function useRouteExecutionStoreContext() {
     );
   }
   return useStore;
+}
+
+export function useRouteExecutionStore<T>(
+  selector: (state: RouteExecutionState) => T,
+  equalityFn?: (left: T, right: T) => boolean,
+): T {
+  const useStore = useRouteExecutionStoreContext();
+  return useStore(selector, equalityFn);
 }

--- a/packages/widget/src/stores/settings/useSplitSubvariantStore.tsx
+++ b/packages/widget/src/stores/settings/useSplitSubvariantStore.tsx
@@ -33,18 +33,6 @@ export function SplitSubvariantStoreProvider({
   );
 }
 
-export function useSplitSubvariantStore<T>(
-  selector: (state: SplitSubvariantState) => T,
-): T {
-  const useStore = useContext(SplitSubvariantStoreContext);
-  if (!useStore) {
-    throw new Error(
-      `You forgot to wrap your component in <${SplitSubvariantStoreProvider.name}>.`,
-    );
-  }
-  return useStore(selector);
-}
-
 export function useSplitSubvariantStoreContext() {
   const useStore = useContext(SplitSubvariantStoreContext);
   if (!useStore) {
@@ -53,6 +41,13 @@ export function useSplitSubvariantStoreContext() {
     );
   }
   return useStore;
+}
+
+export function useSplitSubvariantStore<T>(
+  selector: (state: SplitSubvariantState) => T,
+): T {
+  const useStore = useSplitSubvariantStoreContext();
+  return useStore(selector);
 }
 
 export const createSplitSubvariantStore = ({ state }: SplitSubvariantProps) =>


### PR DESCRIPTION
We want to change the chain selection logic to elevate swap capabilities so when users select the source chain and token, we also pre-select the same chain on the destination for them. ([LF-7074](https://lifi.atlassian.net/browse/LF-7074))

Also fixes #218 