### PR TITLE
fix(format): wrap hashes in messages for better display

### DIFF
--- a/packages/widget/src/components/Step/StepProcess.tsx
+++ b/packages/widget/src/components/Step/StepProcess.tsx
@@ -10,7 +10,7 @@ export const StepProcess: React.FC<{
   step: LiFiStep
   process: Process
 }> = ({ step, process }) => {
-  const { title, message } = useProcessMessage(step, process)
+  const { title, messageWrapped } = useProcessMessage(step, process)
   const { getTransactionLink } = useExplorer()
 
   return (
@@ -60,7 +60,7 @@ export const StepProcess: React.FC<{
           </CardIconButton>
         ) : null}
       </Box>
-      {message ? (
+      {messageWrapped ? (
         <Typography
           sx={{
             ml: 7,
@@ -69,7 +69,7 @@ export const StepProcess: React.FC<{
             color: 'text.secondary',
           }}
         >
-          {message}
+          {messageWrapped}
         </Typography>
       ) : null}
     </Box>

--- a/packages/widget/src/hooks/useProcessMessage.ts
+++ b/packages/widget/src/hooks/useProcessMessage.ts
@@ -12,7 +12,7 @@ import type { TFunction } from 'i18next'
 import { useTranslation } from 'react-i18next'
 import { useWidgetConfig } from '../providers/WidgetProvider/WidgetProvider.js'
 import type { SubvariantOptions, WidgetSubvariant } from '../types/widget.js'
-import { formatTokenAmount } from '../utils/format.js'
+import { formatTokenAmount, wrapHashes } from '../utils/format.js'
 import { useAvailableChains } from './useAvailableChains.js'
 
 export const useProcessMessage = (step?: LiFiStep, process?: Process) => {
@@ -136,6 +136,7 @@ export function getProcessMessage(
 ): {
   title?: string
   message?: string
+  messageWrapped?: string
 } {
   if (process.error && process.status === 'FAILED') {
     const getDefaultErrorMessage = (key?: string) =>
@@ -249,7 +250,8 @@ export function getProcessMessage(
         }
         break
     }
-    return { title, message }
+    const messageWrapped = wrapHashes(message)
+    return { title, message, messageWrapped }
   }
   const title =
     processSubstatusMessages[process.status as StatusMessage]?.[

--- a/packages/widget/src/pages/TransactionPage/StatusBottomSheet.tsx
+++ b/packages/widget/src/pages/TransactionPage/StatusBottomSheet.tsx
@@ -186,7 +186,7 @@ export const StatusBottomSheetContent: React.FC<
       }
       const processMessage = getProcessMessage(t, getChainById, step, process)
       title = processMessage.title
-      failedMessage = processMessage.message
+      failedMessage = processMessage.messageWrapped
       handlePrimaryButton = handleClose
       break
     }

--- a/packages/widget/src/utils/format.ts
+++ b/packages/widget/src/utils/format.ts
@@ -114,3 +114,22 @@ export function formatDuration(seconds: number, locale: string): string {
     unitDisplay: 'narrow',
   })
 }
+
+export function wrapHashes(text: string): string {
+  const shouldWrap = (text: string): boolean => {
+    const cleanText = text.replace(/[.,!?;:]$/, '')
+    const hashPattern = /^[A-Za-z0-9]{32,}$/
+    return hashPattern.test(cleanText)
+  }
+  return text
+    .split(' ')
+    .map((word) => {
+      if (shouldWrap(word)) {
+        return word.length > 12
+          ? `${word.slice(0, 8)}...${word.slice(-4)}`
+          : word
+      }
+      return word
+    })
+    .join(' ')
+}


### PR DESCRIPTION
## Which Jira task is linked to this PR?  
https://lifi.atlassian.net/browse/LF-8638

## Why was it implemented this way?  
The solution I explored was checking messages for hashes, and wrapping with middle elipses, that way, the full error message is visible, but the hashes don't overflow.

## Visual showcase (Screenshots or Videos)  

<img width="464" height="702" alt="Screenshot 2025-07-17 at 4 37 08 PM" src="https://github.com/user-attachments/assets/d7a8178a-832e-4f77-b623-76a6057169be" />
<img width="461" height="689" alt="Screenshot 2025-07-17 at 4 36 59 PM" src="https://github.com/user-attachments/assets/0c569df9-6eca-40e5-807c-da9e90193a34" />

## Checklist before requesting a review  
- [ ] I have performed a self-review of my code.  
- [ ] This pull request is focused and addresses a single problem.  
- [ ] If this PR modifies the Widget API, I have updated the documentation (or submitted a change request on GitBook).  
