### PR TITLE
fix: use tokens hash as cache key

### DIFF
--- a/packages/widget/src/hooks/useTokenBalances.ts
+++ b/packages/widget/src/hooks/useTokenBalances.ts
@@ -3,21 +3,15 @@ import { useAccount } from '@lifi/wallet-management'
 import { useQuery } from '@tanstack/react-query'
 import { formatUnits } from 'viem'
 import { useWidgetConfig } from '../providers/WidgetProvider/WidgetProvider.js'
-import type { FormType } from '../stores/form/types.js'
 import type { TokenAmount } from '../types/token.js'
 import { getQueryKey } from '../utils/queries.js'
 import { useTokens } from './useTokens.js'
 
 const defaultRefetchInterval = 32_000
 
-export const useTokenBalances = (
-  selectedChainId?: number,
-  formType?: FormType
-) => {
-  const { tokens, featuredTokens, popularTokens, chain, isLoading } = useTokens(
-    selectedChainId,
-    formType
-  )
+export const useTokenBalances = (selectedChainId?: number) => {
+  const { tokens, featuredTokens, popularTokens, chain, isLoading } =
+    useTokens(selectedChainId)
   const { account } = useAccount({ chainType: chain?.chainType })
   const { keyPrefix } = useWidgetConfig()
 
@@ -36,7 +30,6 @@ export const useTokenBalances = (
       account.address,
       selectedChainId,
       tokens?.length,
-      formType,
     ],
     queryFn: async ({ queryKey: [, accountAddress] }) => {
       const tokensWithBalance: TokenAmount[] = await getTokenBalances(

--- a/packages/widget/src/hooks/useTokens.ts
+++ b/packages/widget/src/hooks/useTokens.ts
@@ -1,14 +1,12 @@
-import { type BaseToken, ChainType, getTokens } from '@lifi/sdk'
+import { ChainType, getTokens } from '@lifi/sdk'
 import { useQuery } from '@tanstack/react-query'
 import { useMemo } from 'react'
 import { useWidgetConfig } from '../providers/WidgetProvider/WidgetProvider.js'
-import type { FormType } from '../stores/form/types.js'
 import type { TokenAmount } from '../types/token.js'
-import { getConfigItemSets, isFormItemAllowed } from '../utils/item.js'
 import { getQueryKey } from '../utils/queries.js'
 import { useChains } from './useChains.js'
 
-export const useTokens = (selectedChainId?: number, formType?: FormType) => {
+export const useTokens = (selectedChainId?: number) => {
   const { tokens: configTokens, keyPrefix } = useWidgetConfig()
   const { data, isLoading } = useQuery({
     queryKey: [getQueryKey('tokens', keyPrefix)],
@@ -46,30 +44,6 @@ export const useTokens = (selectedChainId?: number, formType?: FormType) => {
     if (includedTokens?.length) {
       filteredTokens = [...includedTokens, ...filteredTokens]
     }
-
-    // Filter config tokens by chain before checking if token is allowed
-    const filteredConfigTokens = getConfigItemSets(
-      configTokens,
-      (tokens: BaseToken[]) =>
-        new Set(
-          tokens
-            .filter((t) => t.chainId === selectedChainId)
-            .map((t) => t.address)
-        ),
-      formType
-    )
-
-    // Get the appropriate allow/deny lists based on formType
-    filteredTokens = filteredTokens.filter(
-      (token) =>
-        token.chainId === selectedChainId &&
-        isFormItemAllowed(
-          token,
-          filteredConfigTokens,
-          formType,
-          (t) => t.address
-        )
-    )
 
     const filteredTokensMap = new Map(
       filteredTokens.map((token) => [token.address, token])
@@ -123,7 +97,6 @@ export const useTokens = (selectedChainId?: number, formType?: FormType) => {
     getChainById,
     isSupportedChainsLoading,
     selectedChainId,
-    formType,
   ])
 
   return {


### PR DESCRIPTION
## Why was it implemented this way?  
**Problem:** Using `formType` and `tokens.length` as cache keys for `token-balances` endpoint causes the balances to be refetched every time we navigate to from or to list, even when `tokens` are the same. At the same time, if we remove `formType` from cache keys and leave only `tokens.length`, when the from and to lists of tokens are different on the same chain (e.g. because of from-to allow-deny config), the token balances are not updated. Therefore, we need a better way to define whether the tokens list changed to refetch balances.

This PR moves `formType`-based check after fetching balances to exclude `formType` as a cache key

## Checklist before requesting a review  
- [x] I have performed a self-review of my code.  
- [x] This pull request is focused and addresses a single problem.  