### PR TITLE
fix: widget header with subvariant split

### DIFF
--- a/packages/widget/src/components/AppContainer.tsx
+++ b/packages/widget/src/components/AppContainer.tsx
@@ -1,10 +1,7 @@
 import { Box, Container, ScopedCssBaseline, styled } from '@mui/material';
 import type { PropsWithChildren } from 'react';
-import {
-  maxHeaderHeight,
-  minHeaderHeight,
-} from '../components/Header/Header.js';
 import { defaultMaxHeight } from '../config/constants.js';
+import { useHeaderHeight } from '../hooks/useHeaderHeight.js';
 import { useWidgetConfig } from '../providers/WidgetProvider/WidgetProvider.js';
 import type { WidgetVariant } from '../types/widget.js';
 import { ElementId, createElementId } from '../utils/elements.js';
@@ -103,14 +100,10 @@ export const FlexContainer = styled(Container)(({ theme }) => ({
 
 export const AppContainer: React.FC<PropsWithChildren<{}>> = ({ children }) => {
   // const ref = useRef<HTMLDivElement>(null);
-  const { variant, elementId, hiddenUI, theme } = useWidgetConfig();
-
+  const { variant, elementId, theme } = useWidgetConfig();
+  const { headerHeight } = useHeaderHeight();
   const positionFixedAdjustment =
-    theme?.header?.position === 'fixed'
-      ? hiddenUI?.includes('walletMenu')
-        ? minHeaderHeight
-        : maxHeaderHeight
-      : 0;
+    theme?.header?.position === 'fixed' ? headerHeight : 0;
 
   return (
     <RelativeContainer

--- a/packages/widget/src/components/Header/Header.tsx
+++ b/packages/widget/src/components/Header/Header.tsx
@@ -2,26 +2,11 @@ import type { FC, PropsWithChildren } from 'react';
 import { useLocation } from 'react-router-dom';
 import { useDefaultElementId } from '../../hooks/useDefaultElementId.js';
 import { useHeaderHeight } from '../../hooks/useHeaderHeight.js';
-import type { WidgetSubvariant } from '../../types/widget.js';
 import { ElementId, createElementId } from '../../utils/elements.js';
 import { stickyHeaderRoutes } from '../../utils/navigationRoutes.js';
 import { Container } from './Header.style.js';
 import { NavigationHeader } from './NavigationHeader.js';
 import { WalletHeader } from './WalletHeader.js';
-
-export const minHeaderHeight = 64;
-export const maxHeaderHeight = 108;
-export const maxHeaderHeightSubvariantSplit = 136;
-
-export const getHeaderHeight = (
-  subvariant: WidgetSubvariant | undefined,
-  isWalletMenuHidden: boolean | undefined,
-) =>
-  subvariant === 'split'
-    ? maxHeaderHeightSubvariantSplit
-    : isWalletMenuHidden
-      ? minHeaderHeight
-      : maxHeaderHeight;
 
 export const HeaderContainer: FC<PropsWithChildren<{}>> = ({ children }) => {
   const { pathname } = useLocation();

--- a/packages/widget/src/components/Header/Header.tsx
+++ b/packages/widget/src/components/Header/Header.tsx
@@ -1,7 +1,8 @@
 import type { FC, PropsWithChildren } from 'react';
 import { useLocation } from 'react-router-dom';
 import { useDefaultElementId } from '../../hooks/useDefaultElementId.js';
-import { useWidgetConfig } from '../../providers/WidgetProvider/WidgetProvider.js';
+import { useHeaderHeight } from '../../hooks/useHeaderHeight.js';
+import type { WidgetSubvariant } from '../../types/widget.js';
 import { ElementId, createElementId } from '../../utils/elements.js';
 import { stickyHeaderRoutes } from '../../utils/navigationRoutes.js';
 import { Container } from './Header.style.js';
@@ -10,15 +11,22 @@ import { WalletHeader } from './WalletHeader.js';
 
 export const minHeaderHeight = 64;
 export const maxHeaderHeight = 108;
+export const maxHeaderHeightSubvariantSplit = 136;
+
+export const getHeaderHeight = (
+  subvariant: WidgetSubvariant | undefined,
+  isWalletMenuHidden: boolean | undefined,
+) =>
+  subvariant === 'split'
+    ? maxHeaderHeightSubvariantSplit
+    : isWalletMenuHidden
+      ? minHeaderHeight
+      : maxHeaderHeight;
 
 export const HeaderContainer: FC<PropsWithChildren<{}>> = ({ children }) => {
   const { pathname } = useLocation();
   const elementId = useDefaultElementId();
-  const { hiddenUI } = useWidgetConfig();
-
-  const headerHeight = hiddenUI?.includes('walletMenu')
-    ? minHeaderHeight
-    : maxHeaderHeight;
+  const { headerHeight } = useHeaderHeight();
 
   return (
     <Container

--- a/packages/widget/src/hooks/useHeaderHeight.ts
+++ b/packages/widget/src/hooks/useHeaderHeight.ts
@@ -1,0 +1,20 @@
+import { useWidgetConfig } from '../providers/WidgetProvider/WidgetProvider.js';
+
+export const minHeaderHeight = 64;
+export const maxHeaderHeight = 108;
+export const maxHeaderHeightSubvariantSplit = 136;
+
+export const useHeaderHeight = () => {
+  const { hiddenUI, subvariant } = useWidgetConfig();
+
+  const headerHeight =
+    subvariant === 'split'
+      ? maxHeaderHeightSubvariantSplit
+      : hiddenUI?.includes('walletMenu')
+        ? minHeaderHeight
+        : maxHeaderHeight;
+
+  return {
+    headerHeight,
+  };
+};


### PR DESCRIPTION
Jira: [LF-9991](https://lifi.atlassian.net/browse/LF-9991)

This should fix the display of the header for subvariant split in the widget

<img width="460" alt="image" src="https://github.com/user-attachments/assets/abad0c20-e033-4ff9-bf64-732de031bb49">

to

![Screenshot 2024-09-11 at 12 17 29](https://github.com/user-attachments/assets/e240884f-cc94-441a-a4d0-3505ba3e3709)


[LF-9991]: https://lifi.atlassian.net/browse/LF-9991?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ