### PR TITLE
feat: replace enable chain sidebar checkbox with switch

### DIFF
--- a/packages/widget-playground/src/components/DrawerControls/DesignControls/SubvariantControl.tsx
+++ b/packages/widget-playground/src/components/DrawerControls/DesignControls/SubvariantControl.tsx
@@ -1,5 +1,4 @@
 import type { WidgetSubvariant } from '@lifi/widget'
-import { Checkbox, FormControlLabel } from '@mui/material'
 import type { SyntheticEvent } from 'react'
 import { useConfigActions } from '../../../store/widgetConfig/useConfigActions'
 import {
@@ -7,8 +6,9 @@ import {
   useConfigSubvariantOptions,
   useConfigVariant,
 } from '../../../store/widgetConfig/useConfigValues'
-import { CardValue } from '../../Card/Card.style'
+import { CardRowContainer, CardValue } from '../../Card/Card.style'
 import { ExpandableCard } from '../../Card/ExpandableCard'
+import { Switch } from '../../Switch'
 import { Tab, Tabs } from '../../Tabs/Tabs.style'
 
 export const SubvariantControl = () => {
@@ -50,16 +50,14 @@ export const SubvariantControl = () => {
         <Tab label="Refuel" value={'refuel'} disableRipple />
       </Tabs>
       {variant === 'wide' && (
-        <FormControlLabel
-          control={
-            <Checkbox
-              checked={subvariantOptions?.wide?.enableChainSidebar ?? true}
-              onChange={handleEnableChainSidebarChange}
-            />
-          }
-          label="Enable chain sidebar"
-          sx={{ padding: 1 }}
-        />
+        <CardRowContainer sx={{ paddingLeft: 1, paddingRight: 1 }}>
+          Enable chain sidebar
+          <Switch
+            checked={subvariantOptions?.wide?.enableChainSidebar ?? true}
+            onChange={handleEnableChainSidebarChange}
+            aria-label="Enable chain sidebar"
+          />
+        </CardRowContainer>
       )}
     </ExpandableCard>
   )


### PR DESCRIPTION
## Why was it implemented this way?  
Design request: replace checkbox with switch, for consistency

## Visual showcase (Screenshots or Videos)  
<img width="365" height="188" alt="Screenshot 2025-07-16 at 14 45 56" src="https://github.com/user-attachments/assets/4b28f8f0-d2b5-4bf2-b82e-89d29ab8d92e" />

## Checklist before requesting a review  
- [x] I have performed a self-review of my code.  
- [x] This pull request is focused and addresses a single problem.   
