### PR TITLE
Move NOT_PROCESSABLE_REFUND_NEEDED and UNKNOWN_ERROR substatus message to failed status

### DIFF
--- a/packages/widget/src/hooks/useProcessMessage.ts
+++ b/packages/widget/src/hooks/useProcessMessage.ts
@@ -116,11 +116,8 @@ const processSubstatusMessages: Record<
     REFUNDED: (t) => t('main.process.receivingChain.partial'),
   },
   FAILED: {
-    // TODO: should be moved to failed status
-    // NOT_PROCESSABLE_REFUND_NEEDED:
-    //   'The transfer cannot be completed successfully. A refund operation is required.',
-    // UNKNOWN_ERROR:
-    //   'An unexpected error occurred. Please seek assistance in the LI.FI discord server.',
+    NOT_PROCESSABLE_REFUND_NEEDED: (t) => t('main.process.receivingChain.notProcessableRefundNeeded'),
+    UNKNOWN_ERROR: (t) => t('main.process.receivingChain.unknownError'),
   },
   INVALID: {},
   NOT_FOUND: {},


### PR DESCRIPTION
Implemented the TODO by moving the NOT_PROCESSABLE_REFUND_NEEDED and UNKNOWN_ERROR substatus messages to the FAILED status in the processSubstatusMessages object. This change ensures that these error cases are handled appropriately according to the process status, following the existing project structure and translation approach. No other code was modified.