### PR TITLE
fix: height of virtualized list in drawer

### DIFF
--- a/packages/widget-playground/src/components/DrawerControls/DesignControls/VariantControl.tsx
+++ b/packages/widget-playground/src/components/DrawerControls/DesignControls/VariantControl.tsx
@@ -22,12 +22,8 @@ export const VariantControl = () => {
           ...getCurrentConfigTheme()?.container,
           maxHeight: undefined,
           display: undefined,
-          height: undefined,
+          height: '100%',
         }
-
-        containerForDrawer.display = undefined
-        containerForDrawer.height = undefined
-        containerForDrawer.maxHeight = undefined
 
         setContainer(containerForDrawer)
         break

--- a/packages/widget/src/App.tsx
+++ b/packages/widget/src/App.tsx
@@ -13,8 +13,8 @@ export const App = forwardRef<WidgetDrawer, WidgetProps>((props, ref) => {
       config.theme = {
         ...config.theme,
         container: {
-          height: '100%',
           ...config.theme?.container,
+          height: '100%',
         },
       }
     }

--- a/packages/widget/src/App.tsx
+++ b/packages/widget/src/App.tsx
@@ -13,8 +13,8 @@ export const App = forwardRef<WidgetDrawer, WidgetProps>((props, ref) => {
       config.theme = {
         ...config.theme,
         container: {
-          ...config.theme?.container,
           height: '100%',
+          ...config.theme?.container,
         },
       }
     }

--- a/packages/widget/src/components/AppContainer.tsx
+++ b/packages/widget/src/components/AppContainer.tsx
@@ -84,12 +84,9 @@ const CssBaselineContainer = styled(ScopedCssBaseline, {
   shouldForwardProp: (prop) =>
     !['variant', 'paddingTopAdjustment', 'elementId'].includes(prop as string),
 })<CssBaselineContainerProps>(({ theme, variant, paddingTopAdjustment }) => {
-  const fullPageHeight =
-    variant === 'drawer' || theme.container?.display === 'flex'
-      ? 'none'
-      : theme.container?.maxHeight
-        ? theme.container?.maxHeight
-        : theme.container?.height || defaultMaxHeight
+  const fullContainerHeight = theme.container?.maxHeight
+    ? theme.container?.maxHeight
+    : theme.container?.height || defaultMaxHeight
   return {
     display: 'flex',
     flex: 1,
@@ -97,13 +94,16 @@ const CssBaselineContainer = styled(ScopedCssBaseline, {
     overflowX: 'clip',
     margin: 0,
     width: '100%',
-    maxHeight: fullPageHeight,
+    maxHeight:
+      variant === 'drawer' || theme.container?.display === 'flex'
+        ? 'none'
+        : fullContainerHeight,
     overflowY: 'auto',
     height: theme.container?.display === 'flex' ? 'auto' : '100%',
     paddingTop: paddingTopAdjustment,
     // This allows FullPageContainer.tsx to expand and fill the available vertical space in max height and default layout modes
     '&:has(.full-page-container)': {
-      height: fullPageHeight,
+      height: fullContainerHeight,
     },
   }
 })

--- a/packages/widget/src/components/AppContainer.tsx
+++ b/packages/widget/src/components/AppContainer.tsx
@@ -83,29 +83,30 @@ interface CssBaselineContainerProps {
 const CssBaselineContainer = styled(ScopedCssBaseline, {
   shouldForwardProp: (prop) =>
     !['variant', 'paddingTopAdjustment', 'elementId'].includes(prop as string),
-})<CssBaselineContainerProps>(({ theme, variant, paddingTopAdjustment }) => ({
-  display: 'flex',
-  flex: 1,
-  flexDirection: 'column',
-  overflowX: 'clip',
-  margin: 0,
-  width: '100%',
-  maxHeight:
+})<CssBaselineContainerProps>(({ theme, variant, paddingTopAdjustment }) => {
+  const fullPageHeight =
     variant === 'drawer' || theme.container?.display === 'flex'
       ? 'none'
       : theme.container?.maxHeight
         ? theme.container?.maxHeight
-        : theme.container?.height || defaultMaxHeight,
-  overflowY: 'auto',
-  height: theme.container?.display === 'flex' ? 'auto' : '100%',
-  paddingTop: paddingTopAdjustment,
-  // This allows FullPageContainer.tsx to expand and fill the available vertical space in max height and default layout modes
-  '&:has(.full-page-container)': {
-    height: theme.container?.maxHeight
-      ? theme.container?.maxHeight
-      : theme.container?.height || defaultMaxHeight,
-  },
-}))
+        : theme.container?.height || defaultMaxHeight
+  return {
+    display: 'flex',
+    flex: 1,
+    flexDirection: 'column',
+    overflowX: 'clip',
+    margin: 0,
+    width: '100%',
+    maxHeight: fullPageHeight,
+    overflowY: 'auto',
+    height: theme.container?.display === 'flex' ? 'auto' : '100%',
+    paddingTop: paddingTopAdjustment,
+    // This allows FullPageContainer.tsx to expand and fill the available vertical space in max height and default layout modes
+    '&:has(.full-page-container)': {
+      height: fullPageHeight,
+    },
+  }
+})
 
 export const FlexContainer = styled(Container)({
   display: 'flex',


### PR DESCRIPTION
## Which Jira task is linked to this PR?  
https://lifi.atlassian.net/browse/LF-13825

## Why was it implemented this way?  
_`maxHeight` is determined differently for drawer subvariant, and that condition for drawer was missing for `height` in `.full-page-container` (which corresponds to general `maxHeight`)_ 

## Visual showcase (Screenshots or Videos)  
_Observe the list in the drawer takes the whole available height._  
https://github.com/user-attachments/assets/a2c6c114-c462-4072-9c3a-c8c7da18c324

## Checklist before requesting a review  
- [x] I have performed a self-review of my code.  
- [x] This pull request is focused and addresses a single problem.  
- [x] If this PR modifies the Widget API, I have updated the documentation (or submitted a change request on GitBook).  
