### PR TITLE
fix: adjust themed status color for processes and bottom sheet

### DIFF
--- a/packages/widget/src/components/Step/CircularProgress.style.tsx
+++ b/packages/widget/src/components/Step/CircularProgress.style.tsx
@@ -24,29 +24,37 @@ const getStatusColor = (
     case 'FAILED':
       return `rgba(${theme.vars.palette.error.mainChannel} / 0.12)`
     default:
-      return theme.vars.palette.grey[theme.palette.mode === 'light' ? 300 : 800]
+      return null
   }
 }
 
 export const CircularIcon = styled(Box, {
   shouldForwardProp: (prop: string) => !['status', 'substatus'].includes(prop),
 })<{ status?: ProcessStatus; substatus?: Substatus }>(
-  ({ theme, status, substatus }) => ({
-    backgroundColor: ['ACTION_REQUIRED', 'DONE', 'FAILED'].includes(status!)
-      ? getStatusColor(theme, status, substatus)
-      : theme.vars.palette.background.paper,
-    borderStyle: 'solid',
-    borderColor: getStatusColor(theme, status, substatus),
-    borderWidth: !['ACTION_REQUIRED', 'DONE', 'FAILED'].includes(status!)
-      ? 3
-      : 0,
-    display: 'grid',
-    position: 'relative',
-    placeItems: 'center',
-    width: 40,
-    height: 40,
-    borderRadius: '50%',
-  })
+  ({ theme, status, substatus }) => {
+    const statusColor = getStatusColor(theme, status, substatus)
+    const isSpecialStatus = ['ACTION_REQUIRED', 'DONE', 'FAILED'].includes(
+      status!
+    )
+
+    return {
+      backgroundColor: isSpecialStatus
+        ? statusColor!
+        : theme.vars.palette.background.paper,
+      borderStyle: 'solid',
+      borderColor: statusColor || theme.vars.palette.grey[300],
+      borderWidth: !isSpecialStatus ? 3 : 0,
+      display: 'grid',
+      position: 'relative',
+      placeItems: 'center',
+      width: 40,
+      height: 40,
+      borderRadius: '50%',
+      ...theme.applyStyles('dark', {
+        borderColor: statusColor || theme.vars.palette.grey[800],
+      }),
+    }
+  }
 )
 
 const circleAnimation = keyframes`

--- a/packages/widget/src/pages/TransactionPage/StatusBottomSheet.style.tsx
+++ b/packages/widget/src/pages/TransactionPage/StatusBottomSheet.style.tsx
@@ -10,13 +10,15 @@ const getStatusColor = (status: StatusColor, theme: Theme) => {
       return {
         color: theme.vars.palette.success.mainChannel,
         alpha: 0.12,
-        darken: 0,
+        lightDarken: 0,
+        darkDarken: 0,
       }
     case RouteExecutionStatus.Failed:
       return {
         color: theme.vars.palette.error.mainChannel,
         alpha: 0.12,
-        darken: 0,
+        lightDarken: 0,
+        darkDarken: 0,
       }
     case RouteExecutionStatus.Done | RouteExecutionStatus.Partial:
     case RouteExecutionStatus.Done | RouteExecutionStatus.Refunded:
@@ -24,13 +26,15 @@ const getStatusColor = (status: StatusColor, theme: Theme) => {
       return {
         color: theme.vars.palette.warning.mainChannel,
         alpha: 0.48,
-        darken: theme.palette.mode === 'light' ? 0.32 : 0,
+        lightDarken: 0.32,
+        darkDarken: 0,
       }
     default:
       return {
         color: theme.vars.palette.primary.mainChannel,
         alpha: 0.12,
-        darken: 0,
+        lightDarken: 0,
+        darkDarken: 0,
       }
   }
 }
@@ -44,13 +48,10 @@ export const CenterContainer = styled(Box)(() => ({
 export const IconCircle = styled(Box, {
   shouldForwardProp: (prop) => prop !== 'status',
 })<{ status: StatusColor }>(({ theme, status }) => {
-  const {
-    color,
-    alpha: alphaValue,
-    darken: darkenValue,
-  } = getStatusColor(status, theme)
+  const statusConfig = getStatusColor(status, theme)
+
   return {
-    backgroundColor: `rgba(${color} / ${alphaValue})`,
+    backgroundColor: `rgba(${statusConfig.color} / ${statusConfig.alpha})`,
     borderRadius: '50%',
     width: 72,
     height: 72,
@@ -58,9 +59,16 @@ export const IconCircle = styled(Box, {
     position: 'relative',
     placeItems: 'center',
     '& > svg': {
-      color: `color-mix(in srgb, rgb(${color}) ${(1 - darkenValue) * 100}%, black)`,
+      color: `color-mix(in srgb, rgb(${statusConfig.color}) ${(1 - statusConfig.lightDarken) * 100}%, black)`,
       width: 36,
       height: 36,
     },
+    ...theme.applyStyles('dark', {
+      '& > svg': {
+        color: `color-mix(in srgb, rgb(${statusConfig.color}) ${(1 - statusConfig.darkDarken) * 100}%, black)`,
+        width: 36,
+        height: 36,
+      },
+    }),
   }
 })


### PR DESCRIPTION
## Why was it implemented this way?  
During the migration to MUI vars we left some components not migrated.

## Visual showcase (Screenshots or Videos)  
<img width="457" alt="image" src="https://github.com/user-attachments/assets/b789a2e3-6b19-4e12-940e-ea9829a2f5c1" />

## Checklist before requesting a review  
- [x] I have performed a self-review of my code.  
- [x] This pull request is focused and addresses a single problem.  
- [x] If this PR modifies the Widget API, I have updated the documentation (or submitted a change request on GitBook).  
