### PR TITLE
fix: remove outer routes container causing unnecessary scrolling

### DIFF
--- a/packages/widget/src/components/Routes/RoutesContent.tsx
+++ b/packages/widget/src/components/Routes/RoutesContent.tsx
@@ -15,11 +15,7 @@ import { ProgressToNextUpdate } from '../ProgressToNextUpdate.js'
 import { RouteCard } from '../RouteCard/RouteCard.js'
 import { RouteCardSkeleton } from '../RouteCard/RouteCardSkeleton.js'
 import { RouteNotFoundCard } from '../RouteCard/RouteNotFoundCard.js'
-import {
-  Container,
-  Header,
-  ScrollableContainer,
-} from './RoutesExpanded.style.js'
+import { Container, Header } from './RoutesExpanded.style.js'
 
 interface RoutesContentProps {
   routes: Route[]
@@ -81,57 +77,55 @@ export const RoutesContent = ({
 
   return (
     <Container enableColorScheme minimumHeight={isLoading}>
-      <ScrollableContainer>
-        <Header>
-          <Typography
-            noWrap
-            sx={{
-              fontSize: 18,
-              fontWeight: '700',
-              flex: 1,
-            }}
-          >
-            {title}
-          </Typography>
-          <ProgressToNextUpdate
-            updatedAt={dataUpdatedAt || Date.now()}
-            timeToUpdate={refetchTime}
-            isLoading={isFetching}
-            onClick={() => refetch()}
-            sx={{ marginRight: -1 }}
-          />
-        </Header>
-        <PageContainer>
-          <Stack
-            direction="column"
-            spacing={2}
-            sx={{
-              flex: 1,
-              paddingBottom: 3,
-            }}
-          >
-            {routeNotFound ? (
-              <RouteNotFoundCard />
-            ) : (isLoading || isFetching) && !routes?.length ? (
-              Array.from({ length: 3 }).map((_, index) => (
-                <RouteCardSkeleton key={index} />
-              ))
-            ) : (
-              routes?.map((route: Route, index: number) => (
-                <RouteCard
-                  key={index}
-                  route={route}
-                  onClick={
-                    allowInteraction ? () => handleRouteClick(route) : undefined
-                  }
-                  active={index === 0}
-                  expanded={routes?.length === 1}
-                />
-              ))
-            )}
-          </Stack>
-        </PageContainer>
-      </ScrollableContainer>
+      <Header>
+        <Typography
+          noWrap
+          sx={{
+            fontSize: 18,
+            fontWeight: '700',
+            flex: 1,
+          }}
+        >
+          {title}
+        </Typography>
+        <ProgressToNextUpdate
+          updatedAt={dataUpdatedAt || Date.now()}
+          timeToUpdate={refetchTime}
+          isLoading={isFetching}
+          onClick={() => refetch()}
+          sx={{ marginRight: -1 }}
+        />
+      </Header>
+      <PageContainer>
+        <Stack
+          direction="column"
+          spacing={2}
+          sx={{
+            flex: 1,
+            paddingBottom: 3,
+          }}
+        >
+          {routeNotFound ? (
+            <RouteNotFoundCard />
+          ) : (isLoading || isFetching) && !routes?.length ? (
+            Array.from({ length: 3 }).map((_, index) => (
+              <RouteCardSkeleton key={index} />
+            ))
+          ) : (
+            routes?.map((route: Route, index: number) => (
+              <RouteCard
+                key={index}
+                route={route}
+                onClick={
+                  allowInteraction ? () => handleRouteClick(route) : undefined
+                }
+                active={index === 0}
+                expanded={routes?.length === 1}
+              />
+            ))
+          )}
+        </Stack>
+      </PageContainer>
     </Container>
   )
 }

--- a/packages/widget/src/components/Routes/RoutesExpanded.style.ts
+++ b/packages/widget/src/components/Routes/RoutesExpanded.style.ts
@@ -4,15 +4,6 @@ import { defaultMaxHeight } from '../../config/constants.js'
 
 export const routesExpansionWidth = '436px'
 
-export const ScrollableContainer = styled(Box)({
-  overflowY: 'auto',
-  height: '100%',
-  width: '100%',
-  flex: 1,
-  display: 'flex',
-  flexDirection: 'column',
-})
-
 interface ContainerProps extends ScopedCssBaselineProps {
   minimumHeight: boolean
 }


### PR DESCRIPTION
## Which Jira task is linked to this PR? 
https://lifi.atlassian.net/browse/LF-14585 

## Why was it implemented this way?  
The problem is that occasionally the whole routes expansion starts to scroll together with the sticky part. Currently there are two scrollable containers around the scrollable area, one is redundant. This should _possibly_ resolve the issue.

## Visual showcase (Screenshots or Videos)  
Bug:
https://github.com/user-attachments/assets/70ed9379-b1da-4ef8-8868-76fd2d018fc3

## Checklist before requesting a review  
- [x] I have performed a self-review of my code.  
- [x] This pull request is focused and addresses a single problem.  
