### PR TITLE
fix: search results for chains with categories

### DIFF
--- a/packages/widget/src/hooks/useTokenBalances.ts
+++ b/packages/widget/src/hooks/useTokenBalances.ts
@@ -72,7 +72,7 @@ export const useTokenBalances = (
   const { processedTokens, withCategories } = useMemo(() => {
     return processTokenBalances(
       isBalanceLoading,
-      isAllNetworks ?? false,
+      isAllNetworks || !!search,
       configTokens,
       selectedChainId,
       displayedTokensList,
@@ -85,6 +85,7 @@ export const useTokenBalances = (
     selectedChainId,
     displayedTokensList,
     displayedTokensWithBalances,
+    search,
   ])
 
   return {

--- a/packages/widget/src/stores/chains/ChainOrderStore.tsx
+++ b/packages/widget/src/stores/chains/ChainOrderStore.tsx
@@ -64,7 +64,9 @@ export function ChainOrderStoreProvider({
 
         // Show "All networks" button if there are multiple networks
         const showAllNetworks = filteredChains.length > 1
-        storeRef.current?.getState().setIsAllNetworks(showAllNetworks, key)
+        if (!showAllNetworks) {
+          storeRef.current?.getState().setIsAllNetworks(false, key)
+        }
         storeRef.current?.getState().setShowAllNetworks(showAllNetworks, key)
 
         const [chainValue] = getFieldValues(`${key}Chain`)

--- a/packages/widget/src/utils/tokenList.ts
+++ b/packages/widget/src/utils/tokenList.ts
@@ -14,14 +14,14 @@ const sortByVolume = (a: TokenExtended, b: TokenExtended) =>
 
 export const processTokenBalances = (
   isBalanceLoading: boolean,
-  isAllNetworks: boolean,
+  noCategories: boolean,
   configTokens?: WidgetTokens,
   selectedChainId?: number,
   tokens?: TokenExtended[],
   tokensWithBalances?: TokenAmount[]
 ) => {
   if (isBalanceLoading) {
-    if (isAllNetworks) {
+    if (noCategories) {
       const sortedTokens = [...(tokens ?? [])].sort(sortByVolume)
       return {
         processedTokens: sortedTokens,
@@ -54,7 +54,7 @@ export const processTokenBalances = (
       })
       .sort(sortByVolume) ?? []
 
-  if (isAllNetworks) {
+  if (noCategories) {
     return {
       processedTokens: [...sortedTokensWithBalances, ...tokensWithoutBalances],
       withCategories: false,


### PR DESCRIPTION
## Which Jira task is linked to this PR?  
https://lifi.atlassian.net/browse/LF-15978

Fast way to reproduce the issue with switching isAllNetworks (initially selected chain was Arbitrum, then it became All networks):

https://github.com/user-attachments/assets/05e89f2a-a5ce-4c67-9060-a4bcbcf81a5c

## Visual showcase (Screenshots or Videos)  
<img width="1421" height="873" alt="Screenshot 2025-10-03 at 12 58 30" src="https://github.com/user-attachments/assets/d39cd8e6-45b7-4b35-8bed-2a18b04f210e" />

For switching isAllNetworks:

https://github.com/user-attachments/assets/04d80496-cd70-45ff-9586-244862f431ca

## Checklist before requesting a review  
- [x] I have performed a self-review and testing of my code.  
- [x] This pull request is focused and addresses a single problem.  
