### PR TITLE
fix: add defaultUI option for navigation header title wrapping

### DIFF
--- a/packages/widget-playground/src/defaultWidgetConfig.ts
+++ b/packages/widget-playground/src/defaultWidgetConfig.ts
@@ -38,6 +38,9 @@ export const widgetBaseConfig: WidgetConfig = {
   // hiddenUI: ['poweredBy', 'language', 'appearance', 'drawerButton', 'toAddress'],
   // disabledUI: ['toAddress', 'fromAmount', 'toToken', 'fromToken'],
   // requiredUI: ['toAddress'],
+  // defaultUI: {
+  //   navigationHeaderTitleNoWrap: false,
+  // },
   // slippage: 0.003,
   // walletConfig: {
   //   usePartialWalletManagement: true,

--- a/packages/widget/src/components/Header/NavigationHeader.tsx
+++ b/packages/widget/src/components/Header/NavigationHeader.tsx
@@ -19,7 +19,7 @@ import { TransactionHistoryButton } from './TransactionHistoryButton.js'
 import { SplitWalletMenuButton } from './WalletHeader.js'
 
 export const NavigationHeader: React.FC = () => {
-  const { subvariant, hiddenUI, variant } = useWidgetConfig()
+  const { subvariant, hiddenUI, variant, defaultUI } = useWidgetConfig()
   const { navigateBack } = useNavigateBack()
   const { account } = useAccount()
   const { element, title } = useHeaderStore((state) => state)
@@ -50,7 +50,7 @@ export const NavigationHeader: React.FC = () => {
         ) : (
           <Typography
             align={hasPath ? 'center' : 'left'}
-            noWrap
+            noWrap={defaultUI?.navigationHeaderTitleNoWrap ?? true}
             sx={{
               fontSize: hasPath ? 18 : 24,
               fontWeight: '700',

--- a/packages/widget/src/types/widget.ts
+++ b/packages/widget/src/types/widget.ts
@@ -117,6 +117,7 @@ export type RequiredUIType = `${RequiredUI}`
 
 export type DefaultUI = {
   transactionDetailsExpanded?: boolean
+  navigationHeaderTitleNoWrap?: boolean
 }
 
 export interface WidgetWalletConfig {


### PR DESCRIPTION
## Which Jira task is linked to this PR?  

## Why was it implemented this way?  
Allows for two lines for the main page title.

## Visual showcase (Screenshots or Videos)  
<img width="449" alt="image" src="https://github.com/user-attachments/assets/dcda5564-e70c-4a17-9853-e18bad345669" />

## Checklist before requesting a review  
- [x] I have performed a self-review of my code.  
- [x] This pull request is focused and addresses a single problem.  
- [ ] If this PR modifies the Widget API, I have updated the documentation (or submitted a change request on GitBook).  
