### PR TITLE
fix: validate address from URL params and bookmark it

### DIFF
--- a/packages/widget/src/stores/form/FormUpdater.tsx
+++ b/packages/widget/src/stores/form/FormUpdater.tsx
@@ -56,8 +56,9 @@ export const FormUpdater: React.FC<{
     if (reactiveFormValues.toAddress) {
       setSendToWallet(true)
     }
-
-    setSelectedBookmark(toAddress)
+    if (toAddress) {
+      setSelectedBookmark(toAddress)
+    }
 
     setUserAndDefaultValues(
       accountForChainId(reactiveFormValues, account.chainId)


### PR DESCRIPTION
When URL builder is enabled and user opens a page with toAddress parameter, we need to validate the address and set it up as a bookmark. This will allow direct linking to the widget with a pre-filled destination address that will be treated the same way as a manually entered and validated address.

https://github.com/user-attachments/assets/78cc5cb4-206f-4bea-adb7-dcad570b3145

