### PR TITLE
fix(timers): display hours and days section of timers, and update copy

### DIFF
--- a/packages/widget/src/components/Timer/RouteTimer.tsx
+++ b/packages/widget/src/components/Timer/RouteTimer.tsx
@@ -1,5 +1,7 @@
 import type { RouteExtended } from '@lifi/sdk'
+
 import { useStopwatch } from '../../hooks/timer/useStopwatch.js'
+import { useSettings } from '../../stores/settings/useSettings.js'
 import { formatTimer } from '../../utils/timer.js'
 import { TimerContent } from './TimerContent.js'
 
@@ -15,6 +17,8 @@ export const RouteTimer: React.FC<{
     offsetTimestamp: startTime,
   })
 
+  const { language } = useSettings(['language'])
+
   return (
     <TimerContent>
       {formatTimer({
@@ -22,6 +26,7 @@ export const RouteTimer: React.FC<{
         hours,
         seconds,
         minutes,
+        locale: language,
       })}
     </TimerContent>
   )

--- a/packages/widget/src/components/Timer/RouteTimer.tsx
+++ b/packages/widget/src/components/Timer/RouteTimer.tsx
@@ -1,5 +1,6 @@
 import type { RouteExtended } from '@lifi/sdk'
 import { useStopwatch } from '../../hooks/timer/useStopwatch.js'
+import { formatTimer } from '../../utils/timer.js'
 import { TimerContent } from './TimerContent.js'
 
 export const RouteTimer: React.FC<{
@@ -9,14 +10,19 @@ export const RouteTimer: React.FC<{
   const firstActiveProcess = firstActiveStep?.execution?.process.at(0)
 
   const startTime = new Date(firstActiveProcess?.startedAt ?? Date.now())
-  const { seconds, minutes } = useStopwatch({
+  const { seconds, minutes, days, hours } = useStopwatch({
     autoStart: true,
     offsetTimestamp: startTime,
   })
 
   return (
     <TimerContent>
-      {`${minutes}:${seconds < 10 ? `0${seconds}` : seconds}`}
+      {formatTimer({
+        days,
+        hours,
+        seconds,
+        minutes,
+      })}
     </TimerContent>
   )
 }

--- a/packages/widget/src/components/Timer/StepTimer.tsx
+++ b/packages/widget/src/components/Timer/StepTimer.tsx
@@ -2,6 +2,7 @@ import type { LiFiStepExtended } from '@lifi/sdk'
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useStopwatch } from '../../hooks/timer/useStopwatch.js'
+import { formatTimer } from '../../utils/timer.js'
 import { TimerContent } from './TimerContent.js'
 
 const getFirstExecutionProcess = (step: LiFiStepExtended) =>
@@ -23,10 +24,11 @@ export const StepTimer: React.FC<{
     () => !!getExecutionProcess(step)
   )
 
-  const { seconds, minutes, isRunning, pause, reset, start } = useStopwatch({
-    autoStart: true,
-    offsetTimestamp: getStartTimestamp(step),
-  })
+  const { seconds, minutes, days, hours, isRunning, pause, reset, start } =
+    useStopwatch({
+      autoStart: true,
+      offsetTimestamp: getStartTimestamp(step),
+    })
 
   useEffect(() => {
     const executionProcess = getExecutionProcess(step)
@@ -78,7 +80,12 @@ export const StepTimer: React.FC<{
 
   return (
     <TimerContent>
-      {`${minutes}:${seconds < 10 ? `0${seconds}` : seconds}`}
+      {formatTimer({
+        days,
+        hours,
+        minutes,
+        seconds,
+      })}
     </TimerContent>
   )
 }

--- a/packages/widget/src/components/Timer/StepTimer.tsx
+++ b/packages/widget/src/components/Timer/StepTimer.tsx
@@ -2,6 +2,7 @@ import type { LiFiStepExtended } from '@lifi/sdk'
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useStopwatch } from '../../hooks/timer/useStopwatch.js'
+import { useSettings } from '../../stores/settings/useSettings.js'
 import { formatTimer } from '../../utils/timer.js'
 import { TimerContent } from './TimerContent.js'
 
@@ -19,6 +20,7 @@ export const StepTimer: React.FC<{
   hideInProgress?: boolean
 }> = ({ step }) => {
   const { i18n } = useTranslation()
+  const { language } = useSettings(['language'])
 
   const [isExecutionStarted, setExecutionStarted] = useState(
     () => !!getExecutionProcess(step)
@@ -81,6 +83,7 @@ export const StepTimer: React.FC<{
   return (
     <TimerContent>
       {formatTimer({
+        locale: language,
         days,
         hours,
         minutes,

--- a/packages/widget/src/i18n/en.json
+++ b/packages/widget/src/i18n/en.json
@@ -186,7 +186,7 @@
   },
   "tooltip": {
     "deselectAll": "Deselect all",
-    "estimatedTime": "Estimated time to complete the swap or bridge transaction, excluding chain switching and token approval.",
+    "estimatedTime": "Time to complete the swap or bridge transaction, excluding chain switching and token approval.",
     "feeCollection": "The fee is applied to selected token pairs and ensures the best experience with {{tool}}.",
     "minReceived": "The estimated minimum amount may change until the swapping/bridging transaction is signed. For 2-step transfers, this applies until the second step transaction is signed.",
     "notFound": {

--- a/packages/widget/src/utils/timer.ts
+++ b/packages/widget/src/utils/timer.ts
@@ -1,0 +1,17 @@
+export const formatTimer = ({
+  days = 0,
+  hours = 0,
+  minutes = 0,
+  seconds = 0,
+}: {
+  days?: number
+  hours?: number
+  minutes?: number
+  seconds?: number
+}): string => {
+  const daysText = days > 0 ? (days < 10 ? `0${days}:` : `${days}:`) : ''
+  const hoursText = hours > 0 ? (hours < 10 ? `0${hours}:` : `${hours}:`) : ''
+  const minutesText = minutes < 10 ? `0${minutes}:` : `${minutes}:`
+  const secondsText = seconds < 10 ? `0${seconds} ` : `${seconds}`
+  return daysText + hoursText + minutesText + secondsText
+}

--- a/packages/widget/src/utils/timer.ts
+++ b/packages/widget/src/utils/timer.ts
@@ -3,15 +3,26 @@ export const formatTimer = ({
   hours = 0,
   minutes = 0,
   seconds = 0,
+  locale = 'en',
 }: {
   days?: number
   hours?: number
   minutes?: number
   seconds?: number
+  locale?: string
 }): string => {
-  const daysText = days > 0 ? (days < 10 ? `0${days}:` : `${days}:`) : ''
-  const hoursText = hours > 0 ? (hours < 10 ? `0${hours}:` : `${hours}:`) : ''
-  const minutesText = minutes < 10 ? `0${minutes}:` : `${minutes}:`
-  const secondsText = seconds < 10 ? `0${seconds} ` : `${seconds}`
-  return daysText + hoursText + minutesText + secondsText
+  if (typeof (Intl as any).DurationFormat === 'function') {
+    return new (Intl as any).DurationFormat(locale, {
+      style: 'digital',
+      hours: '2-digit',
+      hoursDisplay: 'auto',
+    }).format({
+      days,
+      hours,
+      minutes,
+      seconds,
+    })
+  }
+
+  return ''
 }


### PR DESCRIPTION
Closes [LF-12067](https://lifi.atlassian.net/browse/LF-12607)
Closes [LF-12616](https://lifi.atlassian.net/browse/LF-12616)

This PR:
- fixes the timer bug where only display the minutes and seconds parts of the timer, now we display days, hours, minutes and seconds
- Removes the timer tool tip text to reflect the change from a count up timer to countdown timer

<img width="358" alt="Screenshot 2025-03-03 at 11 48 17 AM" src="https://github.com/user-attachments/assets/7141d707-e8ac-4b02-b90c-99a34c255238" />


[LF-12067]: https://lifi.atlassian.net/browse/LF-12067?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LF-12616]: https://lifi.atlassian.net/browse/LF-12616?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ