### PR TITLE
fix: enable _vcComponent

### DIFF
--- a/packages/widget/src/pages/TransactionPage/StatusBottomSheet.tsx
+++ b/packages/widget/src/pages/TransactionPage/StatusBottomSheet.tsx
@@ -83,6 +83,7 @@ export const StatusBottomSheetContent: React.FC<
     subvariantOptions,
     contractSecondaryComponent,
     contractCompactComponent,
+    feeConfig,
   } = useWidgetConfig()
   const { getChainById } = useAvailableChains()
 
@@ -248,6 +249,9 @@ export const StatusBottomSheetContent: React.FC<
     hasEnumFlag(status, RouteExecutionStatus.Done) &&
     (contractCompactComponent || contractSecondaryComponent)
 
+  const VcComponent =
+    status === RouteExecutionStatus.Done ? feeConfig?._vcComponent : undefined
+
   return (
     <Box
       ref={ref}
@@ -316,6 +320,7 @@ export const StatusBottomSheetContent: React.FC<
           {secondaryMessage}
         </Typography>
       ) : null}
+      {VcComponent ? <VcComponent route={route} /> : null}
       <Box sx={{ display: 'flex', marginTop: 2, gap: 1.5 }}>
         {hasEnumFlag(status, RouteExecutionStatus.Done) ? (
           <Button variant="text" onClick={handleSeeDetails} fullWidth>

--- a/packages/widget/src/types/widget.ts
+++ b/packages/widget/src/types/widget.ts
@@ -3,6 +3,7 @@ import type {
   ChainType,
   ContractCall,
   Order,
+  RouteExtended,
   RouteOptions,
   SDKConfig,
   StaticToken,
@@ -19,6 +20,7 @@ import type {
 import type { TypographyOptions } from '@mui/material/styles/createTypography.js'
 import type {
   CSSProperties,
+  FC,
   MutableRefObject,
   ReactNode,
   RefObject,
@@ -114,7 +116,7 @@ export interface WidgetWalletConfig {
    *
    * In partial mode, external wallet management will be used for "opt-out" providers,
    * while the internal management is applied for any remaining providers that do not opt out.
-   * This allows a flexible balance between the integrator’s custom wallet menu and the widget’s native wallet menu.
+   * This allows a flexible balance between the integrator's custom wallet menu and the widget's native wallet menu.
    * @default false
    */
   usePartialWalletManagement?: boolean
@@ -162,6 +164,10 @@ export interface WidgetFeeConfig {
    * @returns A promise that resolves to the calculated fee as a number (e.g., 0.03 represents a 3% fee)
    */
   calculateFee?(params: CalculateFeeParams): Promise<number | undefined>
+  /**
+   * @internal
+   */
+  _vcComponent: FC<{ route: RouteExtended }>
 }
 
 export interface ToAddress {


### PR DESCRIPTION
## Which Jira task is linked to this PR? 
https://lifi.atlassian.net/browse/LF-13299

## Why was it implemented this way?  
_It is used to re-enable the _vcComponent on the feeConfig to pass in custom React components to be shown after a transaction has been executed, as part of the drawer_  

## Visual showcase (Screenshots or Videos)  
![image](https://github.com/user-attachments/assets/11c1388a-92e9-4762-a11f-6b1d24aee03c)

## Checklist before requesting a review  
- [x] I have performed a self-review of my code.  
- [x] This pull request is focused and addresses a single problem.  
- [x] If this PR modifies the Widget API, I have updated the documentation (or submitted a change request on GitBook).  
