### PR TITLE
chore: add skeleton to the exports of the widget package

### DIFF
--- a/scripts/format-package-json.js
+++ b/scripts/format-package-json.js
@@ -30,6 +30,9 @@ export async function createPackageFile(packagePath, path) {
         default: './_esm/index.js',
       },
       './package.json': './package.json',
+      ...(packageDataOther.name === '@lifi/widget'
+        ? { './skeleton': './_esm/components/Skeleton/WidgetSkeleton.js' }
+        : {}),
     },
   };
 


### PR DESCRIPTION
Jira: [LF-7886](https://lifi.atlassian.net/browse/LF-7886)

This allows the WidgetSkeleton to be imported without all the imports from Widget being resolved, which currently can create issues in some envirionments.

Should be able to import WidgetSkeleton using

```
import { WidgetSkeleton } from '@lifi/widget/skeleton';
```

[LF-7886]: https://lifi.atlassian.net/browse/LF-7886?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ