### PR TITLE
fix: no widget render when using chain filters

### DIFF
--- a/packages/widget/src/providers/WalletProvider/SuiBaseProvider.tsx
+++ b/packages/widget/src/providers/WalletProvider/SuiBaseProvider.tsx
@@ -13,16 +13,10 @@ export const SuiBaseProvider: FC<PropsWithChildren> = ({ children }) => {
 
   const config = useMemo(() => {
     const sui = chains?.find((chain) => chain.id === ChainId.SUI)
-    if (sui) {
-      return createNetworkConfig({
-        mainnet: { url: sui.metamask?.rpcUrls[0] ?? getFullnodeUrl('mainnet') },
-      })
-    }
+    return createNetworkConfig({
+      mainnet: { url: sui?.metamask?.rpcUrls[0] ?? getFullnodeUrl('mainnet') },
+    })
   }, [chains])
-
-  if (!config?.networkConfig) {
-    return null
-  }
 
   return (
     <SuiClientProvider networks={config.networkConfig} defaultNetwork="mainnet">


### PR DESCRIPTION
## Which Jira task is linked to this PR?  
https://lifi.atlassian.net/browse/LF-13898

## Why was it implemented this way?  
_All ecosystem providers, regardless of the specified filter, wrap the widget as the `children` prop. The SUI provider was returning `null` when its chain type wasn’t in the list, which is why the widget wasn’t rendered. This has been replaced with a non-null provider that uses default props instead (when filtered out as a type)._ 

## Checklist before requesting a review  
- [x] I have performed a self-review of my code.  
- [x] This pull request is focused and addresses a single problem.  
- [x] If this PR modifies the Widget API, I have updated the documentation (or submitted a change request on GitBook).  
