### PR TITLE
feat(timer):  counts up instead of countdown

### DIFF
--- a/packages/widget/src/components/ActiveTransactions/ActiveTransactionItem.tsx
+++ b/packages/widget/src/components/ActiveTransactions/ActiveTransactionItem.tsx
@@ -7,7 +7,7 @@ import { RouteExecutionStatus } from '../../stores/routes/types.js'
 import { navigationRoutes } from '../../utils/navigationRoutes.js'
 import { TokenAvatarGroup } from '../Avatar/Avatar.style.js'
 import { TokenAvatar } from '../Avatar/TokenAvatar.js'
-import { StepTimer } from '../Step/StepTimer.js'
+import { RouteTimer } from '../Timer/RouteTimer.js'
 import { ListItem, ListItemButton } from './ActiveTransactions.style.js'
 
 export const ActiveTransactionItem: React.FC<{
@@ -47,7 +47,7 @@ export const ActiveTransactionItem: React.FC<{
               fontWeight: 600,
             }}
           >
-            <StepTimer step={lastActiveStep} hideInProgress />
+            <RouteTimer route={route} />
           </Typography>
         )
     }

--- a/packages/widget/src/components/Step/Step.tsx
+++ b/packages/widget/src/components/Step/Step.tsx
@@ -8,9 +8,9 @@ import { Token } from '../../components/Token/Token.js'
 import { useExplorer } from '../../hooks/useExplorer.js'
 import { useWidgetConfig } from '../../providers/WidgetProvider/WidgetProvider.js'
 import { shortenAddress } from '../../utils/wallet.js'
+import { StepTimer } from '../Timer/StepTimer.js'
 import { DestinationWalletAddress } from './DestinationWalletAddress.js'
 import { StepProcess } from './StepProcess.js'
-import { StepTimer } from './StepTimer.js'
 
 export const Step: React.FC<{
   step: LiFiStepExtended

--- a/packages/widget/src/components/Step/StepTimer.tsx
+++ b/packages/widget/src/components/Step/StepTimer.tsx
@@ -65,6 +65,10 @@ export const StepTimer: React.FC<{
     }
   }, [isExecutionStarted, isRunning, pause, reset, start, step])
 
+  if (step.execution?.status === 'DONE') {
+    return null
+  }
+
   if (!isExecutionStarted) {
     const showSeconds = step.estimate.executionDuration < 60
     const duration = showSeconds
@@ -79,13 +83,6 @@ export const StepTimer: React.FC<{
         })}
       </StepTimerContent>
     )
-  }
-
-  if (
-    step.execution?.status === 'DONE' ||
-    step.execution?.status === 'FAILED'
-  ) {
-    return null
   }
 
   return (

--- a/packages/widget/src/components/Step/StepTimer.tsx
+++ b/packages/widget/src/components/Step/StepTimer.tsx
@@ -37,7 +37,9 @@ export const StepTimer: React.FC<{
     if (!executionProcess) {
       return
     }
-    const shouldRestart = executionProcess.status === 'FAILED'
+
+    const shouldRestart =
+      executionProcess.status === 'FAILED' || executionProcess.status === 'DONE'
     const shouldPause = executionProcess.status === 'ACTION_REQUIRED'
     const shouldStart =
       executionProcess.status === 'STARTED' ||
@@ -45,20 +47,21 @@ export const StepTimer: React.FC<{
     const shouldResume = executionProcess.status === 'PENDING'
     if (isExecutionStarted && shouldRestart) {
       setExecutionStarted(false)
+      pause()
       return
     }
-    if (isExecutionStarted) {
+    if (isExecutionStarted && shouldPause && isRunning) {
+      pause()
+      return
+    }
+    if (isExecutionStarted && !isRunning && shouldResume) {
+      start()
       return
     }
     if (!isExecutionStarted && shouldStart) {
       setExecutionStarted(true)
       reset()
       return
-    }
-    if (isRunning && shouldPause) {
-      pause()
-    } else if (!isRunning && shouldResume) {
-      start()
     }
   }, [isExecutionStarted, isRunning, pause, reset, start, step])
 

--- a/packages/widget/src/components/Timer/RouteTimer.tsx
+++ b/packages/widget/src/components/Timer/RouteTimer.tsx
@@ -1,0 +1,22 @@
+import type { RouteExtended } from '@lifi/sdk'
+import { useStopwatch } from '../../hooks/timer/useStopwatch.js'
+import { TimerContent } from './TimerContent.js'
+
+export const RouteTimer: React.FC<{
+  route: RouteExtended
+}> = ({ route }) => {
+  const firstActiveStep = route?.steps.find((step) => step.execution)
+  const firstActiveProcess = firstActiveStep?.execution?.process.at(0)
+
+  const startTime = new Date(firstActiveProcess?.startedAt ?? Date.now())
+  const { seconds, minutes } = useStopwatch({
+    autoStart: true,
+    offsetTimestamp: startTime,
+  })
+
+  return (
+    <TimerContent>
+      {`${minutes}:${seconds < 10 ? `0${seconds}` : seconds}`}
+    </TimerContent>
+  )
+}

--- a/packages/widget/src/components/Timer/StepTimer.tsx
+++ b/packages/widget/src/components/Timer/StepTimer.tsx
@@ -1,5 +1,4 @@
 import type { LiFiStepExtended } from '@lifi/sdk'
-import {} from '@mui/material'
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useStopwatch } from '../../hooks/timer/useStopwatch.js'

--- a/packages/widget/src/components/Timer/StepTimer.tsx
+++ b/packages/widget/src/components/Timer/StepTimer.tsx
@@ -1,21 +1,18 @@
 import type { LiFiStepExtended } from '@lifi/sdk'
-import { AccessTimeFilled } from '@mui/icons-material'
-import { Box, Tooltip } from '@mui/material'
-import { type FC, type PropsWithChildren, useEffect, useState } from 'react'
+import {} from '@mui/material'
+import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useStopwatch } from '../../hooks/timer/useStopwatch.js'
-import { IconTypography } from '../IconTypography.js'
+import { TimerContent } from './TimerContent.js'
+
+const getFirstExecutionProcess = (step: LiFiStepExtended) =>
+  step.execution?.process.at(0)
 
 const getExecutionProcess = (step: LiFiStepExtended) =>
-  step.execution?.process.findLast(
-    (process) =>
-      process.type === 'SWAP' ||
-      process.type === 'CROSS_CHAIN' ||
-      process.type === 'RECEIVING_CHAIN'
-  )
+  step.execution?.process.at(-1)
 
 const getStartTimestamp = (step: LiFiStepExtended) =>
-  new Date(getExecutionProcess(step)?.startedAt ?? Date.now())
+  new Date(getFirstExecutionProcess(step)?.startedAt ?? Date.now())
 
 export const StepTimer: React.FC<{
   step: LiFiStepExtended
@@ -28,7 +25,7 @@ export const StepTimer: React.FC<{
   )
 
   const { seconds, minutes, isRunning, pause, reset, start } = useStopwatch({
-    autoStart: false,
+    autoStart: true,
     offsetTimestamp: getStartTimestamp(step),
   })
 
@@ -40,17 +37,12 @@ export const StepTimer: React.FC<{
 
     const shouldRestart =
       executionProcess.status === 'FAILED' || executionProcess.status === 'DONE'
-    const shouldPause = executionProcess.status === 'ACTION_REQUIRED'
     const shouldStart =
       executionProcess.status === 'STARTED' ||
       executionProcess.status === 'PENDING'
     const shouldResume = executionProcess.status === 'PENDING'
     if (isExecutionStarted && shouldRestart) {
       setExecutionStarted(false)
-      pause()
-      return
-    }
-    if (isExecutionStarted && shouldPause && isRunning) {
       pause()
       return
     }
@@ -75,48 +67,19 @@ export const StepTimer: React.FC<{
       ? Math.floor(step.estimate.executionDuration)
       : Math.floor(step.estimate.executionDuration / 60)
     return (
-      <StepTimerContent>
+      <TimerContent>
         {duration.toLocaleString(i18n.language, {
           style: 'unit',
           unit: showSeconds ? 'second' : 'minute',
           unitDisplay: 'narrow',
         })}
-      </StepTimerContent>
+      </TimerContent>
     )
   }
 
   return (
-    <StepTimerContent>
+    <TimerContent>
       {`${minutes}:${seconds < 10 ? `0${seconds}` : seconds}`}
-    </StepTimerContent>
-  )
-}
-
-const StepTimerContent: FC<PropsWithChildren> = ({ children }) => {
-  const { t } = useTranslation()
-  return (
-    <Tooltip title={t('tooltip.estimatedTime')} sx={{ cursor: 'help' }}>
-      <Box
-        component="span"
-        sx={{
-          display: 'flex',
-          alignItems: 'center',
-          height: 14,
-        }}
-      >
-        <IconTypography as="span" sx={{ marginRight: 0.5, fontSize: 16 }}>
-          <AccessTimeFilled fontSize="inherit" />
-        </IconTypography>
-        <Box
-          component="span"
-          sx={{
-            fontVariantNumeric: 'tabular-nums',
-            cursor: 'help',
-          }}
-        >
-          {children}
-        </Box>
-      </Box>
-    </Tooltip>
+    </TimerContent>
   )
 }

--- a/packages/widget/src/components/Timer/TimerContent.tsx
+++ b/packages/widget/src/components/Timer/TimerContent.tsx
@@ -1,0 +1,35 @@
+import { AccessTimeFilled } from '@mui/icons-material'
+import { Tooltip } from '@mui/material'
+import { Box } from '@mui/system'
+import type { FC, PropsWithChildren } from 'react'
+import { useTranslation } from 'react-i18next'
+import { IconTypography } from '../IconTypography.js'
+
+export const TimerContent: FC<PropsWithChildren> = ({ children }) => {
+  const { t } = useTranslation()
+  return (
+    <Tooltip title={t('tooltip.estimatedTime')} sx={{ cursor: 'help' }}>
+      <Box
+        component="span"
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          height: 14,
+        }}
+      >
+        <IconTypography as="span" sx={{ marginRight: 0.5, fontSize: 16 }}>
+          <AccessTimeFilled fontSize="inherit" />
+        </IconTypography>
+        <Box
+          component="span"
+          sx={{
+            fontVariantNumeric: 'tabular-nums',
+            cursor: 'help',
+          }}
+        >
+          {children}
+        </Box>
+      </Box>
+    </Tooltip>
+  )
+}

--- a/packages/widget/src/hooks/timer/useStopwatch.ts
+++ b/packages/widget/src/hooks/timer/useStopwatch.ts
@@ -1,0 +1,64 @@
+import { useCallback, useState } from 'react'
+import { useInterval } from './useInterval.js'
+import {
+  getSecondsFromExpiry,
+  getSecondsFromPrevTime,
+  getTimeFromSeconds,
+} from './utils.js'
+
+interface UseStopwatchProps {
+  offsetTimestamp: Date
+  autoStart?: boolean
+}
+
+// This implementation was taken from the common js project - https://www.npmjs.com/package/react-timer-hook
+// modified to work in the Widget codebase with Typescript
+export function useStopwatch({
+  autoStart,
+  offsetTimestamp,
+}: UseStopwatchProps) {
+  const [passedSeconds, setPassedSeconds] = useState(
+    getSecondsFromExpiry(offsetTimestamp, true) || 0
+  )
+  const [prevTime, setPrevTime] = useState(new Date())
+  const [seconds, setSeconds] = useState(
+    passedSeconds + getSecondsFromPrevTime(prevTime || 0, true)
+  )
+  const [isRunning, setIsRunning] = useState(autoStart)
+
+  useInterval(
+    () => {
+      setSeconds(passedSeconds + getSecondsFromPrevTime(prevTime, true))
+    },
+    isRunning ? 1000 : 0
+  )
+
+  const start = useCallback(() => {
+    const newPrevTime = new Date()
+    setPrevTime(newPrevTime)
+    setIsRunning(true)
+    setSeconds(passedSeconds + getSecondsFromPrevTime(newPrevTime, true))
+  }, [passedSeconds])
+
+  const pause = useCallback(() => {
+    setPassedSeconds(seconds)
+    setIsRunning(false)
+  }, [seconds])
+
+  const reset = useCallback((offset = new Date(), newAutoStart = true) => {
+    const newPassedSeconds = getSecondsFromExpiry(offset, true) || 0
+    const newPrevTime = new Date()
+    setPrevTime(newPrevTime)
+    setPassedSeconds(newPassedSeconds)
+    setIsRunning(newAutoStart)
+    setSeconds(newPassedSeconds + getSecondsFromPrevTime(newPrevTime, true))
+  }, [])
+
+  return {
+    ...getTimeFromSeconds(seconds),
+    start,
+    pause,
+    reset,
+    isRunning,
+  }
+}

--- a/packages/widget/src/hooks/timer/useStopwatch.ts
+++ b/packages/widget/src/hooks/timer/useStopwatch.ts
@@ -18,11 +18,11 @@ export function useStopwatch({
   offsetTimestamp,
 }: UseStopwatchProps) {
   const [passedSeconds, setPassedSeconds] = useState(
-    getSecondsFromExpiry(offsetTimestamp, true) || 0
+    getSecondsFromPrevTime(offsetTimestamp, true) || 0
   )
   const [prevTime, setPrevTime] = useState(new Date())
   const [seconds, setSeconds] = useState(
-    passedSeconds + getSecondsFromPrevTime(prevTime || 0, true)
+    passedSeconds + getSecondsFromPrevTime(prevTime, true)
   )
   const [isRunning, setIsRunning] = useState(autoStart)
 
@@ -45,14 +45,17 @@ export function useStopwatch({
     setIsRunning(false)
   }, [seconds])
 
-  const reset = useCallback((offset = new Date(), newAutoStart = true) => {
-    const newPassedSeconds = getSecondsFromExpiry(offset, true) || 0
-    const newPrevTime = new Date()
-    setPrevTime(newPrevTime)
-    setPassedSeconds(newPassedSeconds)
-    setIsRunning(newAutoStart)
-    setSeconds(newPassedSeconds + getSecondsFromPrevTime(newPrevTime, true))
-  }, [])
+  const reset = useCallback(
+    (offset = offsetTimestamp, newAutoStart = true) => {
+      const newPassedSeconds = getSecondsFromExpiry(offset, true) || 0
+      const newPrevTime = new Date()
+      setPrevTime(newPrevTime)
+      setPassedSeconds(newPassedSeconds)
+      setIsRunning(newAutoStart)
+      setSeconds(newPassedSeconds + getSecondsFromPrevTime(newPrevTime, true))
+    },
+    [offsetTimestamp]
+  )
 
   return {
     ...getTimeFromSeconds(seconds),

--- a/packages/widget/src/hooks/timer/useStopwatch.ts
+++ b/packages/widget/src/hooks/timer/useStopwatch.ts
@@ -6,6 +6,8 @@ import {
   getTimeFromSeconds,
 } from './utils.js'
 
+const DEFAULT_DELAY = 1000
+
 interface UseStopwatchProps {
   offsetTimestamp: Date
   autoStart?: boolean
@@ -18,20 +20,13 @@ export function useStopwatch({
   offsetTimestamp,
 }: UseStopwatchProps) {
   const [passedSeconds, setPassedSeconds] = useState(
-    getSecondsFromPrevTime(offsetTimestamp, true) || 0
+    getSecondsFromExpiry(offsetTimestamp, true) || 0
   )
   const [prevTime, setPrevTime] = useState(new Date())
   const [seconds, setSeconds] = useState(
     passedSeconds + getSecondsFromPrevTime(prevTime, true)
   )
   const [isRunning, setIsRunning] = useState(autoStart)
-
-  useInterval(
-    () => {
-      setSeconds(passedSeconds + getSecondsFromPrevTime(prevTime, true))
-    },
-    isRunning ? 1000 : 0
-  )
 
   const start = useCallback(() => {
     const newPrevTime = new Date()
@@ -55,6 +50,13 @@ export function useStopwatch({
       setSeconds(newPassedSeconds + getSecondsFromPrevTime(newPrevTime, true))
     },
     [offsetTimestamp]
+  )
+
+  useInterval(
+    () => {
+      setSeconds(passedSeconds + getSecondsFromPrevTime(prevTime, true))
+    },
+    isRunning ? DEFAULT_DELAY : 0
   )
 
   return {

--- a/packages/widget/src/hooks/timer/useStopwatch.ts
+++ b/packages/widget/src/hooks/timer/useStopwatch.ts
@@ -1,10 +1,6 @@
 import { useCallback, useState } from 'react'
 import { useInterval } from './useInterval.js'
-import {
-  getSecondsFromExpiry,
-  getSecondsFromPrevTime,
-  getTimeFromSeconds,
-} from './utils.js'
+import { getSecondsFromPrevTime, getTimeFromSeconds } from './utils.js'
 
 const DEFAULT_DELAY = 1000
 
@@ -20,7 +16,7 @@ export function useStopwatch({
   offsetTimestamp,
 }: UseStopwatchProps) {
   const [passedSeconds, setPassedSeconds] = useState(
-    getSecondsFromExpiry(offsetTimestamp, true) || 0
+    getSecondsFromPrevTime(offsetTimestamp, true) || 0
   )
   const [prevTime, setPrevTime] = useState(new Date())
   const [seconds, setSeconds] = useState(
@@ -42,7 +38,7 @@ export function useStopwatch({
 
   const reset = useCallback(
     (offset = offsetTimestamp, newAutoStart = true) => {
-      const newPassedSeconds = getSecondsFromExpiry(offset, true) || 0
+      const newPassedSeconds = getSecondsFromPrevTime(offset, true) || 0
       const newPrevTime = new Date()
       setPrevTime(newPrevTime)
       setPassedSeconds(newPassedSeconds)

--- a/packages/widget/src/hooks/timer/utils.ts
+++ b/packages/widget/src/hooks/timer/utils.ts
@@ -24,6 +24,16 @@ export function getSecondsFromExpiry(expiry: Date, shouldRound?: boolean) {
   return 0
 }
 
+export function getSecondsFromPrevTime(prevTime: Date, shouldRound?: boolean) {
+  const now = new Date().getTime()
+  const milliSecondsDistance = now - prevTime.getTime()
+  if (milliSecondsDistance > 0) {
+    const val = milliSecondsDistance / 1000
+    return shouldRound ? Math.round(val) : val
+  }
+  return 0
+}
+
 export function validateExpiryTimestamp(expiryTimestamp: Date) {
   const isValid = new Date(expiryTimestamp).getTime() > 0
   if (!isValid) {


### PR DESCRIPTION
Closes [LF-11996](https://lifi.atlassian.net/browse/LF-11996)

This PR:
- updates the widget timer from a countdown to a count up, basically replaces a timer with a stopwatch.
- tiny: hides the timer for DONE transactions

https://github.com/user-attachments/assets/9ca12725-b771-48fb-8111-a2203911aadf


[LF-11996]: https://lifi.atlassian.net/browse/LF-11996?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ