### PR TITLE
feat: emit settings updated widget event

### DIFF
--- a/packages/widget/src/components/PageEntered.ts
+++ b/packages/widget/src/components/PageEntered.ts
@@ -1,14 +1,60 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useLocation } from 'react-router-dom';
+import { shallow } from 'zustand/shallow';
 import { useWidgetEvents } from '../hooks/useWidgetEvents.js';
+import type { SettingsProps } from '../stores/settings/types.js';
+import { useSettingsStore } from '../stores/settings/useSettingsStore.js';
 import { WidgetEvent } from '../types/events.js';
+import { deepEqual } from '../utils/deepEquality.js';
 
 export function PageEntered() {
   const location = useLocation();
   const emitter = useWidgetEvents();
+  const lastLocation = useRef<string | undefined>();
+  const getSettingsState = useSettingsStore(
+    (state) => state.getSettingsState,
+    shallow,
+  );
+
+  const previousSettings = useRef<SettingsProps | undefined>();
 
   useEffect(() => {
+    const previousPathname = lastLocation.current;
+    const currentPathname = location.pathname;
+
     emitter.emit(WidgetEvent.PageEntered, location.pathname);
-  }, [emitter, location.pathname]);
+
+    if (
+      currentPathname === '/settings' &&
+      !previousPathname?.includes('/settings')
+    ) {
+      // this is the entry point to settings, setting can have subpages for bridges, exchanges and languages
+      // so we have to check that the user didn't come from a child page
+      // we capture the initialSettingState
+      previousSettings.current = getSettingsState();
+    } else if (
+      !currentPathname.includes('/settings') &&
+      previousPathname === '/settings'
+    ) {
+      // this is the exit point to settings, setting can have subpages for bridges, exchanges and languages
+      // so we have to check that the user didn't navigate to a child page
+      const currentSettings = getSettingsState();
+      if (
+        previousSettings.current &&
+        !deepEqual(previousSettings.current, currentSettings)
+      ) {
+        emitter.emit(WidgetEvent.SettingsUpdated, {
+          currentSettings: currentSettings,
+          previousSettings: previousSettings.current,
+        });
+        previousSettings.current = undefined;
+      }
+    }
+
+    return () => {
+      lastLocation.current = location.pathname;
+    };
+  }, [emitter, location.pathname, getSettingsState]);
+
   return null;
 }

--- a/packages/widget/src/components/PageEntered.ts
+++ b/packages/widget/src/components/PageEntered.ts
@@ -31,7 +31,8 @@ export function PageEntered() {
       isNotSettingsSubpage(previousPathname)
     ) {
       // The first if detects the user entering the settings page and captures the settings state
-      //   From this settings section the user can navigate from these subpages without meaningfully leaving the settings section
+      //   Note that the user can navigate to the settings page from the following subpages without meaningfully
+      //   leaving the settings section...
       //   - bridges - /settings/bridges
       //   - exchanges - /settings/exchanges
       //   - languages - /settings/languages
@@ -43,16 +44,15 @@ export function PageEntered() {
       isNotSettingsSubpage(currentPathname) &&
       previousPathname === '/settings'
     ) {
-      // The second if detects the user leaving the settings page and checks the settings state against the
-      // state captured when the user entered the settings, emitting a SettingsUpdated event if there has been
-      // any settings changed.
-      //   From this section the user can navigate to these subpages without leave the settings section
+      // The second if detects the user leaving the settings page and checks the current settings state against the
+      // state previously captured, emitting a SettingsUpdated event if there has been any settings changed.
+      //   From settings page the user can navigate to these subpages without meaningfully leave the settings section
       //   - bridges - /settings/bridges
       //   - exchanges - /settings/exchanges
       //   - languages - /settings/languages
       //   - select wallet pages - /select-wallet
       //   We check that the location the user navigated to is not one of these pages
-      //   in order ensure we emit the SettingsUpdated event at the point the user meaningfully leaves the Settings
+      //   in order to ensure we only emit the SettingsUpdated event at the point the user meaningfully leaves the Settings
       const currentSettings = getSettings();
       if (
         previousSettings.current &&

--- a/packages/widget/src/components/PageEntered.ts
+++ b/packages/widget/src/components/PageEntered.ts
@@ -1,22 +1,23 @@
+import microdiff from 'microdiff';
 import { useEffect, useRef } from 'react';
 import { useLocation } from 'react-router-dom';
 import { shallow } from 'zustand/shallow';
 import { useWidgetEvents } from '../hooks/useWidgetEvents.js';
-import type { SettingsProps } from '../stores/settings/types.js';
+import type { SettingsValues } from '../stores/settings/types.js';
 import { useSettingsStore } from '../stores/settings/useSettingsStore.js';
 import { WidgetEvent } from '../types/events.js';
 import { deepEqual } from '../utils/deepEquality.js';
+
+const isNotSettingsSubpage = (pathname?: string) =>
+  !pathname?.includes('/settings') && !pathname?.includes('/select-wallet');
 
 export function PageEntered() {
   const location = useLocation();
   const emitter = useWidgetEvents();
   const lastLocation = useRef<string | undefined>();
-  const getSettingsState = useSettingsStore(
-    (state) => state.getSettingsState,
-    shallow,
-  );
+  const getSettings = useSettingsStore((state) => state.getSettings, shallow);
 
-  const previousSettings = useRef<SettingsProps | undefined>();
+  const previousSettings = useRef<SettingsValues | undefined>();
 
   useEffect(() => {
     const previousPathname = lastLocation.current;
@@ -24,21 +25,35 @@ export function PageEntered() {
 
     emitter.emit(WidgetEvent.PageEntered, location.pathname);
 
+    // SettingsUpdated logic
     if (
       currentPathname === '/settings' &&
-      !previousPathname?.includes('/settings')
+      isNotSettingsSubpage(previousPathname)
     ) {
-      // this is the entry point to settings, setting can have subpages for bridges, exchanges and languages
-      // so we have to check that the user didn't come from a child page
-      // we capture the initialSettingState
-      previousSettings.current = getSettingsState();
+      // The first if detects the user entering the settings page and captures the settings state
+      //   From this settings section the user can navigate from these subpages without meaningfully leaving the settings section
+      //   - bridges - /settings/bridges
+      //   - exchanges - /settings/exchanges
+      //   - languages - /settings/languages
+      //   - select wallet pages - /select-wallet
+      //   We check that the location the user came from is not one of these pages
+      //   in order to avoid re-capturing the settings state again
+      previousSettings.current = getSettings();
     } else if (
-      !currentPathname.includes('/settings') &&
+      isNotSettingsSubpage(currentPathname) &&
       previousPathname === '/settings'
     ) {
-      // this is the exit point to settings, setting can have subpages for bridges, exchanges and languages
-      // so we have to check that the user didn't navigate to a child page
-      const currentSettings = getSettingsState();
+      // The second if detects the user leaving the settings page and checks the settings state against the
+      // state captured when the user entered the settings, emitting a SettingsUpdated event if there has been
+      // any settings changed.
+      //   From this section the user can navigate to these subpages without leave the settings section
+      //   - bridges - /settings/bridges
+      //   - exchanges - /settings/exchanges
+      //   - languages - /settings/languages
+      //   - select wallet pages - /select-wallet
+      //   We check that the location the user navigated to is not one of these pages
+      //   in order ensure we emit the SettingsUpdated event at the point the user meaningfully leaves the Settings
+      const currentSettings = getSettings();
       if (
         previousSettings.current &&
         !deepEqual(previousSettings.current, currentSettings)
@@ -46,6 +61,7 @@ export function PageEntered() {
         emitter.emit(WidgetEvent.SettingsUpdated, {
           currentSettings: currentSettings,
           previousSettings: previousSettings.current,
+          diff: microdiff(previousSettings.current, currentSettings),
         });
         previousSettings.current = undefined;
       }
@@ -54,7 +70,7 @@ export function PageEntered() {
     return () => {
       lastLocation.current = location.pathname;
     };
-  }, [emitter, location.pathname, getSettingsState]);
+  }, [emitter, location.pathname, getSettings]);
 
   return null;
 }

--- a/packages/widget/src/stores/settings/types.ts
+++ b/packages/widget/src/stores/settings/types.ts
@@ -31,6 +31,20 @@ export interface SettingsProps {
   _enabledExchanges: Record<string, boolean>;
 }
 
+export interface SettingsValues
+  extends Omit<
+    SettingsProps,
+    | '_enabledBridges'
+    | '_enabledExchanges'
+    | 'disabledBridges'
+    | 'enabledBridges'
+    | 'disabledExchanges'
+    | 'enabledExchanges'
+  > {
+  enabledBridges: Record<string, boolean>;
+  enabledExchanges: Record<string, boolean>;
+}
+
 export interface SettingsState extends SettingsProps {
   setValue: ValueSetter<SettingsProps>;
   setValues: ValuesSetter<SettingsProps>;
@@ -42,7 +56,7 @@ export interface SettingsState extends SettingsProps {
   setToolValue(toolType: SettingsToolType, tool: string, value: boolean): void;
   toggleToolKeys(toolType: SettingsToolType, toolKeys: string[]): void;
   reset(bridges: string[], exchanges: string[]): void;
-  getSettingsState(): SettingsProps;
+  getSettings(): SettingsValues;
 }
 
 export interface SendToWalletState {

--- a/packages/widget/src/stores/settings/types.ts
+++ b/packages/widget/src/stores/settings/types.ts
@@ -42,6 +42,7 @@ export interface SettingsState extends SettingsProps {
   setToolValue(toolType: SettingsToolType, tool: string, value: boolean): void;
   toggleToolKeys(toolType: SettingsToolType, toolKeys: string[]): void;
   reset(bridges: string[], exchanges: string[]): void;
+  getSettingsState(): SettingsProps;
 }
 
 export interface SendToWalletState {

--- a/packages/widget/src/stores/settings/useSettingsStore.ts
+++ b/packages/widget/src/stores/settings/useSettingsStore.ts
@@ -142,6 +142,20 @@ export const useSettingsStore = createWithEqualityFn<SettingsState>(
         get().initializeTools('Bridges', bridges, true);
         get().initializeTools('Exchanges', exchanges, true);
       },
+      getSettingsState: () => ({
+        appearance: get().appearance,
+        gasPrice: get().gasPrice,
+        language: get().language,
+        routePriority: get().routePriority,
+        enabledAutoRefuel: get().enabledAutoRefuel,
+        slippage: get().slippage,
+        disabledBridges: get().disabledBridges,
+        enabledBridges: get().enabledBridges,
+        _enabledBridges: get()._enabledBridges,
+        disabledExchanges: get().disabledExchanges,
+        enabledExchanges: get().enabledExchanges,
+        _enabledExchanges: get()._enabledExchanges,
+      }),
     }),
     {
       name: `li.fi-widget-settings`,

--- a/packages/widget/src/stores/settings/useSettingsStore.ts
+++ b/packages/widget/src/stores/settings/useSettingsStore.ts
@@ -142,19 +142,15 @@ export const useSettingsStore = createWithEqualityFn<SettingsState>(
         get().initializeTools('Bridges', bridges, true);
         get().initializeTools('Exchanges', exchanges, true);
       },
-      getSettingsState: () => ({
+      getSettings: () => ({
         appearance: get().appearance,
         gasPrice: get().gasPrice,
         language: get().language,
         routePriority: get().routePriority,
         enabledAutoRefuel: get().enabledAutoRefuel,
         slippage: get().slippage,
-        disabledBridges: get().disabledBridges,
-        enabledBridges: get().enabledBridges,
-        _enabledBridges: get()._enabledBridges,
-        disabledExchanges: get().disabledExchanges,
-        enabledExchanges: get().enabledExchanges,
-        _enabledExchanges: get()._enabledExchanges,
+        enabledBridges: { ...get()._enabledBridges },
+        enabledExchanges: { ...get()._enabledExchanges },
       }),
     }),
     {

--- a/packages/widget/src/types/events.ts
+++ b/packages/widget/src/types/events.ts
@@ -1,5 +1,5 @@
 import type { ChainId, ChainType, Process, Route } from '@lifi/sdk';
-import type { SettingsProps } from '@lifi/widget/stores/settings/types.js';
+import type { SettingsValues } from '@lifi/widget/stores/settings/types.js';
 import type { NavigationRouteType } from '../utils/navigationRoutes.js';
 
 export enum WidgetEvent {
@@ -70,6 +70,7 @@ export interface WalletConnected {
 }
 
 export interface SettingsUpdated {
-  currentSettings: SettingsProps;
-  previousSettings: SettingsProps;
+  currentSettings: SettingsValues;
+  previousSettings: SettingsValues;
+  diff: any;
 }

--- a/packages/widget/src/types/events.ts
+++ b/packages/widget/src/types/events.ts
@@ -1,4 +1,5 @@
 import type { ChainId, ChainType, Process, Route } from '@lifi/sdk';
+import type { SettingsProps } from '@lifi/widget/stores/settings/types.js';
 import type { NavigationRouteType } from '../utils/navigationRoutes.js';
 
 export enum WidgetEvent {
@@ -19,6 +20,7 @@ export enum WidgetEvent {
   WalletConnected = 'walletConnected',
   WidgetExpanded = 'widgetExpanded',
   PageEntered = 'pageEntered',
+  SettingsUpdated = 'settingsUpdated',
 }
 
 export type WidgetEvents = {
@@ -36,6 +38,7 @@ export type WidgetEvents = {
   walletConnected: WalletConnected;
   widgetExpanded: boolean;
   pageEntered: NavigationRouteType;
+  settingsUpdated: SettingsUpdated;
 };
 
 export interface ContactSupport {
@@ -64,4 +67,9 @@ export interface WalletConnected {
   address?: string;
   chainId?: number;
   chainType?: ChainType;
+}
+
+export interface SettingsUpdated {
+  currentSettings: SettingsProps;
+  previousSettings: SettingsProps;
 }

--- a/packages/widget/src/utils/deepEquality.ts
+++ b/packages/widget/src/utils/deepEquality.ts
@@ -1,0 +1,30 @@
+export function deepEqual(obj1: any, obj2: any) {
+  // Base case: If both objects are identical, return true.
+  if (obj1 === obj2) {
+    return true;
+  }
+  // Check if both objects are objects and not null.
+  if (
+    typeof obj1 !== 'object' ||
+    typeof obj2 !== 'object' ||
+    obj1 === null ||
+    obj2 === null
+  ) {
+    return false;
+  }
+  // Get the keys of both objects.
+  const keys1 = Object.keys(obj1);
+  const keys2 = Object.keys(obj2);
+  // Check if the number of keys is the same.
+  if (keys1.length !== keys2.length) {
+    return false;
+  }
+  // Iterate through the keys and compare their values recursively.
+  for (const key of keys1) {
+    if (!keys2.includes(key) || !deepEqual(obj1[key], obj2[key])) {
+      return false;
+    }
+  }
+  // If all checks pass, the objects are deep equal.
+  return true;
+}


### PR DESCRIPTION
Jira: [LF-10342](https://lifi.atlassian.net/browse/LF-10342)

This adds the SettingsUpdated to the Widget

When the user enters the settings section of the Widget 
And makes changes to the settings 
And leaves the settings returns to the main page 
Then a SettingsUpdated event will be emitted

The SettingsUpdated event presents the currentSettings (featuring the changes), previousSettings (before the changes were made) and a diff that presents a list of changes.

**Testing**
Note: for testing I have been cherry-picking the addition of the WidgetEventsControl from the [send to wallet address changed PR](https://github.com/lifinance/widget/pull/309). its in this [one commit](https://github.com/lifinance/widget/pull/309/commits/9a11251a6c93f41460c55d074b1fd95ade49c4a1). Once that PR is merged those changes will be available here as well

To test using the WidgetEventsControl

- Open Playground, go to the Playground settings and turn on the Dev view option
- The Widget events control should be visible in the playground
- You can toggle on event listener for `settingsUpdated`
- `settingsUpdated` event name with its payloads will be printed in the console

**More Detail on the event**

To listen to the even a listening emitter will be attached like so

```
widgetEvents.on(WidgetEvent.SettingsUpdated, (payload) => console.log(payload))
```

The payload for the event will look like this...
```
{
  currentSettings: {}, // the all settings as they look after changes
  previousSettings: {}, // the all settings as they looked before changes
  diff: [], // the changes that have taken place to get to get from the previous to the current settings
}
```
The diff here is created using microdiff.

A verbose example will look like this...
```
{
  "currentSettings": {
    "appearance": "dark",
    "gasPrice": "normal",
    "language": "es",
    "routePriority": "FASTEST",
    "enabledAutoRefuel": true,
    "slippage": "0.5",
    "enabledBridges": {
      "hop": false,
      "cbridge": true,
      "hyphen": true,
      "optimism": true,
      "arbitrum": true,
      "across": true,
      "stargate": true,
      "gnosis": true,
      "omni": true,
      "celercircle": true,
      "allbridge": true,
      "celerim": true,
      "thorswap": true,
      "symbiosis": true,
      "squid": true,
      "stargateV2": true,
      "mayan": true,
      "stargateV2Bus": true
    },
    "enabledExchanges": {
      "dodo": true,
      "paraswap": true,
      "enso": true,
      "odos": true,
      "1inch": true,
      "openocean": true,
      "0x": true,
      "uniswap": true,
      "sushiswap": true,
      "apeswap": true,
      "verse": true,
      "quickswap": true,
      "honeyswap": true,
      "lif3swap": true,
      "pancakeswap": true,
      "swapr": true,
      "spookyswap": true,
      "spiritswap": true,
      "soulswap": true,
      "tombswap": true,
      "arbswap": true,
      "solarbeam": true,
      "stellaswap": true,
      "beamswap": true,
      "voltage": true,
      "ubeswap": true,
      "oolongswap": true,
      "trisolaris": true,
      "stable": true,
      "kyberswap": true,
      "lifidexaggregator": true,
      "jupiter": true
    }
  },
  "previousSettings": {
    "appearance": "auto",
    "gasPrice": "normal",
    "language": "en",
    "routePriority": "CHEAPEST",
    "enabledAutoRefuel": true,
    "slippage": "0.5",
    "enabledBridges": {
      "hop": true,
      "cbridge": true,
      "hyphen": true,
      "optimism": true,
      "arbitrum": true,
      "across": true,
      "stargate": true,
      "gnosis": true,
      "omni": true,
      "celercircle": true,
      "allbridge": true,
      "celerim": true,
      "thorswap": true,
      "symbiosis": true,
      "squid": true,
      "stargateV2": true,
      "mayan": true,
      "stargateV2Bus": true
    },
    "enabledExchanges": {
      "dodo": true,
      "paraswap": false,
      "enso": true,
      "odos": true,
      "1inch": true,
      "openocean": true,
      "0x": true,
      "uniswap": true,
      "sushiswap": true,
      "apeswap": true,
      "verse": true,
      "quickswap": true,
      "honeyswap": true,
      "lif3swap": true,
      "pancakeswap": true,
      "swapr": true,
      "spookyswap": true,
      "spiritswap": true,
      "soulswap": true,
      "tombswap": true,
      "arbswap": true,
      "solarbeam": true,
      "stellaswap": true,
      "beamswap": true,
      "voltage": true,
      "ubeswap": true,
      "oolongswap": true,
      "trisolaris": true,
      "stable": true,
      "kyberswap": true,
      "lifidexaggregator": true,
      "jupiter": true
    }
  },
  "diff": [
    {
      "path": [
        "appearance"
      ],
      "type": "CHANGE",
      "value": "dark",
      "oldValue": "auto"
    },
    {
      "path": [
        "language"
      ],
      "type": "CHANGE",
      "value": "es",
      "oldValue": "en"
    },
    {
      "path": [
        "routePriority"
      ],
      "type": "CHANGE",
      "value": "FASTEST",
      "oldValue": "CHEAPEST"
    },
    {
      "path": [
        "enabledBridges",
        "hop"
      ],
      "type": "CHANGE",
      "value": false,
      "oldValue": true
    },
    {
      "path": [
        "enabledExchanges",
        "paraswap"
      ],
      "type": "CHANGE",
      "value": true,
      "oldValue": false
    }
  ]
}
```


[LF-10342]: https://lifi.atlassian.net/browse/LF-10342?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ