### PR TITLE
fix: broken height when switching from drawer variant

### DIFF
--- a/packages/widget-playground/src/components/DrawerControls/DesignControls/VariantControl.tsx
+++ b/packages/widget-playground/src/components/DrawerControls/DesignControls/VariantControl.tsx
@@ -33,14 +33,9 @@ export const VariantControl = () => {
 
         const containerForWide = {
           ...getCurrentConfigTheme()?.container,
-        }
-
-        if (
-          containerForWide.display === 'flex' &&
-          containerForWide.height === '100%'
-        ) {
-          containerForWide.display = undefined
-          containerForWide.height = undefined
+          // Reset values for Default layout (since they are different for Drawer variant)
+          display: undefined,
+          height: undefined,
         }
 
         setContainer(containerForWide)


### PR DESCRIPTION
## Which Jira task is linked to this PR?  
https://lifi.atlassian.net/browse/LF-13924

## Why was it implemented this way?  
_The problem is that Drawer's Default Layout has height: 100%, whereas Wide's Default layout is supposed to have height: undefined. When switching between variants, the height was not reset. Now it is._  

## Visual showcase (Screenshots or Videos)  
https://github.com/user-attachments/assets/ae5f8b39-f2e8-4910-bb4a-d9f99bbfc48b

## Checklist before requesting a review  
- [x] I have performed a self-review of my code.  
- [x] This pull request is focused and addresses a single problem.  
- [x] If this PR modifies the Widget API, I have updated the documentation (or submitted a change request on GitBook).  
