### PR TITLE
refactor: use zustand create instead of createWithEqualityFn

### DIFF
--- a/examples/zustand-widget-config/src/store/createWidgetConfigStore.ts
+++ b/examples/zustand-widget-config/src/store/createWidgetConfigStore.ts
@@ -1,6 +1,6 @@
 import type { WidgetConfig } from '@lifi/widget'
+import { create } from 'zustand'
 import { useShallow } from 'zustand/shallow'
-import { createWithEqualityFn } from 'zustand/traditional'
 import type { WidgetConfigState } from './types'
 
 const initialWidgetConfig = {
@@ -14,41 +14,38 @@ const initialWidgetConfig = {
   },
 }
 
-const widgetConfigStore = createWithEqualityFn<WidgetConfigState>(
-  (set, get) => ({
-    config: initialWidgetConfig,
-    setConfig: (config) => {
-      set({
-        config,
-      })
-    },
-    setFormValues: (formValues) => {
-      const config = get().config ?? {}
+const widgetConfigStore = create<WidgetConfigState>((set, get) => ({
+  config: initialWidgetConfig,
+  setConfig: (config) => {
+    set({
+      config,
+    })
+  },
+  setFormValues: (formValues) => {
+    const config = get().config ?? {}
 
-      // we remove the updatable form values as we only want pass properties with
-      // updated values. Only updated values should be specified in the config (even if that a value of undefined)
-      // formUpdateKey here is passed in from the FormControl component to ensure updates
-      ;[
-        'fromAmount',
-        'fromChain',
-        'fromToken',
-        'toAddress',
-        'toChain',
-        'toToken',
-      ].forEach((key) => {
-        delete config[key as keyof WidgetConfig]
-      })
+    // we remove the updatable form values as we only want pass properties with
+    // updated values. Only updated values should be specified in the config (even if that a value of undefined)
+    // formUpdateKey here is passed in from the FormControl component to ensure updates
+    ;[
+      'fromAmount',
+      'fromChain',
+      'fromToken',
+      'toAddress',
+      'toChain',
+      'toToken',
+    ].forEach((key) => {
+      delete config[key as keyof WidgetConfig]
+    })
 
-      set({
-        config: {
-          ...get().config,
-          ...(formValues as Partial<WidgetConfig>),
-        },
-      })
-    },
-  }),
-  Object.is
-)
+    set({
+      config: {
+        ...get().config,
+        ...(formValues as Partial<WidgetConfig>),
+      },
+    })
+  },
+}))
 
 export const useWidgetConfigStore = <T>(
   selector: (state: WidgetConfigState) => T

--- a/packages/widget-playground/src/store/editTools/createEditToolsStore.ts
+++ b/packages/widget-playground/src/store/editTools/createEditToolsStore.ts
@@ -1,13 +1,13 @@
 import type { WidgetTheme } from '@lifi/widget'
 import type { StateCreator } from 'zustand'
+import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
-import { createWithEqualityFn } from 'zustand/traditional'
 import type { FormValues } from '../types.js'
 import { defaultDrawerWidth } from './constants.js'
 import type { ToolsState } from './types.js'
 
 export const createEditToolsStore = (initialTheme?: WidgetTheme) =>
-  createWithEqualityFn<ToolsState>(
+  create<ToolsState>()(
     persist(
       (set, get) => ({
         formValues: undefined,
@@ -189,6 +189,5 @@ export const createEditToolsStore = (initialTheme?: WidgetTheme) =>
           }
         },
       }
-    ) as StateCreator<ToolsState, [], [], ToolsState>,
-    Object.is
+    ) as StateCreator<ToolsState, [], [], ToolsState>
   )

--- a/packages/widget-playground/src/store/editTools/createEditToolsStore.ts
+++ b/packages/widget-playground/src/store/editTools/createEditToolsStore.ts
@@ -1,5 +1,4 @@
 import type { WidgetTheme } from '@lifi/widget'
-import type { StateCreator } from 'zustand'
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
 import type { FormValues } from '../types.js'
@@ -189,5 +188,5 @@ export const createEditToolsStore = (initialTheme?: WidgetTheme) =>
           }
         },
       }
-    ) as StateCreator<ToolsState, [], [], ToolsState>
+    )
   )

--- a/packages/widget-playground/src/store/widgetConfig/createWidgetConfigStore.ts
+++ b/packages/widget-playground/src/store/widgetConfig/createWidgetConfigStore.ts
@@ -1,7 +1,7 @@
 import type { WidgetConfig, WidgetTheme } from '@lifi/widget'
 import type { StateCreator } from 'zustand'
+import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
-import { createWithEqualityFn } from 'zustand/traditional'
 import { addValueFromPathString } from '../../utils/addValue.js'
 import { cloneStructuredConfig } from '../../utils/cloneStructuredConfig.js'
 import type { ThemeItem } from '../editTools/types.js'
@@ -15,7 +15,7 @@ export const createWidgetConfigStore = (
   themeItems: ThemeItem[],
   prefersDarkMode: boolean
 ) =>
-  createWithEqualityFn<WidgetConfigState>(
+  create<WidgetConfigState>()(
     persist(
       (set, get) => ({
         defaultConfig: initialConfig,
@@ -297,6 +297,5 @@ export const createWidgetConfigStore = (
           }
         },
       }
-    ) as StateCreator<WidgetConfigState, [], [], WidgetConfigState>,
-    Object.is
+    ) as StateCreator<WidgetConfigState, [], [], WidgetConfigState>
   )

--- a/packages/widget-playground/src/store/widgetConfig/createWidgetConfigStore.ts
+++ b/packages/widget-playground/src/store/widgetConfig/createWidgetConfigStore.ts
@@ -1,5 +1,4 @@
 import type { WidgetConfig, WidgetTheme } from '@lifi/widget'
-import type { StateCreator } from 'zustand'
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
 import { addValueFromPathString } from '../../utils/addValue.js'
@@ -297,5 +296,5 @@ export const createWidgetConfigStore = (
           }
         },
       }
-    ) as StateCreator<WidgetConfigState, [], [], WidgetConfigState>
+    )
   )

--- a/packages/widget/src/stores/bookmarks/createBookmarkStore.ts
+++ b/packages/widget/src/stores/bookmarks/createBookmarkStore.ts
@@ -1,6 +1,6 @@
 import type { StateCreator } from 'zustand'
+import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
-import { createWithEqualityFn } from 'zustand/traditional'
 import type { ToAddress } from '../../types/widget.js'
 import type { PersistStoreProps } from '../types.js'
 import type { BookmarkState } from './types.js'
@@ -14,7 +14,7 @@ export const createBookmarksStore = ({
   namePrefix,
   toAddress,
 }: PersistBookmarkProps) =>
-  createWithEqualityFn<BookmarkState>(
+  create<BookmarkState>()(
     persist(
       (set, get) => ({
         selectedBookmark: toAddress,
@@ -76,6 +76,5 @@ export const createBookmarksStore = ({
           }
         },
       }
-    ) as StateCreator<BookmarkState, [], [], BookmarkState>,
-    Object.is
+    ) as StateCreator<BookmarkState, [], [], BookmarkState>
   )

--- a/packages/widget/src/stores/bookmarks/createBookmarkStore.ts
+++ b/packages/widget/src/stores/bookmarks/createBookmarkStore.ts
@@ -1,4 +1,3 @@
-import type { StateCreator } from 'zustand'
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
 import type { ToAddress } from '../../types/widget.js'
@@ -76,5 +75,5 @@ export const createBookmarksStore = ({
           }
         },
       }
-    ) as StateCreator<BookmarkState, [], [], BookmarkState>
+    )
   )

--- a/packages/widget/src/stores/chains/createChainOrderStore.ts
+++ b/packages/widget/src/stores/chains/createChainOrderStore.ts
@@ -1,6 +1,6 @@
 import type { StateCreator } from 'zustand'
+import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
-import { createWithEqualityFn } from 'zustand/traditional'
 import { widgetEvents } from '../../hooks/useWidgetEvents.js'
 import { WidgetEvent } from '../../types/events.js'
 import type { PersistStoreProps } from '../types.js'
@@ -19,7 +19,7 @@ const defaultChainState = {
 }
 
 export const createChainOrderStore = ({ namePrefix }: PersistStoreProps) =>
-  createWithEqualityFn<ChainOrderState>(
+  create<ChainOrderState>()(
     persist(
       (set, get) => ({
         chainOrder: defaultChainState,
@@ -126,6 +126,5 @@ export const createChainOrderStore = ({ namePrefix }: PersistStoreProps) =>
           pinnedChains: state.pinnedChains,
         }),
       }
-    ) as StateCreator<ChainOrderState, [], [], ChainOrderState>,
-    Object.is
+    ) as StateCreator<ChainOrderState, [], [], ChainOrderState>
   )

--- a/packages/widget/src/stores/chains/createChainOrderStore.ts
+++ b/packages/widget/src/stores/chains/createChainOrderStore.ts
@@ -1,4 +1,3 @@
-import type { StateCreator } from 'zustand'
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
 import { widgetEvents } from '../../hooks/useWidgetEvents.js'
@@ -126,5 +125,5 @@ export const createChainOrderStore = ({ namePrefix }: PersistStoreProps) =>
           pinnedChains: state.pinnedChains,
         }),
       }
-    ) as StateCreator<ChainOrderState, [], [], ChainOrderState>
+    )
   )

--- a/packages/widget/src/stores/chains/useChainOrder.ts
+++ b/packages/widget/src/stores/chains/useChainOrder.ts
@@ -1,3 +1,4 @@
+import { useMemo } from 'react'
 import type { FormType } from '../form/types.js'
 import { useChainOrderStore } from './ChainOrderStore.js'
 import { maxChainsToOrder } from './createChainOrderStore.js'
@@ -5,8 +6,15 @@ import { maxChainsToOrder } from './createChainOrderStore.js'
 export const useChainOrder = (
   type: FormType
 ): [number[], (chainId: number, type: FormType) => void] => {
-  return useChainOrderStore((state) => [
-    state.chainOrder[type].slice(0, maxChainsToOrder),
+  const [chainOrder, setChain] = useChainOrderStore((state) => [
+    state.chainOrder[type],
     state.setChain,
   ])
+
+  const limitedChainOrder = useMemo(
+    () => chainOrder.slice(0, maxChainsToOrder),
+    [chainOrder]
+  )
+
+  return [limitedChainOrder, setChain]
 }

--- a/packages/widget/src/stores/form/createFormStore.ts
+++ b/packages/widget/src/stores/form/createFormStore.ts
@@ -1,4 +1,4 @@
-import { createWithEqualityFn } from 'zustand/traditional'
+import { create } from 'zustand'
 
 import type {
   DefaultValues,
@@ -68,7 +68,7 @@ const mergeDefaultFormValues = (
   )
 
 export const createFormStore = (defaultValues?: DefaultValues) =>
-  createWithEqualityFn<FormValuesState>((set, get) => {
+  create<FormValuesState>((set, get) => {
     const _defaultValues = valuesToFormValues({
       ...formDefaultValues,
       ...defaultValues,
@@ -231,4 +231,4 @@ export const createFormStore = (defaultValues?: DefaultValues) =>
         }))
       },
     }
-  }, Object.is)
+  })

--- a/packages/widget/src/stores/header/useHeaderStore.tsx
+++ b/packages/widget/src/stores/header/useHeaderStore.tsx
@@ -1,6 +1,6 @@
 import { createContext, useContext, useRef } from 'react'
+import { create } from 'zustand'
 import { useShallow } from 'zustand/shallow'
-import { createWithEqualityFn } from 'zustand/traditional'
 import type { PersistStoreProviderProps } from '../types.js'
 import type { HeaderState, HeaderStore } from './types.js'
 
@@ -55,36 +55,33 @@ export function useSetHeaderHeight() {
 }
 
 const createHeaderStore = () =>
-  createWithEqualityFn<HeaderState>(
-    (set, get) => ({
-      headerHeight: 108, // a basic default height
-      setAction: (element) => {
-        set(() => ({
-          element,
-        }))
-        return get().removeAction
-      },
-      setTitle: (title) => {
-        set(() => ({
-          title,
-        }))
-        return get().removeTitle
-      },
-      removeAction: () => {
-        set(() => ({
-          element: null,
-        }))
-      },
-      removeTitle: () => {
-        set(() => ({
-          title: undefined,
-        }))
-      },
-      setHeaderHeight: (headerHeight) => {
-        set(() => ({
-          headerHeight,
-        }))
-      },
-    }),
-    Object.is
-  )
+  create<HeaderState>((set, get) => ({
+    headerHeight: 108, // a basic default height
+    setAction: (element) => {
+      set(() => ({
+        element,
+      }))
+      return get().removeAction
+    },
+    setTitle: (title) => {
+      set(() => ({
+        title,
+      }))
+      return get().removeTitle
+    },
+    removeAction: () => {
+      set(() => ({
+        element: null,
+      }))
+    },
+    removeTitle: () => {
+      set(() => ({
+        title: undefined,
+      }))
+    },
+    setHeaderHeight: (headerHeight) => {
+      set(() => ({
+        headerHeight,
+      }))
+    },
+  }))

--- a/packages/widget/src/stores/routes/createRouteExecutionStore.ts
+++ b/packages/widget/src/stores/routes/createRouteExecutionStore.ts
@@ -1,7 +1,7 @@
 import type { Route, RouteExtended } from '@lifi/sdk'
 import type { StateCreator } from 'zustand'
+import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
-import { createWithEqualityFn } from 'zustand/traditional'
 import { hasEnumFlag } from '../../utils/enum.js'
 import type { PersistStoreProps } from '../types.js'
 import type { RouteExecutionState } from './types.js'
@@ -14,7 +14,7 @@ import {
 } from './utils.js'
 
 export const createRouteExecutionStore = ({ namePrefix }: PersistStoreProps) =>
-  createWithEqualityFn<RouteExecutionState>(
+  create<RouteExecutionState>()(
     persist(
       (set, get) => ({
         routes: {},
@@ -150,6 +150,5 @@ export const createRouteExecutionStore = ({ namePrefix }: PersistStoreProps) =>
           return state
         },
       }
-    ) as StateCreator<RouteExecutionState, [], [], RouteExecutionState>,
-    Object.is
+    ) as StateCreator<RouteExecutionState, [], [], RouteExecutionState>
   )

--- a/packages/widget/src/stores/routes/createRouteExecutionStore.ts
+++ b/packages/widget/src/stores/routes/createRouteExecutionStore.ts
@@ -1,5 +1,4 @@
 import type { Route, RouteExtended } from '@lifi/sdk'
-import type { StateCreator } from 'zustand'
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
 import { hasEnumFlag } from '../../utils/enum.js'
@@ -150,5 +149,5 @@ export const createRouteExecutionStore = ({ namePrefix }: PersistStoreProps) =>
           return state
         },
       }
-    ) as StateCreator<RouteExecutionState, [], [], RouteExecutionState>
+    )
   )

--- a/packages/widget/src/stores/settings/useSendToWalletStore.ts
+++ b/packages/widget/src/stores/settings/useSendToWalletStore.ts
@@ -1,17 +1,14 @@
+import { create } from 'zustand'
 import { useShallow } from 'zustand/shallow'
-import { createWithEqualityFn } from 'zustand/traditional'
 import type { SendToWalletStore } from './types.js'
 
-export const sendToWalletStore = createWithEqualityFn<SendToWalletStore>(
-  (set) => ({
-    showSendToWallet: false,
-    setSendToWallet: (value) =>
-      set({
-        showSendToWallet: value,
-      }),
-  }),
-  Object.is
-)
+export const sendToWalletStore = create<SendToWalletStore>((set) => ({
+  showSendToWallet: false,
+  setSendToWallet: (value) =>
+    set({
+      showSendToWallet: value,
+    }),
+}))
 
 export const useSendToWalletStore = <T>(
   selector: (state: SendToWalletStore) => T

--- a/packages/widget/src/stores/settings/useSplitSubvariantStore.tsx
+++ b/packages/widget/src/stores/settings/useSplitSubvariantStore.tsx
@@ -1,6 +1,6 @@
 import { createContext, useContext, useRef } from 'react'
+import { create } from 'zustand'
 import { useShallow } from 'zustand/shallow'
-import { createWithEqualityFn } from 'zustand/traditional'
 import type {
   SplitSubvariantProps,
   SplitSubvariantProviderProps,
@@ -53,14 +53,11 @@ export function useSplitSubvariantStore<T>(
 }
 
 const createSplitSubvariantStore = ({ state }: SplitSubvariantProps) =>
-  createWithEqualityFn<SplitSubvariantState>(
-    (set) => ({
-      state,
-      setState(state) {
-        set(() => ({
-          state,
-        }))
-      },
-    }),
-    Object.is
-  )
+  create<SplitSubvariantState>((set) => ({
+    state,
+    setState(state) {
+      set(() => ({
+        state,
+      }))
+    },
+  }))


### PR DESCRIPTION
## Why was it implemented this way?  
Updated outdated zustand store setups where we use `createWithEqualityFn` function with `Object.is` equality function, since this is the same default as a standard `create` function.

Added memoization to `useChainOrder` as it triggered infinite loop with the state changes.

(settingsStore is updated in https://github.com/lifinance/widget/pull/545, skipped not to case merge conflicts)

## Checklist before requesting a review  
- [x] I have performed a self-review and testing of my code.  
- [x] This pull request is focused and addresses a single problem.  
