### PR TITLE
feat: add option to hide chain selection

### DIFF
--- a/packages/widget/src/components/SelectTokenButton/SelectTokenButton.tsx
+++ b/packages/widget/src/components/SelectTokenButton/SelectTokenButton.tsx
@@ -8,6 +8,7 @@ import { useWidgetConfig } from '../../providers/WidgetProvider/WidgetProvider.j
 import type { FormTypeProps } from '../../stores/form/types.js'
 import { FormKeyHelper } from '../../stores/form/types.js'
 import { useFieldValues } from '../../stores/form/useFieldValues.js'
+import { HiddenUI } from '../../types/widget.js'
 import { navigationRoutes } from '../../utils/navigationRoutes.js'
 import { AvatarBadgedDefault, AvatarBadgedSkeleton } from '../Avatar/Avatar.js'
 import { TokenAvatar } from '../Avatar/TokenAvatar.js'
@@ -25,7 +26,7 @@ export const SelectTokenButton: React.FC<
 > = ({ formType, compact }) => {
   const { t } = useTranslation()
   const navigate = useNavigate()
-  const { disabledUI, subvariant } = useWidgetConfig()
+  const { disabledUI, subvariant, hiddenUI } = useWidgetConfig()
   const swapOnly = useSwapOnly()
   const tokenKey = FormKeyHelper.getTokenKey(formType)
   const [chainId, tokenAddress] = useFieldValues(
@@ -50,7 +51,8 @@ export const SelectTokenButton: React.FC<
   const defaultPlaceholder =
     formType === 'to' && subvariant === 'refuel'
       ? t('main.selectChain')
-      : formType === 'to' && swapOnly
+      : (formType === 'to' && swapOnly) ||
+          hiddenUI?.includes(HiddenUI.ChainSelect)
         ? t('main.selectToken')
         : t('main.selectChainAndToken')
   const cardTitle: string =

--- a/packages/widget/src/pages/SelectTokenPage/SelectTokenPage.tsx
+++ b/packages/widget/src/pages/SelectTokenPage/SelectTokenPage.tsx
@@ -12,6 +12,7 @@ import { useScrollableOverflowHidden } from '../../hooks/useScrollableContainer.
 import { useSwapOnly } from '../../hooks/useSwapOnly.js'
 import { useWidgetConfig } from '../../providers/WidgetProvider/WidgetProvider.js'
 import type { FormTypeProps } from '../../stores/form/types.js'
+import { HiddenUI } from '../../types/widget.js'
 import { SearchTokenInput } from './SearchTokenInput.js'
 
 export const SelectTokenPage: FC<FormTypeProps> = ({ formType }) => {
@@ -26,7 +27,7 @@ export const SelectTokenPage: FC<FormTypeProps> = ({ formType }) => {
 
   const swapOnly = useSwapOnly()
 
-  const { subvariant } = useWidgetConfig()
+  const { subvariant, hiddenUI } = useWidgetConfig()
   const { t } = useTranslation()
   const title =
     formType === 'from'
@@ -37,7 +38,8 @@ export const SelectTokenPage: FC<FormTypeProps> = ({ formType }) => {
 
   useHeader(title)
 
-  const hideChainSelect = swapOnly && formType === 'to'
+  const hideChainSelect =
+    (swapOnly && formType === 'to') || hiddenUI?.includes(HiddenUI.ChainSelect)
 
   return (
     <FullPageContainer disableGutters>

--- a/packages/widget/src/types/widget.ts
+++ b/packages/widget/src/types/widget.ts
@@ -99,6 +99,7 @@ export enum HiddenUI {
   IntegratorStepDetails = 'integratorStepDetails',
   ReverseTokensButton = 'reverseTokensButton',
   RouteTokenDescription = 'routeTokenDescription',
+  ChainSelect = 'chainSelect',
 }
 export type HiddenUIType = `${HiddenUI}`
 


### PR DESCRIPTION
## Why was it implemented this way?  
Some integrations need to have a swap-only widget experience, so we added an option to hide the chain selection UI.

## Checklist before requesting a review  
- [x] I have performed a self-review of my code.  
- [x] This pull request is focused and addresses a single problem.  
- [x] If this PR modifies the Widget API, I have updated the documentation (or submitted a change request on GitBook).  
