### PR TITLE
fix(widget): remove always on reconnection for bitcoin wallets

### DIFF
--- a/packages/widget/src/providers/WalletProvider/UTXOBaseProvider.tsx
+++ b/packages/widget/src/providers/WalletProvider/UTXOBaseProvider.tsx
@@ -1,5 +1,5 @@
 import type { Config } from '@bigmi/client'
-import { BigmiProvider, useReconnect } from '@bigmi/react'
+import { BigmiProvider } from '@bigmi/react'
 import type { DefaultBigmiConfigResult } from '@lifi/wallet-management'
 import { createDefaultBigmiConfig } from '@lifi/wallet-management'
 import { type FC, type PropsWithChildren, useRef } from 'react'
@@ -15,8 +15,6 @@ export const UTXOBaseProvider: FC<PropsWithChildren> = ({ children }) => {
       },
     })
   }
-
-  useReconnect(bigmi.current.config as Config)
 
   return (
     <BigmiProvider


### PR DESCRIPTION
## Which Jira task is linked to this PR?  

## Why was it implemented this way?  
There is no need for the `useReconnect` hook as the `reconnectOnMount` param on provider component has been configured to `false`

## Visual showcase (Screenshots or Videos)  
_If applicable, attach screenshots, GIFs, or videos to showcase the functionality, UI changes, or bug fixes._  

## Checklist before requesting a review  
- [x] I have performed a self-review of my code.  
- [ ] This pull request is focused and addresses a single problem.  
- [ ] If this PR modifies the Widget API, I have updated the documentation (or submitted a change request on GitBook).  
