### PR TITLE
fix: adjust show all transactions button styles

### DIFF
--- a/packages/widget/src/components/ActiveTransactions/ActiveTransactions.style.ts
+++ b/packages/widget/src/components/ActiveTransactions/ActiveTransactions.style.ts
@@ -1,5 +1,4 @@
 import {
-  Button,
   ListItem as MuiListItem,
   ListItemButton as MuiListItemButton,
   listItemSecondaryActionClasses,
@@ -19,20 +18,11 @@ export const ListItemButton = styled(MuiListItemButton)(({ theme }) => ({
 export const ListItem = styled(MuiListItem, {
   shouldForwardProp: (prop) => prop !== 'disableRipple',
 })(({ theme }) => ({
-  padding: theme.spacing(0, 2),
+  padding: theme.spacing(0),
   [`.${listItemSecondaryActionClasses.root}`]: {
     right: theme.spacing(3),
   },
   '&:hover': {
     cursor: 'pointer',
   },
-}))
-
-export const ShowAllButton = styled(Button)(({ theme }) => ({
-  background: 'none',
-  '&:hover': {
-    background: 'none',
-  },
-  padding: theme.spacing(0.75, 2),
-  fontSize: '0.875rem',
 }))

--- a/packages/widget/src/components/ActiveTransactions/ActiveTransactions.tsx
+++ b/packages/widget/src/components/ActiveTransactions/ActiveTransactions.tsx
@@ -4,10 +4,10 @@ import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
 import { useExecutingRoutesIds } from '../../stores/routes/useExecutingRoutesIds.js'
 import { navigationRoutes } from '../../utils/navigationRoutes.js'
+import { ButtonTertiary } from '../ButtonTertiary.js'
 import { Card } from '../Card/Card.js'
 import { CardTitle } from '../Card/CardTitle.js'
 import { ActiveTransactionItem } from './ActiveTransactionItem.js'
-import { ShowAllButton } from './ActiveTransactions.style.js'
 
 export const ActiveTransactions: React.FC<CardProps> = (props) => {
   const { t } = useTranslation()
@@ -27,22 +27,21 @@ export const ActiveTransactions: React.FC<CardProps> = (props) => {
   return (
     <Card type="selected" selectionColor="secondary" {...props}>
       <CardTitle>{t('header.activeTransactions')}</CardTitle>
-      <Stack
-        spacing={1.5}
-        sx={{
-          pt: 1.5,
-          pb: hasShowAll ? 0 : 2,
-        }}
-      >
+      <Stack spacing={1.5} sx={{ m: 2 }}>
         {executingRoutes.slice(0, 2).map((routeId) => (
           <ActiveTransactionItem key={routeId} routeId={routeId} dense />
         ))}
+        {hasShowAll ? (
+          <ButtonTertiary
+            variant="text"
+            onClick={handleShowAll}
+            disableRipple
+            fullWidth
+          >
+            {t('button.showAll')}
+          </ButtonTertiary>
+        ) : null}
       </Stack>
-      {hasShowAll ? (
-        <ShowAllButton disableRipple fullWidth onClick={handleShowAll}>
-          {t('button.showAll')}
-        </ShowAllButton>
-      ) : null}
     </Card>
   )
 }


### PR DESCRIPTION
## Which Jira task is linked to this PR?  
https://lifi.atlassian.net/browse/LF-13926

## Visual showcase (Screenshots or Videos)  
(transaction route data was mocked before passing to `ActiveTransactionItem`, that's why looks a bit unrealistic. please see the margins, paddings, etc. of the button)
https://github.com/user-attachments/assets/1968be58-05df-41eb-b40d-ea7db9300c80

## Checklist before requesting a review  
- [x] I have performed a self-review of my code.  
- [x] This pull request is focused and addresses a single problem.  
- [x] If this PR modifies the Widget API, I have updated the documentation (or submitted a change request on GitBook).  
