### PR TITLE
fix: update transaction link handling

### DIFF
--- a/packages/widget/src/components/Step/StepProcess.tsx
+++ b/packages/widget/src/components/Step/StepProcess.tsx
@@ -13,17 +13,12 @@ export const StepProcess: React.FC<{
   const { title, message } = useProcessMessage(step, process)
   const { getTransactionLink } = useExplorer()
 
-  const transactionLink = process.txHash
+  const transactionLink = process.txLink
     ? getTransactionLink({
-        txHash: process.txHash,
+        txLink: process.txLink,
         chain: process.chainId,
       })
-    : process.txLink
-      ? getTransactionLink({
-          txLink: process.txLink,
-          chain: process.chainId,
-        })
-      : undefined
+    : undefined
 
   return (
     <Box


### PR DESCRIPTION
## Why was it implemented this way?  
The tx link will come from the SDK now, so we should not create it from tx hash in the widget anymore.

## Checklist before requesting a review  
- [x] I have performed a self-review of my code.  
- [x] This pull request is focused and addresses a single problem.  
- [x] If this PR modifies the Widget API, I have updated the documentation (or submitted a change request on GitBook).  
