### PR TITLE
feat: implement separate token filtering for from/to lists

### DIFF
--- a/packages/widget/src/components/TokenList/TokenList.tsx
+++ b/packages/widget/src/components/TokenList/TokenList.tsx
@@ -42,7 +42,7 @@ export const TokenList: FC<TokenListProps> = ({
     isBalanceLoading,
     featuredTokens,
     popularTokens,
-  } = useTokenBalances(selectedChainId)
+  } = useTokenBalances(selectedChainId, formType)
 
   let filteredTokens = (tokensWithBalance ?? chainTokens ?? []) as TokenAmount[]
   const normalizedSearchFilter = tokenSearchFilter?.replaceAll('$', '')
@@ -70,7 +70,12 @@ export const TokenList: FC<TokenListProps> = ({
     !!selectedChainId
 
   const { token: searchedToken, isLoading: isSearchedTokenLoading } =
-    useTokenSearch(selectedChainId, normalizedSearchFilter, tokenSearchEnabled)
+    useTokenSearch(
+      selectedChainId,
+      normalizedSearchFilter,
+      tokenSearchEnabled,
+      formType
+    )
 
   const isLoading =
     isTokensLoading ||

--- a/packages/widget/src/hooks/useTokenBalances.ts
+++ b/packages/widget/src/hooks/useTokenBalances.ts
@@ -2,14 +2,20 @@ import { getTokenBalances } from '@lifi/sdk'
 import { useAccount } from '@lifi/wallet-management'
 import { useQuery } from '@tanstack/react-query'
 import { formatUnits } from 'viem'
+import type { FormType } from '../stores/form/types.js'
 import type { TokenAmount } from '../types/token.js'
 import { useTokens } from './useTokens.js'
 
 const defaultRefetchInterval = 32_000
 
-export const useTokenBalances = (selectedChainId?: number) => {
-  const { tokens, featuredTokens, popularTokens, chain, isLoading } =
-    useTokens(selectedChainId)
+export const useTokenBalances = (
+  selectedChainId?: number,
+  formType?: FormType
+) => {
+  const { tokens, featuredTokens, popularTokens, chain, isLoading } = useTokens(
+    selectedChainId,
+    formType
+  )
   const { account } = useAccount({ chainType: chain?.chainType })
 
   const isBalanceLoadingEnabled =

--- a/packages/widget/src/hooks/useTokenSearch.ts
+++ b/packages/widget/src/hooks/useTokenSearch.ts
@@ -1,13 +1,18 @@
 import { type ChainId, type TokensResponse, getToken } from '@lifi/sdk'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { useWidgetConfig } from '../providers/WidgetProvider/WidgetProvider.js'
+import type { FormType } from '../stores/form/types.js'
 import type { TokenAmount } from '../types/token.js'
 
 export const useTokenSearch = (
   chainId?: number,
   tokenQuery?: string,
-  enabled?: boolean
+  enabled?: boolean,
+  formType?: FormType
 ) => {
   const queryClient = useQueryClient()
+  const { tokens: configTokens } = useWidgetConfig()
+
   const { data, isLoading } = useQuery({
     queryKey: ['token-search', chainId, tokenQuery],
     queryFn: async ({ queryKey: [, chainId, tokenQuery], signal }) => {
@@ -16,6 +21,21 @@ export const useTokenSearch = (
       })
 
       if (token) {
+        // Check if the token is in the denied list for the current form type
+        const formTypeConfig = formType ? configTokens?.[formType] : undefined
+        const globalConfig = configTokens
+
+        const deniedTokenAddressesSet = new Set(
+          [...(formTypeConfig?.deny || []), ...(globalConfig?.deny || [])]
+            .filter((t) => t.chainId === chainId)
+            .map((t) => t.address)
+        )
+
+        // If the token is in the denied list, return null
+        if (deniedTokenAddressesSet.has(token.address)) {
+          return undefined
+        }
+
         queryClient.setQueriesData<TokensResponse>(
           { queryKey: ['tokens'] },
           (data) => {

--- a/packages/widget/src/types/widget.ts
+++ b/packages/widget/src/types/widget.ts
@@ -216,6 +216,8 @@ export type WidgetTokens = {
   featured?: StaticToken[]
   include?: Token[]
   popular?: StaticToken[]
+  from?: AllowDeny<BaseToken>
+  to?: AllowDeny<BaseToken>
 } & AllowDeny<BaseToken>
 
 export type WidgetLanguages = {


### PR DESCRIPTION
- Add formType-aware token filtering in useTokenSearch hook
- Allow denying tokens specifically for from or to lists independently
- Update TokenList to pass formType for context-aware filtering
- Prevent denied tokens from appearing in search results based on list type