### PR TITLE
fix: limit decimals in formatInputAmount

### DIFF
--- a/packages/widget/src/utils/format.test.ts
+++ b/packages/widget/src/utils/format.test.ts
@@ -16,7 +16,7 @@ describe('formatInputAmount', () => {
   })
 
   it('should handle leading and trailing zeros', () => {
-    expect(formatInputAmount('00123', 2, true)).toBe('123')
+    expect(formatInputAmount('00123', 2, true)).toBe('00123')
     expect(formatInputAmount('00123', 2, false)).toBe('123')
     expect(formatInputAmount('123.45000', 6, true)).toBe('123.45000')
     expect(formatInputAmount('123.45000', 6, false)).toBe('123.45')
@@ -34,15 +34,15 @@ describe('formatInputAmount', () => {
     expect(formatInputAmount('  1,23  ', null, false)).toBe('1.23')
     expect(formatInputAmount('1.2.3', null, true)).toBe('1.23')
     expect(formatInputAmount('1.2.3', null, false)).toBe('1.23')
-    expect(formatInputAmount('..5', null, true)).toBe('0.5')
+    expect(formatInputAmount('..5', null, true)).toBe('.5')
     expect(formatInputAmount('..5', null, false)).toBe('0.5')
   })
 
   it('should handle zero input', () => {
     expect(formatInputAmount('0', null, true)).toBe('0')
-    expect(formatInputAmount('00', null, true)).toBe('0')
+    expect(formatInputAmount('00', null, true)).toBe('00')
     expect(formatInputAmount('0.00', 2, true)).toBe('0.00')
-    expect(formatInputAmount('.0', 2, true)).toBe('0.0')
+    expect(formatInputAmount('.0', 2, true)).toBe('.0')
     expect(formatInputAmount('0..', 2, true)).toBe('0.')
     expect(formatInputAmount('0', null, false)).toBe('')
     expect(formatInputAmount('00', null, false)).toBe('')

--- a/packages/widget/src/utils/format.ts
+++ b/packages/widget/src/utils/format.ts
@@ -65,22 +65,19 @@ export function formatInputAmount(
 
   // Replace commas with dots
   let formattedAmount = amount.trim().replaceAll(',', '.')
+
   // Keep only the first dot, remove all subsequent dots
   const dotIndex = formattedAmount.indexOf('.')
   if (dotIndex !== -1) {
     formattedAmount = `${formattedAmount.slice(0, dotIndex + 1)}${formattedAmount.slice(dotIndex + 1).replaceAll('.', '')}`
   }
+
   // If the amount starts with a dot, prepend 0
-  if (formattedAmount.startsWith('.')) {
+  if (
+    (!returnInitial && formattedAmount.startsWith('.')) ||
+    formattedAmount === '.'
+  ) {
     formattedAmount = `0${formattedAmount}`
-  }
-  // Handle leading zeros
-  if (formattedAmount.startsWith('00')) {
-    let withoutLeadingZeros = formattedAmount
-    while (withoutLeadingZeros.length > 0 && withoutLeadingZeros[0] === '0') {
-      withoutLeadingZeros = withoutLeadingZeros.slice(1)
-    }
-    formattedAmount = withoutLeadingZeros
   }
 
   // Parse the valid part of the amount
@@ -98,16 +95,17 @@ export function formatInputAmount(
     fraction = fraction.slice(0, decimals)
   }
 
-  if (returnInitial && !fraction) {
-    return formattedAmount
+  if (returnInitial) {
+    if (!fraction) {
+      return formattedAmount
+    }
+    return `${integer}${fraction ? `.${fraction}` : ''}`
   }
 
-  if (!returnInitial) {
-    // Remove leading zeros and minus sign
-    integer = integer.replace(/^0+|-/, '')
-    // Remove trailing zeros
-    fraction = fraction.replace(/(0+)$/, '')
-  }
+  // Remove leading zeros and minus sign
+  integer = integer.replace(/^0+|-/, '')
+  // Remove trailing zeros
+  fraction = fraction.replace(/(0+)$/, '')
 
   return `${integer || (fraction ? '0' : '')}${fraction ? `.${fraction}` : ''}`
 }


### PR DESCRIPTION
## Which Jira task is linked to this PR?  
https://lifi.atlassian.net/browse/LF-16725

## Why was it implemented this way?  
The initial problem was in the fact that the input allowed entering numbers like "0.003" when only 2 decimal places were actually handled internally (e.g. for USD) - the truncation would handle the number like "0.00", which resolved to no route selected.

This PR refactors formatting input amount logic: prevents entering more decimals than expected, handles leading zeros, multiple dots.

## Checklist before requesting a review  
- [x] I have performed a self-review and testing of my code.  
- [x] This pull request is focused and addresses a single problem.  
