### PR TITLE
fix: prevent bottom sheets from mounting when hidden not to affect widget height

### DIFF
--- a/packages/widget/src/components/BottomSheet/BottomSheet.tsx
+++ b/packages/widget/src/components/BottomSheet/BottomSheet.tsx
@@ -12,7 +12,7 @@ import { modalProps, slotProps } from '../Dialog.js'
 import type { BottomSheetBase, BottomSheetProps } from './types.js'
 
 export const BottomSheet = forwardRef<BottomSheetBase, BottomSheetProps>(
-  ({ elementRef, children, open, onClose }, ref) => {
+  ({ elementRef, children, open, onClose, keepMounted = false }, ref) => {
     const getContainer = useGetScrollableContainer()
     const openRef = useRef(open)
     const [drawerOpen, setDrawerOpen] = useState(open)
@@ -54,7 +54,7 @@ export const BottomSheet = forwardRef<BottomSheetBase, BottomSheetProps>(
         ModalProps={modalProps}
         slotProps={slotProps}
         disableAutoFocus
-        keepMounted={true}
+        keepMounted={keepMounted}
         inert={isInert}
       >
         {children}

--- a/packages/widget/src/components/BottomSheet/types.ts
+++ b/packages/widget/src/components/BottomSheet/types.ts
@@ -4,6 +4,7 @@ import type { RefObject } from 'react'
 export type BottomSheetProps = Omit<DrawerProps, 'onClose'> & {
   elementRef?: RefObject<HTMLDivElement>
   onClose?(): void
+  keepMounted?: boolean
 }
 
 export interface BottomSheetBase {

--- a/packages/widget/src/components/TokenList/TokenDetailsSheet.tsx
+++ b/packages/widget/src/components/TokenList/TokenDetailsSheet.tsx
@@ -35,7 +35,7 @@ export const TokenDetailsSheet = forwardRef<
   )
 
   return (
-    <BottomSheet ref={bottomSheetRef}>
+    <BottomSheet ref={bottomSheetRef} keepMounted>
       <TokenDetailsSheetContent
         ref={ref}
         tokenAddress={tokenAddress}


### PR DESCRIPTION
## Jira task
https://lifi.atlassian.net/browse/LF-15318

## Problem
From Slack: "...It seems that the issue is only appearing on Jumper, and the playground works fine, but we need to understand and fix why Jumper is affected by the `useSetContentHeight` hook. For some reason min-height gets set before we show any confirmation bottom sheets and it always appears when entering the review page..."
https://github.com/user-attachments/assets/283fb1dc-c339-442c-996d-94b386feddac

## Why was it implemented this way?  
Now we have <BottomSheet />-wrapped components mounted even when closed, and they reset height of the widget if they are taller than the current widget height.

From what I can see, `keepMounted={true}` is needed only for token details, but not for any other bottom sheet. So I made it a prop, and set to false by default.

To test: now there won't be any `MuiDrawer` on the transaction pages, so `useSetContentHeight` won't get triggered.

## Checklist before requesting a review  
- [x] I have performed a self-review and testing of my code.  
- [x] This pull request is focused and addresses a single problem.  
