### PR TITLE
fix: import for common js lib react-timer-hook

### DIFF
--- a/packages/widget/src/components/Step/StepTimer.tsx
+++ b/packages/widget/src/components/Step/StepTimer.tsx
@@ -1,8 +1,8 @@
 import type { LiFiStepExtended } from '@lifi/sdk';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import pkg from 'react-timer-hook';
-const { useTimer } = pkg;
+import * as reactTimerHook from 'react-timer-hook';
+const { useTimer } = reactTimerHook;
 
 const getExpiryTimestamp = (step: LiFiStepExtended) =>
   new Date(


### PR DESCRIPTION
The import for one of the common js libs we are using wasn't working properly. this is the fix

Have tested in the nextjs example and the vite widget playground