### PR TITLE
fix: avoid undefined query data in gas sufficiency

### DIFF
--- a/packages/widget/src/hooks/useGasSufficiency.ts
+++ b/packages/widget/src/hooks/useGasSufficiency.ts
@@ -57,7 +57,7 @@ export const useGasSufficiency = (route?: RouteExtended) => {
       EVMAccount.chainType
     )
 
-  const { data: insufficientGas, isLoading } = useQuery({
+  const { data: insufficientGas, isLoading } = useQuery<GasSufficiency[]>({
     queryKey: [
       getQueryKey('gas-sufficiency-check', keyPrefix),
       relevantAccountsQueryKey,
@@ -66,7 +66,7 @@ export const useGasSufficiency = (route?: RouteExtended) => {
     ] as const,
     queryFn: async () => {
       if (!route) {
-        return
+        return []
       }
 
       // Filter out steps that are relayer steps or have primaryType 'Permit' or 'Order'
@@ -80,7 +80,7 @@ export const useGasSufficiency = (route?: RouteExtended) => {
 
       // If all steps are filtered out, we don't need to check for gas sufficiency
       if (!filteredSteps.length) {
-        return
+        return []
       }
 
       // We assume that LI.Fuel protocol always refuels the destination chain
@@ -163,7 +163,7 @@ export const useGasSufficiency = (route?: RouteExtended) => {
         .flatMap((result) => result.value)
 
       if (!tokenBalances?.length) {
-        return
+        return []
       }
 
       Object.keys(gasCosts).forEach((chainId) => {


### PR DESCRIPTION
## Which Jira task is linked to this PR?  
https://lifi.atlassian.net/browse/LF-14731

## Why was it implemented this way? 

We started seeing
```
Query data cannot be undefined. Please make sure to return a value other
than undefined from your query function.
Affected query key: ["jumper-custom-widget-gas-sufficiency-check","0xdCD411fC40447b08bF52498Dd6f8282EE6e76Fae","d98fccfb-bed2-43fc-94b8-...]
```

I made sure the function returns empty arrays instead of undefineds, and typed the `useQuery` generics to catch future bugs at compile time.

## Checklist before requesting a review  
- [x] I have performed a self-review of my code.  
- [x] This pull request is focused and addresses a single problem.  
- [x] If this PR modifies the Widget API, I have updated the documentation (or submitted a change request on GitBook).  
