### PR TITLE
fix: allow-deny - do not filter out tokens from unspecified chains

### DIFF
--- a/packages/widget/src/hooks/useTokenSearch.ts
+++ b/packages/widget/src/hooks/useTokenSearch.ts
@@ -3,7 +3,7 @@ import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { useWidgetConfig } from '../providers/WidgetProvider/WidgetProvider.js'
 import type { FormType } from '../stores/form/types.js'
 import type { TokenAmount } from '../types/token.js'
-import { isTokenAllowed } from '../utils/item.js'
+import { filterConfigTokensByChain, isTokenAllowed } from '../utils/item.js'
 import { getQueryKey } from '../utils/queries.js'
 
 export const useTokenSearch = (
@@ -23,8 +23,15 @@ export const useTokenSearch = (
       })
 
       if (token) {
+        // Filter config tokens by chain before checking if token is allowed
+        const filteredConfigTokens = filterConfigTokensByChain(
+          configTokens,
+          formType,
+          token.chainId
+        )
+
         // Return undefined if the token is denied
-        if (!isTokenAllowed(token, configTokens, formType)) {
+        if (!isTokenAllowed(token, filteredConfigTokens, formType)) {
           return undefined
         }
 

--- a/packages/widget/src/hooks/useTokens.ts
+++ b/packages/widget/src/hooks/useTokens.ts
@@ -4,7 +4,7 @@ import { useMemo } from 'react'
 import { useWidgetConfig } from '../providers/WidgetProvider/WidgetProvider.js'
 import type { FormType } from '../stores/form/types.js'
 import type { TokenAmount } from '../types/token.js'
-import { isTokenAllowed } from '../utils/item.js'
+import { filterConfigTokensByChain, isTokenAllowed } from '../utils/item.js'
 import { getQueryKey } from '../utils/queries.js'
 import { useChains } from './useChains.js'
 
@@ -47,11 +47,18 @@ export const useTokens = (selectedChainId?: number, formType?: FormType) => {
       filteredTokens = [...includedTokens, ...filteredTokens]
     }
 
+    // Filter config tokens by chain before checking if token is allowed
+    const filteredConfigTokens = filterConfigTokensByChain(
+      configTokens,
+      formType,
+      selectedChainId
+    )
+
     // Get the appropriate allow/deny lists based on formType
     filteredTokens = filteredTokens.filter(
       (token) =>
         token.chainId === selectedChainId &&
-        isTokenAllowed(token, configTokens, formType)
+        isTokenAllowed(token, filteredConfigTokens, formType)
     )
 
     const filteredTokensMap = new Map(

--- a/packages/widget/src/utils/item.ts
+++ b/packages/widget/src/utils/item.ts
@@ -24,10 +24,32 @@ export const isTokenAllowed = (
   configTokens: WidgetTokens | undefined,
   formType: FormType | undefined
 ) => {
+  if (!configTokens) {
+    return true
+  }
+
+  const filteredByChainConfig = {
+    ...configTokens,
+    allow: configTokens.allow?.filter((t) => t.chainId === token.chainId) ?? [],
+    deny: configTokens.deny?.filter((t) => t.chainId === token.chainId) ?? [],
+    ...(formType && {
+      [formType]: {
+        allow:
+          configTokens[formType]?.allow?.filter(
+            (t) => t.chainId === token.chainId
+          ) ?? [],
+        deny:
+          configTokens[formType]?.deny?.filter(
+            (t) => t.chainId === token.chainId
+          ) ?? [],
+      },
+    }),
+  }
+
   return (
-    isItemAllowed(token, configTokens, tokenIncludes) &&
+    isItemAllowed(token, filteredByChainConfig, tokenIncludes) &&
     (formType
-      ? isItemAllowed(token, configTokens?.[formType], tokenIncludes)
+      ? isItemAllowed(token, filteredByChainConfig?.[formType], tokenIncludes)
       : true)
   )
 }

--- a/packages/widget/src/utils/item.ts
+++ b/packages/widget/src/utils/item.ts
@@ -24,32 +24,36 @@ export const isTokenAllowed = (
   configTokens: WidgetTokens | undefined,
   formType: FormType | undefined
 ) => {
+  return (
+    isItemAllowed(token, configTokens, tokenIncludes) &&
+    (formType
+      ? isItemAllowed(token, configTokens?.[formType], tokenIncludes)
+      : true)
+  )
+}
+
+export const filterConfigTokensByChain = (
+  configTokens: WidgetTokens | undefined,
+  formType: FormType | undefined,
+  chainId: number
+) => {
   if (!configTokens) {
-    return true
+    return configTokens
   }
 
-  const filteredByChainConfig = {
+  return {
     ...configTokens,
-    allow: configTokens.allow?.filter((t) => t.chainId === token.chainId) ?? [],
-    deny: configTokens.deny?.filter((t) => t.chainId === token.chainId) ?? [],
+    allow: configTokens.allow?.filter((t) => t.chainId === chainId) ?? [],
+    deny: configTokens.deny?.filter((t) => t.chainId === chainId) ?? [],
     ...(formType && {
       [formType]: {
         allow:
-          configTokens[formType]?.allow?.filter(
-            (t) => t.chainId === token.chainId
-          ) ?? [],
+          configTokens[formType]?.allow?.filter((t) => t.chainId === chainId) ??
+          [],
         deny:
-          configTokens[formType]?.deny?.filter(
-            (t) => t.chainId === token.chainId
-          ) ?? [],
+          configTokens[formType]?.deny?.filter((t) => t.chainId === chainId) ??
+          [],
       },
     }),
   }
-
-  return (
-    isItemAllowed(token, filteredByChainConfig, tokenIncludes) &&
-    (formType
-      ? isItemAllowed(token, filteredByChainConfig?.[formType], tokenIncludes)
-      : true)
-  )
 }


### PR DESCRIPTION
## Why was it implemented this way?  
If `allow` list of tokens does not include tokens of chainId=X, all the tokens on chain with chainId=X should be allowed. The same applied to deny. Filtering by chainId is currently missing - the current filter considers only rules for specified chains and filters out the rest. 
This fix filters config by chains before allowing allow-deny rules.

## Checklist before requesting a review  
- [x] I have performed a self-review of my code.  
- [x] This pull request is focused and addresses a single problem. 