### PR TITLE
fix: transaction history page virtualization

### DIFF
--- a/packages/widget/src/hooks/useListHeight.ts
+++ b/packages/widget/src/hooks/useListHeight.ts
@@ -1,17 +1,17 @@
 import { debounce, useTheme } from '@mui/material'
-import type { MutableRefObject } from 'react'
+import type { RefObject } from 'react'
 import { useLayoutEffect, useState } from 'react'
-import { useDefaultElementId } from '../../hooks/useDefaultElementId.js'
 import {
   ElementId,
   getAppContainer,
   getHeaderElement,
   getScrollableContainer,
-} from '../../utils/elements.js'
+} from '../utils/elements.js'
+import { useDefaultElementId } from './useDefaultElementId.js'
 
 const getContentHeight = (
   elementId: string,
-  listParentRef: MutableRefObject<HTMLUListElement | null>
+  listParentRef: RefObject<HTMLUListElement | HTMLDivElement | null>
 ) => {
   const containerElement = getScrollableContainer(elementId)
 
@@ -22,7 +22,7 @@ const getContentHeight = (
   let oldHeight: string | undefined = undefined
 
   // This covers the case where in full height flex mode when the browser height is reduced
-  // - this allows the virtualised token list to be made smaller
+  // - this allows a virtualised list to be made smaller
   if (listParentElement) {
     oldHeight = listParentElement.style.height
     listParentElement.style.height = '0'
@@ -38,7 +38,7 @@ const getContentHeight = (
   const { height: headerHeight } = headerElement.getBoundingClientRect()
 
   // This covers the case where in full height flex mode when the browser height is reduced the
-  // - this allows the virtualised token list to be set to minimum size
+  // - this allows a virtualised list to be set to minimum size
   if (listParentElement && oldHeight) {
     listParentElement.style.height = oldHeight
   }
@@ -47,18 +47,18 @@ const getContentHeight = (
 }
 
 interface UseContentHeightProps {
-  listParentRef: MutableRefObject<HTMLUListElement | null>
-  headerRef: MutableRefObject<HTMLElement | null>
+  listParentRef: RefObject<HTMLUListElement | HTMLDivElement | null>
+  headerRef?: RefObject<HTMLElement | null>
 }
 
-export const minTokenListHeight = 360
-export const minMobileTokenListHeight = 160
+export const defaultMinListHeight = 360
+export const minMobileListHeight = 160
 
 // NOTE: this hook is implicitly tied to the widget height functionality in the
 //   AppExpandedContainer, RelativeContainer and CssBaselineContainer components as defined in AppContainer.ts
 //   CSS changes in those components can have implications for the functionality in this hook
 
-export const useTokenListHeight = ({
+export const useListHeight = ({
   listParentRef,
   headerRef,
 }: UseContentHeightProps) => {
@@ -93,16 +93,16 @@ export const useTokenListHeight = ({
 
   const minListHeight =
     theme.container?.height === '100%'
-      ? minMobileTokenListHeight
-      : minTokenListHeight
+      ? minMobileListHeight
+      : defaultMinListHeight
 
-  const tokenListHeight = Math.max(
-    contentHeight - (headerRef.current?.offsetHeight ?? 0),
+  const listHeight = Math.max(
+    contentHeight - (headerRef?.current?.offsetHeight ?? 0),
     minListHeight
   )
 
   return {
     minListHeight,
-    tokenListHeight,
+    listHeight,
   }
 }

--- a/packages/widget/src/pages/SelectTokenPage/SelectTokenPage.tsx
+++ b/packages/widget/src/pages/SelectTokenPage/SelectTokenPage.tsx
@@ -6,20 +6,20 @@ import { ChainSelect } from '../../components/ChainSelect/ChainSelect.js'
 import { FullPageContainer } from '../../components/FullPageContainer.js'
 import { TokenList } from '../../components/TokenList/TokenList.js'
 import { useHeader } from '../../hooks/useHeader.js'
+import { useListHeight } from '../../hooks/useListHeight.js'
 import { useNavigateBack } from '../../hooks/useNavigateBack.js'
 import { useScrollableOverflowHidden } from '../../hooks/useScrollableContainer.js'
 import { useSwapOnly } from '../../hooks/useSwapOnly.js'
 import { useWidgetConfig } from '../../providers/WidgetProvider/WidgetProvider.js'
 import type { FormTypeProps } from '../../stores/form/types.js'
 import { SearchTokenInput } from './SearchTokenInput.js'
-import { useTokenListHeight } from './useTokenListHeight.js'
 
 export const SelectTokenPage: FC<FormTypeProps> = ({ formType }) => {
   useScrollableOverflowHidden()
   const { navigateBack } = useNavigateBack()
   const headerRef = useRef<HTMLElement>(null)
   const listParentRef = useRef<HTMLUListElement | null>(null)
-  const { tokenListHeight, minListHeight } = useTokenListHeight({
+  const { listHeight, minListHeight } = useListHeight({
     listParentRef,
     headerRef,
   })
@@ -64,7 +64,7 @@ export const SelectTokenPage: FC<FormTypeProps> = ({ formType }) => {
       >
         <TokenList
           parentRef={listParentRef}
-          height={tokenListHeight}
+          height={listHeight}
           onClick={navigateBack}
           formType={formType}
         />

--- a/packages/widget/src/pages/TransactionHistoryPage/TransactionHistoryPage.tsx
+++ b/packages/widget/src/pages/TransactionHistoryPage/TransactionHistoryPage.tsx
@@ -1,6 +1,7 @@
 import type { FullStatusData } from '@lifi/sdk'
-import { List } from '@mui/material'
+import { Box, List } from '@mui/material'
 import { useVirtualizer } from '@tanstack/react-virtual'
+import React from 'react'
 import { useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { PageContainer } from '../../components/PageContainer.js'
@@ -10,6 +11,8 @@ import { TransactionHistoryEmpty } from './TransactionHistoryEmpty.js'
 import { TransactionHistoryItem } from './TransactionHistoryItem.js'
 import { TransactionHistoryItemSkeleton } from './TransactionHistorySkeleton.js'
 import { minTransactionListHeight } from './constants.js'
+
+const MemoizedItem = React.memo(TransactionHistoryItem)
 
 export const TransactionHistoryPage: React.FC = () => {
   // Parent ref and useVirtualizer should be in one file to avoid blank page (0 virtual items) issue
@@ -21,7 +24,7 @@ export const TransactionHistoryPage: React.FC = () => {
 
   const { getVirtualItems, getTotalSize } = useVirtualizer({
     count: transactions.length,
-    overscan: 10,
+    overscan: 5,
     paddingEnd: 12,
     getScrollElement: () => parentRef.current,
     estimateSize: () => 186,
@@ -34,37 +37,39 @@ export const TransactionHistoryPage: React.FC = () => {
   }
 
   return (
-    <PageContainer
-      ref={parentRef}
-      style={{ height: minTransactionListHeight, overflow: 'auto' }}
-    >
-      {isLoading ? (
-        <List disablePadding>
-          {Array.from({ length: 3 }).map((_, index) => (
-            <TransactionHistoryItemSkeleton key={index} />
-          ))}
-        </List>
-      ) : (
-        <List
-          style={{
-            height: getTotalSize(),
-            width: '100%',
-            position: 'relative',
-          }}
-          disablePadding
-        >
-          {getVirtualItems().map((item) => {
-            const transaction = transactions[item.index]
-            return (
-              <TransactionHistoryItem
-                key={item.key}
-                start={item.start}
-                transaction={transaction}
-              />
-            )
-          })}
-        </List>
-      )}
+    <PageContainer>
+      <Box
+        ref={parentRef}
+        style={{ height: minTransactionListHeight, overflow: 'auto' }}
+      >
+        {isLoading ? (
+          <List disablePadding>
+            {Array.from({ length: 3 }).map((_, index) => (
+              <TransactionHistoryItemSkeleton key={index} />
+            ))}
+          </List>
+        ) : (
+          <List
+            style={{
+              height: `${getTotalSize()}px`,
+              width: '100%',
+              position: 'relative',
+            }}
+            disablePadding
+          >
+            {getVirtualItems().map((item) => {
+              const transaction = transactions[item.index]
+              return (
+                <MemoizedItem
+                  key={item.key}
+                  start={item.start}
+                  transaction={transaction}
+                />
+              )
+            })}
+          </List>
+        )}
+      </Box>
     </PageContainer>
   )
 }

--- a/packages/widget/src/pages/TransactionHistoryPage/TransactionHistoryPage.tsx
+++ b/packages/widget/src/pages/TransactionHistoryPage/TransactionHistoryPage.tsx
@@ -1,18 +1,18 @@
 import type { FullStatusData } from '@lifi/sdk'
 import { Box, List } from '@mui/material'
 import { useVirtualizer } from '@tanstack/react-virtual'
-import React from 'react'
+import type React from 'react'
 import { useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { PageContainer } from '../../components/PageContainer.js'
 import { useHeader } from '../../hooks/useHeader.js'
 import { useTransactionHistory } from '../../hooks/useTransactionHistory.js'
+
+import { useListHeight } from '../../hooks/useListHeight.js'
 import { TransactionHistoryEmpty } from './TransactionHistoryEmpty.js'
 import { TransactionHistoryItem } from './TransactionHistoryItem.js'
 import { TransactionHistoryItemSkeleton } from './TransactionHistorySkeleton.js'
 import { minTransactionListHeight } from './constants.js'
-
-const MemoizedItem = React.memo(TransactionHistoryItem)
 
 export const TransactionHistoryPage: React.FC = () => {
   // Parent ref and useVirtualizer should be in one file to avoid blank page (0 virtual items) issue
@@ -21,6 +21,10 @@ export const TransactionHistoryPage: React.FC = () => {
 
   const { t } = useTranslation()
   useHeader(t('header.transactionHistory'))
+
+  const { listHeight } = useListHeight({
+    listParentRef: parentRef,
+  })
 
   const { getVirtualItems, getTotalSize } = useVirtualizer({
     count: transactions.length,
@@ -37,38 +41,47 @@ export const TransactionHistoryPage: React.FC = () => {
   }
 
   return (
-    <PageContainer>
-      <Box
-        ref={parentRef}
-        style={{ height: minTransactionListHeight, overflow: 'auto' }}
-      >
-        {isLoading ? (
-          <List disablePadding>
-            {Array.from({ length: 3 }).map((_, index) => (
-              <TransactionHistoryItemSkeleton key={index} />
-            ))}
-          </List>
-        ) : (
-          <List
-            style={{
-              height: `${getTotalSize()}px`,
-              width: '100%',
-              position: 'relative',
-            }}
-            disablePadding
-          >
-            {getVirtualItems().map((item) => {
-              const transaction = transactions[item.index]
-              return (
-                <MemoizedItem
-                  key={item.key}
-                  start={item.start}
-                  transaction={transaction}
-                />
-              )
-            })}
-          </List>
-        )}
+    <PageContainer disableGutters>
+      <Box style={{ minHeight: minTransactionListHeight }}>
+        <Box
+          ref={parentRef}
+          style={{
+            height: listHeight,
+          }}
+          sx={{
+            overflow: 'auto',
+            paddingX: 4,
+          }}
+        >
+          {isLoading ? (
+            <List disablePadding>
+              {Array.from({ length: 3 }).map((_, index) => (
+                <TransactionHistoryItemSkeleton key={index} />
+              ))}
+            </List>
+          ) : (
+            <List
+              style={{
+                height: `${getTotalSize()}px`,
+              }}
+              sx={{
+                position: 'relative',
+              }}
+              disablePadding
+            >
+              {getVirtualItems().map((item) => {
+                const transaction = transactions[item.index]
+                return (
+                  <TransactionHistoryItem
+                    key={item.key}
+                    start={item.start}
+                    transaction={transaction}
+                  />
+                )
+              })}
+            </List>
+          )}
+        </Box>
       </Box>
     </PageContainer>
   )


### PR DESCRIPTION
closes [LF-10831](https://lifi.atlassian.net/browse/LF-10831?atlOrigin=eyJpIjoiYjc4N2JhMjg4ZDJiNDVhMzhmNWY3MTg5ZWI3OGQ2YTkiLCJwIjoiaiJ9)

This PR fixes the issues with virtualization of the transaction history page.

### Technical Details
The problem was caused by the `flex: 1` property of the `Container` element used to render parent of the virtualized list.
This broke `react-virtual`  as the `Container` grew to the size of the child list, the entire user transaction history was being rendered instead of the number of elements that could fit into the fixed container height.

I switched the parent element from a  `Container` out for a `Box` component to fix it.

Additionally, I applied the `useListHeight` hook on the list so the height grew dynamically for when we switch from compact to drawer mode.

https://github.com/user-attachments/assets/260e7767-c77c-42f2-96b7-e74917876063



