### PR TITLE
chore: add Node.js version requirement to nextjs example

### DIFF
--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -7,6 +7,9 @@
     "build": "next build",
     "start": "next start"
   },
+  "engines": {
+    "node": ">=21.0.0"
+  },
   "dependencies": {
     "@lifi/sdk": "^3.11.3",
     "@lifi/widget": "^3.28.0",


### PR DESCRIPTION
When I launched the example/next.js project using Node.js version 20.19.2 and accessed http://localhost:3000/pages-example, the page displayed an error. After troubleshooting, I identified that the issue was caused by the **outdated local Node.js version** (20.19.2), which led to a runtime error.  

The error disappeared once I upgraded Node.js to version 21.0.0 or higher and re-ran the project.  

Therefore, added a version prompt to help users avoid similar errors.