### PR TITLE
fix: return from queryFn

### DIFF
--- a/packages/widget/src/hooks/useTokenSearch.ts
+++ b/packages/widget/src/hooks/useTokenSearch.ts
@@ -46,7 +46,7 @@ export const useTokenSearch = (
             t.address.toLowerCase()
           )
         ) {
-          return undefined
+          return null
         }
 
         queryClient.setQueriesData<TokensResponse>(
@@ -75,7 +75,7 @@ export const useTokenSearch = (
     retry: false,
   })
   return {
-    token: data,
+    token: data || undefined,
     isLoading,
   }
 }


### PR DESCRIPTION
<img width="674" height="561" alt="image" src="https://github.com/user-attachments/assets/4cf64519-e7fa-48c6-82e9-bc7cf6a8326e" />

## Why was it implemented this way?  
Addresses the undefined return. The filtering logic should already work fine.

## Checklist before requesting a review  
- [x] I have performed a self-review and testing of my code.  
- [x] This pull request is focused and addresses a single problem.  
