### PR TITLE
feat: reset to all networks if no chain in URL

### DIFF
--- a/packages/widget/src/stores/chains/ChainOrderStore.tsx
+++ b/packages/widget/src/stores/chains/ChainOrderStore.tsx
@@ -88,6 +88,12 @@ export function ChainOrderStoreProvider({
           return
         }
 
+        // If no chain is selected (e.g., removed from URL params) and
+        // showAllNetworks is enabled, reset isAllNetworks to true
+        if (showAllNetworks) {
+          storeRef.current?.getState().setIsAllNetworks(true, key)
+        }
+
         const firstAllowedPinnedChain = storeRef.current
           ?.getState()
           .pinnedChains?.find((chainId) =>


### PR DESCRIPTION
## Why was it implemented this way?  
Currently, when there is no chain in the URL, the chain defaults to ETH. Instead, we will default it to all networks from now on.

## Visual showcase (Screenshots or Videos)  
https://github.com/user-attachments/assets/0dffbd00-30db-40ed-b728-754e1f567f7d

## Checklist before requesting a review  
- [x] I have performed a self-review and testing of my code.  
- [x] This pull request is focused and addresses a single problem.  
