### PR TITLE
fix: do not pass non-evm chains to wagmi

### DIFF
--- a/packages/wallet-management/src/syncWagmiConfig.ts
+++ b/packages/wallet-management/src/syncWagmiConfig.ts
@@ -1,26 +1,18 @@
-import type { ExtendedChain } from '@lifi/sdk'
 import type { Chain } from 'viem'
 import { mainnet } from 'viem/chains'
 import type { Config, CreateConnectorFn } from 'wagmi'
 import { reconnect } from 'wagmi/actions'
-import {
-  convertExtendedChain,
-  isExtendedChain,
-} from './utils/convertExtendedChain.js'
 
 export const syncWagmiConfig = async (
   wagmiConfig: Config,
   connectors: CreateConnectorFn[],
-  chains: (ExtendedChain | Chain)[]
+  chains: readonly [Chain, ...Chain[]]
 ) => {
-  const _chains = chains.map((chain) =>
-    isExtendedChain(chain) ? convertExtendedChain(chain) : chain
-  ) as [Chain, ...Chain[]]
-  const _mainnet = _chains.find((chain) => chain.id === mainnet.id)
+  const _mainnet = chains.find((chain) => chain.id === mainnet.id)
   if (_mainnet) {
     _mainnet.contracts = { ...mainnet.contracts, ..._mainnet.contracts }
   }
-  wagmiConfig._internal.chains.setState(_chains)
+  wagmiConfig._internal.chains.setState(chains)
   wagmiConfig._internal.connectors.setState(() =>
     [
       ...connectors,

--- a/packages/wallet-management/src/useSyncWagmiConfig.ts
+++ b/packages/wallet-management/src/useSyncWagmiConfig.ts
@@ -1,17 +1,33 @@
-import type { ExtendedChain } from '@lifi/sdk'
-import { useEffect } from 'react'
+import { ChainType, type ExtendedChain } from '@lifi/sdk'
+import { useEffect, useMemo } from 'react'
 import type { Chain } from 'viem'
 import type { Config, CreateConnectorFn } from 'wagmi'
 import { syncWagmiConfig } from './syncWagmiConfig.js'
+import {
+  convertExtendedChain,
+  isExtendedChain,
+} from './utils/convertExtendedChain.js'
 
 export const useSyncWagmiConfig = (
   wagmiConfig: Config,
   connectors: CreateConnectorFn[],
   chains?: (ExtendedChain | Chain)[]
 ) => {
+  const _chains = useMemo(
+    () =>
+      chains
+        ?.filter((chain) =>
+          isExtendedChain(chain) ? chain.chainType === ChainType.EVM : true
+        )
+        .map((chain) =>
+          isExtendedChain(chain) ? convertExtendedChain(chain) : chain
+        ) as [Chain, ...Chain[]],
+    [chains]
+  )
+
   useEffect(() => {
-    if (chains?.length) {
-      syncWagmiConfig(wagmiConfig, connectors, chains)
+    if (_chains?.length) {
+      syncWagmiConfig(wagmiConfig, connectors, _chains)
     }
-  }, [chains, connectors, wagmiConfig])
+  }, [_chains, connectors, wagmiConfig])
 }

--- a/packages/wallet-management/src/useSyncWagmiConfig.ts
+++ b/packages/wallet-management/src/useSyncWagmiConfig.ts
@@ -14,18 +14,14 @@ export const useSyncWagmiConfig = (
   chains?: (ExtendedChain | Chain)[]
 ) => {
   const _chains = useMemo(() => {
-    if (!chains) {
-      return undefined
-    }
     const mappedChains = chains
-      .map((chain) => {
-        if (!isExtendedChain(chain)) {
-          return chain
-        }
-        return chain.chainType === ChainType.EVM
-          ? convertExtendedChain(chain)
-          : undefined
-      })
+      ?.map((chain) =>
+        isExtendedChain(chain)
+          ? chain.chainType === ChainType.EVM
+            ? convertExtendedChain(chain)
+            : undefined
+          : chain
+      )
       .filter(Boolean) as [Chain, ...Chain[]]
     return mappedChains
   }, [chains])

--- a/packages/wallet-management/src/useSyncWagmiConfig.ts
+++ b/packages/wallet-management/src/useSyncWagmiConfig.ts
@@ -13,17 +13,22 @@ export const useSyncWagmiConfig = (
   connectors: CreateConnectorFn[],
   chains?: (ExtendedChain | Chain)[]
 ) => {
-  const _chains = useMemo(
-    () =>
-      chains
-        ?.filter((chain) =>
-          isExtendedChain(chain) ? chain.chainType === ChainType.EVM : true
-        )
-        .map((chain) =>
-          isExtendedChain(chain) ? convertExtendedChain(chain) : chain
-        ) as [Chain, ...Chain[]],
-    [chains]
-  )
+  const _chains = useMemo(() => {
+    if (!chains) {
+      return undefined
+    }
+    const mappedChains = chains
+      .map((chain) => {
+        if (!isExtendedChain(chain)) {
+          return chain
+        }
+        return chain.chainType === ChainType.EVM
+          ? convertExtendedChain(chain)
+          : undefined
+      })
+      .filter(Boolean) as [Chain, ...Chain[]]
+    return mappedChains
+  }, [chains])
 
   useEffect(() => {
     if (_chains?.length) {

--- a/packages/widget/src/providers/WalletProvider/EVMBaseProvider.tsx
+++ b/packages/widget/src/providers/WalletProvider/EVMBaseProvider.tsx
@@ -1,4 +1,3 @@
-import { ChainType } from '@lifi/sdk'
 import type { DefaultWagmiConfigResult } from '@lifi/wallet-management'
 import {
   createDefaultWagmiConfig,
@@ -29,8 +28,7 @@ export const EVMBaseProvider: FC<PropsWithChildren> = ({ children }) => {
     })
   }
 
-  const evmChains = chains?.filter((chain) => chain.chainType === ChainType.EVM)
-  useSyncWagmiConfig(wagmi.current.config, wagmi.current.connectors, evmChains)
+  useSyncWagmiConfig(wagmi.current.config, wagmi.current.connectors, chains)
 
   return (
     <WagmiProvider config={wagmi.current.config} reconnectOnMount={false}>

--- a/packages/widget/src/providers/WalletProvider/EVMBaseProvider.tsx
+++ b/packages/widget/src/providers/WalletProvider/EVMBaseProvider.tsx
@@ -1,3 +1,4 @@
+import { ChainType } from '@lifi/sdk'
 import type { DefaultWagmiConfigResult } from '@lifi/wallet-management'
 import {
   createDefaultWagmiConfig,
@@ -28,7 +29,8 @@ export const EVMBaseProvider: FC<PropsWithChildren> = ({ children }) => {
     })
   }
 
-  useSyncWagmiConfig(wagmi.current.config, wagmi.current.connectors, chains)
+  const evmChains = chains?.filter((chain) => chain.chainType === ChainType.EVM)
+  useSyncWagmiConfig(wagmi.current.config, wagmi.current.connectors, evmChains)
 
   return (
     <WagmiProvider config={wagmi.current.config} reconnectOnMount={false}>


### PR DESCRIPTION
## Which Jira task is linked to this PR?  
https://lifi.atlassian.net/browse/LF-13928

## Why was it implemented this way?  
_The original problem: Metamask SDK (triggered on onboarding, when Metamask wallet is not installed) fails to load, since Wagmi's connect() receives SUI's chain id (which is > max integer) via its config (and this is uncaught exception during casting). Wagmi works neither with SUI nor with Bitcoin, they are not supposed to be passed to Wagmi's config (useAvailableChains, etc.).  

## Visual showcase (Screenshots or Videos)  
![image](https://github.com/user-attachments/assets/7377ab85-a63d-4be7-8692-702f01b5ff71)

## Checklist before requesting a review  
- [x] I have performed a self-review of my code.  
- [x] This pull request is focused and addresses a single problem.  
- [x] If this PR modifies the Widget API, I have updated the documentation (or submitted a change request on GitBook).  
