### PR TITLE
fix: make input price background transparent in dark mode

### DIFF
--- a/packages/widget/src/components/AmountInput/PriceFormHelperText.style.tsx
+++ b/packages/widget/src/components/AmountInput/PriceFormHelperText.style.tsx
@@ -25,5 +25,8 @@ export const InputPriceButton = styled(Button)(({ theme, onClick }) => ({
         cursor: 'text',
         userSelect: 'text',
         pointerEvents: 'none',
+        ...theme.applyStyles('dark', {
+          backgroundColor: 'transparent',
+        }),
       }),
 }))


### PR DESCRIPTION
## Visual showcase (Screenshots or Videos)  
Bug: price input tag should be transparent in dark mode:
<img width="490" height="131" alt="Screenshot 2025-12-12 at 15 39 38" src="https://github.com/user-attachments/assets/621f6a56-6ecd-4c56-8a78-57b47795ff5b" />


## Checklist before requesting a review  
- [x] I have performed a self-review and testing of my code.  
- [x] This pull request is focused and addresses a single problem.  
