### PR TITLE
fix: delay clearing token details not to have empty state on transition

### DIFF
--- a/packages/widget/src/components/TokenList/TokenDetailsSheet.tsx
+++ b/packages/widget/src/components/TokenList/TokenDetailsSheet.tsx
@@ -13,9 +13,6 @@ export const TokenDetailsSheet = forwardRef<
   TokenDetailsSheetProps
 >(({ chainId }, ref) => {
   const bottomSheetRef = useRef<BottomSheetBase>(null)
-  const timeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(
-    undefined
-  )
   const [tokenAddress, setTokenAddress] = useState<string | undefined>(
     undefined
   )
@@ -32,15 +29,6 @@ export const TokenDetailsSheet = forwardRef<
       },
       close: () => {
         bottomSheetRef.current?.close()
-        if (timeoutRef.current) {
-          clearTimeout(timeoutRef.current)
-        }
-        // Delay clearing state until after bottom sheet animation completes
-        timeoutRef.current = setTimeout(() => {
-          setTokenAddress(undefined)
-          setWithoutContractAddress(false)
-          timeoutRef.current = undefined
-        }, 200)
       },
     }),
     []

--- a/packages/widget/src/components/TokenList/TokenDetailsSheet.tsx
+++ b/packages/widget/src/components/TokenList/TokenDetailsSheet.tsx
@@ -13,6 +13,9 @@ export const TokenDetailsSheet = forwardRef<
   TokenDetailsSheetProps
 >(({ chainId }, ref) => {
   const bottomSheetRef = useRef<BottomSheetBase>(null)
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(
+    undefined
+  )
   const [tokenAddress, setTokenAddress] = useState<string | undefined>(
     undefined
   )
@@ -29,8 +32,15 @@ export const TokenDetailsSheet = forwardRef<
       },
       close: () => {
         bottomSheetRef.current?.close()
-        setTokenAddress(undefined)
-        setWithoutContractAddress(false)
+        if (timeoutRef.current) {
+          clearTimeout(timeoutRef.current)
+        }
+        // Delay clearing state until after bottom sheet animation completes
+        timeoutRef.current = setTimeout(() => {
+          setTokenAddress(undefined)
+          setWithoutContractAddress(false)
+          timeoutRef.current = undefined
+        }, 200)
       },
     }),
     []


### PR DESCRIPTION
## Why was it implemented this way?  
Currently, when token details drawer closes, the state gets cleared immediately, meaning that on closing transition there can be noticed an empty state. This PR removes clearing the state.

## Visual showcase (Screenshots or Videos)  
Before:
<img width="482" height="477" alt="Screenshot 2025-07-28 at 11 26 16" src="https://github.com/user-attachments/assets/922f06d0-74dc-4a01-ba5c-be0179d982f8" />
https://github.com/user-attachments/assets/7655bf82-fdcc-4f90-990d-21e6ac4b488a
After:
https://github.com/user-attachments/assets/490c3638-74af-4976-ad5c-8e757e959ca2

## Checklist before requesting a review  
- [x] I have performed a self-review of my code.  
- [x] This pull request is focused and addresses a single problem.  
