### PR TITLE
fix: correct typos in wallet ID and price impact interface

### DIFF
--- a/packages/wallet-management/src/utils/isWalletInstalled.ts
+++ b/packages/wallet-management/src/utils/isWalletInstalled.ts
@@ -21,7 +21,7 @@ export const isWalletInstalled = (id: string): boolean => {
       )
     case 'app.phantom.bitcoin':
       return anyWindow.phantom?.bitcoin?.isPhantom
-    case 'com.okx.wallet.bitcoin':
+    case 'com.okex.wallet.bitcoin':
       return anyWindow.okxwallet?.bitcoin?.isOkxWallet
     case 'XverseProviders.BitcoinProvider':
       return anyWindow.XverseProviders?.BitcoinProvider


### PR DESCRIPTION
- Fixed wallet ID typo: 'com.okex.wallet.bitcoin' → 'com.okx.wallet.bitcoin' in isWalletInstalled.ts.
- Fixed interface name typo: GetPriceImpractProps → GetPriceImpactProps in getPriceImpact.ts.