### PR TITLE
fix: missing usd conversion

### DIFF
--- a/packages/widget/src/hooks/useTokenAddressBalance.ts
+++ b/packages/widget/src/hooks/useTokenAddressBalance.ts
@@ -1,3 +1,4 @@
+import type { TokenAmount } from '@lifi/sdk'
 import { useAccount } from '@lifi/wallet-management'
 import { useChain } from './useChain.js'
 import { useToken } from './useToken.js'
@@ -18,7 +19,7 @@ export const useTokenAddressBalance = (
   } = useTokenBalance(account?.address, token)
 
   return {
-    token: tokenBalance,
+    token: tokenBalance ?? (token as TokenAmount),
     chain,
     isLoading: isBalanceLoading || isChainLoading || isTokenLoading,
     refetch,


### PR DESCRIPTION
When no wallet is connected, USD amount is 0:
<img width="455" height="496" alt="Screenshot 2025-09-02 at 17 40 15" src="https://github.com/user-attachments/assets/ac558e4c-9f2e-4fce-8bfe-02ee8be390ed" />

## Why was it implemented this way?  
Added fallback to token with no balance.

## Checklist before requesting a review  
- [x] I have performed a self-review and testing of my code.  
- [x] This pull request is focused and addresses a single problem.  
