### PR TITLE
fix: update height setting for restricted heights

### DIFF
--- a/packages/widget/src/components/AppContainer.tsx
+++ b/packages/widget/src/components/AppContainer.tsx
@@ -63,9 +63,6 @@ export const RelativeContainer = styled(Box, {
       theme.container?.display === 'flex' && !theme.container?.height
         ? '100%'
         : maxHeight,
-    '&:has(.long-list)': {
-      maxHeight: theme.container?.maxHeight || defaultMaxHeight,
-    },
     variants: [
       {
         props: {
@@ -119,7 +116,12 @@ const CssBaselineContainer = styled(ScopedCssBaseline, {
         defaultMaxHeight,
     },
     '&:has(.long-list)': {
-      maxHeight: theme.container?.maxHeight || defaultMaxHeight,
+      maxHeight:
+        theme.container?.maxHeight ||
+        (theme.container?.height !== 'fit-content'
+          ? theme.container?.height
+          : undefined) ||
+        defaultMaxHeight,
     },
   }
 })


### PR DESCRIPTION
## Which Jira task is linked to this PR?  

## Why was it implemented this way?  
Currently, pages with long lists (tokens, chains, etc.) get restricted by maxHeight, and if we specify maxHeight (e.g. on playground), it is fine. But "full height" and "restricted height" specify only height (but not maxHeight), and then the maxHeight resolves to default (686px), and the pages end up cut. This PR adds the missing condition to use height as maxHeight.
Fit-content for maxHeight should not be applied to long-lists - it should be either default or specified maxHeight.
Also removed &:has(.long-list) from RelativeContainer, as it wraps CssBaselineContainer, and the later one already defines the heights - excessive.

## Visual showcase (Screenshots or Videos)  
_If applicable, attach screenshots, GIFs, or videos to showcase the functionality, UI changes, or bug fixes._  

## Checklist before requesting a review  
- [ ] I have performed a self-review of my code.  
- [ ] This pull request is focused and addresses a single problem.  
- [ ] If this PR modifies the Widget API, I have updated the documentation (or submitted a change request on GitBook).  
