### PR TITLE
chore: factor external wallet management into header height calculations

### DIFF
--- a/packages/widget/src/hooks/useHeaderHeight.ts
+++ b/packages/widget/src/hooks/useHeaderHeight.ts
@@ -1,3 +1,4 @@
+import { useHasExternalWalletProvider } from '../providers/WalletProvider/useHasExternalWalletProvider.js';
 import { useWidgetConfig } from '../providers/WidgetProvider/WidgetProvider.js';
 
 export const minHeaderHeight = 64;
@@ -6,11 +7,12 @@ export const maxHeaderHeightSubvariantSplit = 136;
 
 export const useHeaderHeight = () => {
   const { hiddenUI, subvariant } = useWidgetConfig();
+  const { hasExternalProvider } = useHasExternalWalletProvider();
 
   const headerHeight =
     subvariant === 'split'
       ? maxHeaderHeightSubvariantSplit
-      : hiddenUI?.includes('walletMenu')
+      : hiddenUI?.includes('walletMenu') || hasExternalProvider
         ? minHeaderHeight
         : maxHeaderHeight;
 


### PR DESCRIPTION
Jira: [LF-10098](https://lifi.atlassian.net/browse/LF-10098)

Uses the `useHasExternalWalletProvider` hook in the header height calculations