### PR TITLE
fix: enableChainSidebar true by default only for playground

### DIFF
--- a/packages/widget-playground/src/components/DrawerControls/DesignControls/SubvariantControl.tsx
+++ b/packages/widget-playground/src/components/DrawerControls/DesignControls/SubvariantControl.tsx
@@ -53,7 +53,7 @@ export const SubvariantControl = () => {
         <CardRowContainer sx={{ paddingLeft: 1, paddingRight: 1 }}>
           Enable chain sidebar
           <Switch
-            checked={subvariantOptions?.wide?.enableChainSidebar ?? true}
+            checked={!!subvariantOptions?.wide?.enableChainSidebar}
             onChange={handleEnableChainSidebarChange}
             aria-label="Enable chain sidebar"
           />

--- a/packages/widget-playground/src/defaultWidgetConfig.ts
+++ b/packages/widget-playground/src/defaultWidgetConfig.ts
@@ -30,6 +30,11 @@ export const widgetBaseConfig: WidgetConfig = {
   // ],
   variant: 'wide',
   // subvariant: 'split',
+  subvariantOptions: {
+    wide: {
+      enableChainSidebar: true,
+    },
+  },
   integrator: 'li.fi-playground',
   // fee: 0.01,
   // useRecommendedRoute: true,

--- a/packages/widget/src/hooks/useHasChainExpansion.ts
+++ b/packages/widget/src/hooks/useHasChainExpansion.ts
@@ -13,7 +13,7 @@ export const useHasChainExpansion = () => {
       expansionType === ExpansionType.ToChain) &&
     !(swapOnly && expansionType === ExpansionType.ToChain) &&
     !hiddenUI?.includes(HiddenUI.ChainSelect) &&
-    (subvariantOptions?.wide?.enableChainSidebar ?? true)
+    !!subvariantOptions?.wide?.enableChainSidebar
 
   return [withChainExpansion, expansionType] as const
 }

--- a/packages/widget/src/pages/SelectTokenPage/SelectTokenPage.tsx
+++ b/packages/widget/src/pages/SelectTokenPage/SelectTokenPage.tsx
@@ -37,7 +37,7 @@ export const SelectTokenPage: FC<FormTypeProps> = ({ formType }) => {
   useHeader(title)
 
   const hideChainSelect =
-    (wideVariant && (subvariantOptions?.wide?.enableChainSidebar ?? true)) ||
+    (wideVariant && subvariantOptions?.wide?.enableChainSidebar) ||
     (swapOnly && formType === 'to') ||
     hiddenUI?.includes(HiddenUI.ChainSelect)
 


### PR DESCRIPTION
## Why was it implemented this way?  
`enableChainSidebar` should be enabled by default only on playground, for others it should be disabled, unless explicitly enabled

## Checklist before requesting a review  
- [x] I have performed a self-review of my code.  
- [x] This pull request is focused and addresses a single problem.  
- [ ] Docs update