### PR TITLE
chore: fixed incorrect regular expression

### DIFF
--- a/scripts/correctSourceMaps.js
+++ b/scripts/correctSourceMaps.js
@@ -4,7 +4,7 @@ const { stat: _stat, readFile, readdir, writeFile } = fsExtra
 
 const replaceInFile = async (filePath) => {
   let content = await readFile(filePath, 'utf8')
-  const regex = '../src/'
+  const regex = /..\/src\//g
   const replacement = ''
   content = content.replace(regex, replacement)
   await writeFile(filePath, content, 'utf8')


### PR DESCRIPTION
## Why was it implemented this way?  
The regular expression needed to properly match the `../src/` string. The original version wasn't functioning as expected because the `/` character wasn't correctly escaped, causing issues in pattern matching.

## Visual showcase (Screenshots or Videos)  
N/A (No visual changes were made)

## Checklist before requesting a review  
- [x] I have performed a self-review of my code.  
- [x] This pull request is focused and addresses a single problem.  
- [x] If this PR modifies the Widget API, I have updated the documentation (or submitted a change request on GitBook).