### PR TITLE
feat: widget auto slippage mode

### DIFF
--- a/packages/widget/src/hooks/useRoutes.ts
+++ b/packages/widget/src/hooks/useRoutes.ts
@@ -183,7 +183,9 @@ export const useRoutes = ({ observableRoute }: RoutesProps = {}) => {
       }) => {
         const fromAmount = parseUnits(fromTokenAmount, fromToken!.decimals)
         const toAmount = parseUnits(toTokenAmount, toToken!.decimals)
-        const formattedSlippage = Number.parseFloat(slippage) / 100
+        const formattedSlippage = slippage
+          ? Number.parseFloat(slippage) / 100
+          : defaultSlippage
 
         const allowBridges = swapOnly
           ? []

--- a/packages/widget/src/hooks/useSettingMonitor.ts
+++ b/packages/widget/src/hooks/useSettingMonitor.ts
@@ -38,6 +38,10 @@ export const useSettingMonitor = () => {
   const isSlippageUnderRecommendedLimits =
     isSlippageChanged && slippage && Number(slippage) < 0.1
 
+  const isSlippageNotRecommended = Boolean(
+    isSlippageOutsideRecommendedLimits || isSlippageUnderRecommendedLimits
+  )
+
   const isRoutePriorityChanged = config.routePriority
     ? routePriority !== config.routePriority
     : routePriority !== defaultConfigurableSettings.routePriority
@@ -54,7 +58,7 @@ export const useSettingMonitor = () => {
     isRoutePriorityChanged ||
     isGasPriceChanged
 
-  const isRouteSettingsWithWarnings = isSlippageOutsideRecommendedLimits
+  const isRouteSettingsWithWarnings = isSlippageNotRecommended
 
   const reset = () => {
     if (tools) {
@@ -71,6 +75,7 @@ export const useSettingMonitor = () => {
     isBridgesChanged,
     isExchangesChanged,
     isSlippageChanged,
+    isSlippageNotRecommended,
     isSlippageOutsideRecommendedLimits,
     isSlippageUnderRecommendedLimits,
     isRoutePriorityChanged,

--- a/packages/widget/src/hooks/useSettingMonitor.ts
+++ b/packages/widget/src/hooks/useSettingMonitor.ts
@@ -33,7 +33,10 @@ export const useSettingMonitor = () => {
     : slippage !== defaultConfigurableSettings.slippage
 
   const isSlippageOutsideRecommendedLimits =
-    isSlippageChanged && Number(slippage) > 1
+    isSlippageChanged && slippage && Number(slippage) > 1
+
+  const isSlippageUnderRecommendedLimits =
+    isSlippageChanged && slippage && Number(slippage) < 0.1
 
   const isRoutePriorityChanged = config.routePriority
     ? routePriority !== config.routePriority
@@ -69,6 +72,7 @@ export const useSettingMonitor = () => {
     isExchangesChanged,
     isSlippageChanged,
     isSlippageOutsideRecommendedLimits,
+    isSlippageUnderRecommendedLimits,
     isRoutePriorityChanged,
     isGasPriceChanged,
     isCustomRouteSettings,

--- a/packages/widget/src/i18n/en.json
+++ b/packages/widget/src/i18n/en.json
@@ -306,6 +306,7 @@
     },
     "routePriority": "Route priority",
     "slippage": "Max. slippage",
+    "defaultSlippage": "Auto",
     "custom": "Custom",
     "resetSettings": "You're using custom settings that can affect the number or sorting of available routes."
   },

--- a/packages/widget/src/i18n/en.json
+++ b/packages/widget/src/i18n/en.json
@@ -307,7 +307,6 @@
     },
     "routePriority": "Route priority",
     "slippage": "Max. slippage",
-    "defaultSlippage": "Auto",
     "custom": "Custom",
     "resetSettings": "You're using custom settings that can affect the number or sorting of available routes."
   },

--- a/packages/widget/src/i18n/en.json
+++ b/packages/widget/src/i18n/en.json
@@ -128,7 +128,8 @@
       "insufficientGas": "You don't have enough gas to complete the transaction. You need to add at least:",
       "rateChanged": "The exchange rate has changed. By continuing the transaction, you'll accept the new rate.",
       "resetSettings": "This will reset your route priority, slippage, gas price, enabled bridges and exchanges.",
-      "slippageOutsideRecommendedLimits": "High slippage tolerance may result in unfavorable trade caused by front-running."
+      "slippageOutsideRecommendedLimits": "High slippage tolerance may result in unfavorable trade caused by front-running.",
+      "slippageUnderRecommendedLimits": "Low slippage tolerance may cause transaction delays or failures."
     },
     "title": {
       "deleteActiveTransactions": "Delete all active transactions?",

--- a/packages/widget/src/pages/SettingsPage/SlippageSettings/SlippageSettings.tsx
+++ b/packages/widget/src/pages/SettingsPage/SlippageSettings/SlippageSettings.tsx
@@ -22,6 +22,7 @@ const DEFAULT_CUSTOM_INPUT_VALUE = '0.5'
 export const SlippageSettings: React.FC = () => {
   const { t } = useTranslation()
   const {
+    isSlippageNotRecommended,
     isSlippageUnderRecommendedLimits,
     isSlippageOutsideRecommendedLimits,
     isSlippageChanged,
@@ -52,7 +53,7 @@ export const SlippageSettings: React.FC = () => {
 
       debouncedSetValue(
         'slippage',
-        formatSlippage(value || defaultSlippage, defaultValue.current, true)
+        formatSlippage(value || defaultSlippage, defaultValue.current)
       )
     },
     [debouncedSetValue]
@@ -71,10 +72,6 @@ export const SlippageSettings: React.FC = () => {
       formattedValue.length ? formattedValue : defaultSlippage
     )
   }
-
-  const isSlippageNotRecommended = Boolean(
-    isSlippageOutsideRecommendedLimits || isSlippageUnderRecommendedLimits
-  )
 
   const badgeColor = isSlippageNotRecommended
     ? 'warning'

--- a/packages/widget/src/pages/SettingsPage/SlippageSettings/SlippageSettings.tsx
+++ b/packages/widget/src/pages/SettingsPage/SlippageSettings/SlippageSettings.tsx
@@ -17,12 +17,15 @@ import {
   SlippageLimitsWarningContainer,
 } from './SlippageSettings.style.js'
 
-const DEFAULT_CUSTOM_INPUT_VALUE = '2'
+const DEFAULT_CUSTOM_INPUT_VALUE = '1'
 
 export const SlippageSettings: React.FC = () => {
   const { t } = useTranslation()
-  const { isSlippageOutsideRecommendedLimits, isSlippageChanged } =
-    useSettingMonitor()
+  const {
+    isSlippageUnderRecommendedLimits,
+    isSlippageOutsideRecommendedLimits,
+    isSlippageChanged,
+  } = useSettingMonitor()
   const { slippage } = useSettings(['slippage'])
   const { setValue } = useSettingsActions()
   const defaultValue = useRef(slippage)
@@ -75,6 +78,16 @@ export const SlippageSettings: React.FC = () => {
       ? 'info'
       : undefined
 
+  const isSlippageNotRecommended = Boolean(
+    isSlippageOutsideRecommendedLimits || isSlippageUnderRecommendedLimits
+  )
+
+  const slippageWarningText = isSlippageOutsideRecommendedLimits
+    ? t('warning.message.slippageOutsideRecommendedLimits')
+    : isSlippageUnderRecommendedLimits
+      ? t('warning.message.slippageUnderRecommendedLimits')
+      : ''
+
   return (
     <SettingCardExpandable
       value={
@@ -119,7 +132,7 @@ export const SlippageSettings: React.FC = () => {
             autoComplete="off"
           />
         </SettingsFieldSet>
-        {isSlippageOutsideRecommendedLimits && (
+        {isSlippageNotRecommended && (
           <SlippageLimitsWarningContainer>
             <WarningRounded color="warning" />
             <Typography
@@ -128,7 +141,7 @@ export const SlippageSettings: React.FC = () => {
                 fontWeight: 400,
               }}
             >
-              {t('warning.message.slippageOutsideRecommendedLimits')}
+              {slippageWarningText}
             </Typography>
           </SlippageLimitsWarningContainer>
         )}

--- a/packages/widget/src/pages/SettingsPage/SlippageSettings/SlippageSettings.tsx
+++ b/packages/widget/src/pages/SettingsPage/SlippageSettings/SlippageSettings.tsx
@@ -17,7 +17,7 @@ import {
   SlippageLimitsWarningContainer,
 } from './SlippageSettings.style.js'
 
-const DEFAULT_CUSTOM_INPUT_VALUE = '1'
+const DEFAULT_CUSTOM_INPUT_VALUE = '0.5'
 
 export const SlippageSettings: React.FC = () => {
   const { t } = useTranslation()
@@ -58,8 +58,8 @@ export const SlippageSettings: React.FC = () => {
     [debouncedSetValue]
   )
 
-  const handleInputBlur: FocusEventHandler<HTMLInputElement> = (event) => {
-    setFocused(undefined)
+  const handleInputFocus: FocusEventHandler<HTMLInputElement> = (event) => {
+    setFocused('input')
 
     const { value } = event.target
 
@@ -72,15 +72,15 @@ export const SlippageSettings: React.FC = () => {
     )
   }
 
-  const badgeColor = isSlippageOutsideRecommendedLimits
+  const isSlippageNotRecommended = Boolean(
+    isSlippageOutsideRecommendedLimits || isSlippageUnderRecommendedLimits
+  )
+
+  const badgeColor = isSlippageNotRecommended
     ? 'warning'
     : isSlippageChanged
       ? 'info'
       : undefined
-
-  const isSlippageNotRecommended = Boolean(
-    isSlippageOutsideRecommendedLimits || isSlippageUnderRecommendedLimits
-  )
 
   const slippageWarningText = isSlippageOutsideRecommendedLimits
     ? t('warning.message.slippageOutsideRecommendedLimits')
@@ -124,10 +124,7 @@ export const SlippageSettings: React.FC = () => {
               inputMode: 'decimal',
             }}
             onChange={handleInputUpdate}
-            onFocus={() => {
-              setFocused('input')
-            }}
-            onBlur={handleInputBlur}
+            onFocus={handleInputFocus}
             value={inputValue}
             autoComplete="off"
           />

--- a/packages/widget/src/pages/SettingsPage/SlippageSettings/SlippageSettings.tsx
+++ b/packages/widget/src/pages/SettingsPage/SlippageSettings/SlippageSettings.tsx
@@ -17,6 +17,8 @@ import {
   SlippageLimitsWarningContainer,
 } from './SlippageSettings.style.js'
 
+const DEFAULT_CUSTOM_INPUT_VALUE = '2'
+
 export const SlippageSettings: React.FC = () => {
   const { t } = useTranslation()
   const { isSlippageOutsideRecommendedLimits, isSlippageChanged } =
@@ -27,12 +29,14 @@ export const SlippageSettings: React.FC = () => {
   const [focused, setFocused] = useState<'input' | 'button'>()
 
   const customInputValue =
-    !slippage || slippage === defaultSlippage ? '' : slippage
+    !slippage || slippage === defaultSlippage
+      ? DEFAULT_CUSTOM_INPUT_VALUE
+      : slippage
 
   const [inputValue, setInputValue] = useState(customInputValue)
 
   const handleDefaultClick = () => {
-    setValue('slippage', formatSlippage(defaultSlippage, defaultValue.current))
+    setValue('slippage', defaultSlippage)
   }
 
   const debouncedSetValue = useMemo(() => debounce(setValue, 500), [setValue])
@@ -56,13 +60,13 @@ export const SlippageSettings: React.FC = () => {
 
     const { value } = event.target
 
-    const formattedValue = formatSlippage(
-      value || defaultSlippage,
-      defaultValue.current
-    )
-    setInputValue(formattedValue === defaultSlippage ? '' : formattedValue)
+    const formattedValue = formatSlippage(value, defaultValue.current)
+    setInputValue(formattedValue)
 
-    setValue('slippage', formattedValue)
+    setValue(
+      'slippage',
+      formattedValue.length ? formattedValue : defaultSlippage
+    )
   }
 
   const badgeColor = isSlippageOutsideRecommendedLimits
@@ -74,10 +78,9 @@ export const SlippageSettings: React.FC = () => {
   return (
     <SettingCardExpandable
       value={
-        <BadgedValue
-          badgeColor={badgeColor}
-          showBadge={!!badgeColor}
-        >{`${slippage}%`}</BadgedValue>
+        <BadgedValue badgeColor={badgeColor} showBadge={!!badgeColor}>
+          {slippage ? `${slippage}%` : t('settings.defaultSlippage')}
+        </BadgedValue>
       }
       icon={<Percent />}
       title={t('settings.slippage')}
@@ -99,7 +102,7 @@ export const SlippageSettings: React.FC = () => {
             onClick={handleDefaultClick}
             disableRipple
           >
-            {defaultSlippage}
+            {t('settings.defaultSlippage')}
           </SlippageDefaultButton>
           <SlippageCustomInput
             selected={defaultSlippage !== slippage && focused !== 'button'}

--- a/packages/widget/src/pages/SettingsPage/SlippageSettings/SlippageSettings.tsx
+++ b/packages/widget/src/pages/SettingsPage/SlippageSettings/SlippageSettings.tsx
@@ -49,11 +49,12 @@ export const SlippageSettings: React.FC = () => {
     (event) => {
       const { value } = event.target
 
-      setInputValue(formatSlippage(value, defaultValue.current, true))
+      const formattedValue = formatSlippage(value, defaultValue.current, true)
 
+      setInputValue(formattedValue)
       debouncedSetValue(
         'slippage',
-        formatSlippage(value || defaultSlippage, defaultValue.current)
+        formattedValue.length ? formattedValue : defaultSlippage
       )
     },
     [debouncedSetValue]
@@ -124,6 +125,7 @@ export const SlippageSettings: React.FC = () => {
             onFocus={handleInputFocus}
             value={inputValue}
             autoComplete="off"
+            onBlur={() => setFocused(undefined)}
           />
         </SettingsFieldSet>
         {isSlippageNotRecommended && (

--- a/packages/widget/src/pages/SettingsPage/SlippageSettings/SlippageSettings.tsx
+++ b/packages/widget/src/pages/SettingsPage/SlippageSettings/SlippageSettings.tsx
@@ -89,7 +89,7 @@ export const SlippageSettings: React.FC = () => {
     <SettingCardExpandable
       value={
         <BadgedValue badgeColor={badgeColor} showBadge={!!badgeColor}>
-          {slippage ? `${slippage}%` : t('settings.defaultSlippage')}
+          {slippage ? `${slippage}%` : t('button.auto')}
         </BadgedValue>
       }
       icon={<Percent />}
@@ -112,7 +112,7 @@ export const SlippageSettings: React.FC = () => {
             onClick={handleDefaultClick}
             disableRipple
           >
-            {t('settings.defaultSlippage')}
+            {t('button.auto')}
           </SlippageDefaultButton>
           <SlippageCustomInput
             selected={defaultSlippage !== slippage && focused !== 'button'}

--- a/packages/widget/src/stores/settings/useSettingsStore.ts
+++ b/packages/widget/src/stores/settings/useSettingsStore.ts
@@ -5,7 +5,7 @@ import type { SettingsProps, SettingsState } from './types.js'
 import { SettingsToolTypes } from './types.js'
 import { getStateValues } from './utils/getStateValues.js'
 
-export const defaultSlippage = '0.5'
+export const defaultSlippage = undefined
 
 export const defaultConfigurableSettings: Pick<
   SettingsState,

--- a/packages/widget/src/types/widget.ts
+++ b/packages/widget/src/types/widget.ts
@@ -144,7 +144,7 @@ export interface CalculateFeeParams {
   toAddress?: string
   fromAmount?: bigint
   toAmount?: bigint
-  slippage: number
+  slippage?: number
 }
 
 export interface WidgetFeeConfig {


### PR DESCRIPTION
closes [LF-11038](https://lifi.atlassian.net/browse/LF-11038)

This PR:
- adds an auto slippage as the default slippage with a value of `undefined`
- add a warning for when a user sets slippage to `< 0.1`

[LF-11038]: https://lifi.atlassian.net/browse/LF-11038?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ