### PR TITLE
fix(widget): hour display bug on safari

### DIFF
--- a/packages/widget/src/utils/timer.ts
+++ b/packages/widget/src/utils/timer.ts
@@ -22,6 +22,12 @@ export const formatTimer = ({
       minutes,
       seconds,
     })
+    // This handles a fixed bug with Webkit, and Safari
+    // https://github.com/WebKit/WebKit/pull/38357
+    // https://developer.apple.com/documentation/safari-release-notes/safari-18_4-release-notes#JavaScript
+    //
+    // Since most users haven't updated their browsers yet, they would have this issue
+    // it should be safe to remove the check after a while.
     return time.replace(/^:, /, '')
   }
 

--- a/packages/widget/src/utils/timer.ts
+++ b/packages/widget/src/utils/timer.ts
@@ -12,7 +12,7 @@ export const formatTimer = ({
   locale?: string
 }): string => {
   if (typeof (Intl as any).DurationFormat === 'function') {
-    return new (Intl as any).DurationFormat(locale, {
+    const time = new (Intl as any).DurationFormat(locale, {
       style: 'digital',
       hours: '2-digit',
       hoursDisplay: 'auto',
@@ -22,6 +22,7 @@ export const formatTimer = ({
       minutes,
       seconds,
     })
+    return time.replace(/^:, /, '')
   }
 
   return ''


### PR DESCRIPTION
## Which Jira task is linked to this PR?  
https://lifi.atlassian.net/browse/LF-13810

## Why was it implemented this way?  
This a [fixed bug with webkit](https://github.com/WebKit/WebKit/pull/38357). 
It was recently fixed in [a Safari update](https://developer.apple.com/documentation/safari-release-notes/safari-18_4-release-notes#JavaScript), but all users have not updated yet.

So, I went with a simple fix of just removing the invalid string if it appears.

## Visual showcase (Screenshots or Videos)  
<img width="439" alt="Screenshot 2025-05-28 at 1 43 16 PM" src="https://github.com/user-attachments/assets/2c69fc52-d761-4a3d-87c7-4421e2184c69" />

## Checklist before requesting a review  
- [x] I have performed a self-review of my code.  
- [x] This pull request is focused and addresses a single problem.  
- [x] If this PR modifies the Widget API, I have updated the documentation (or submitted a change request on GitBook).  
