### PR TITLE
fix: support fromAmount mode in custom subvariant contract call quotes

### DIFF
--- a/packages/widget/src/hooks/useRoutes.ts
+++ b/packages/widget/src/hooks/useRoutes.ts
@@ -282,7 +282,11 @@ export const useRoutes = ({ observableRoute }: RoutesProps = {}) => {
           slippage: formattedSlippage,
         })
 
-        if (subvariant === 'custom' && contractCalls && toAmount) {
+        if (
+          subvariant === 'custom' &&
+          contractCalls &&
+          (toAmount || fromAmount)
+        ) {
           const contractCallQuote = await getContractCallsQuote(
             sdkClient,
             {
@@ -290,7 +294,9 @@ export const useRoutes = ({ observableRoute }: RoutesProps = {}) => {
               fromAddress: fromAddress as string,
               fromChain: fromChainId,
               fromToken: fromTokenAddress,
-              toAmount: toAmount.toString(),
+              ...(toAmount
+                ? { toAmount: toAmount.toString() }
+                : { fromAmount: fromAmount.toString() }),
               toChain: toChainId,
               toToken: toTokenAddress,
               contractCalls,


### PR DESCRIPTION
## Which Linear task is linked to this PR?

Fixes #575

## Why was it implemented this way?

`@lifi/sdk`'s `ContractCallsQuoteRequest` is a union of `ContractCallsQuoteRequestFromAmount`
and `ContractCallsQuoteRequestToAmount` — both modes are supported at the API level.

`useRoutes.ts` only called `getContractCallsQuote` when `toAmount` was set, silently
skipping the request when only `fromAmount` was provided. This breaks deposit and checkout
flows where users input a source amount rather than a destination amount.

The fix updates the condition from `contractCalls && toAmount` to
`contractCalls && (toAmount || fromAmount)` and spreads either `{ toAmount }` or
`{ fromAmount }` depending on which is set. `toAmount` takes priority, so existing
integrators are unaffected.

No alternative approach was considered — the SDK already supports both modes, this is
purely a missing branch in the widget.

## Visual showcase (Screenshots or Videos)

No UI changes. Logic fix only.

Before: with only `fromAmount` set, no request to `/v1/quote/contractCalls` fires.
After: request fires with `fromAmount` passed to the SDK.

## Checklist before requesting a review
- [x] I have performed a self-review and testing of my code.
- [x] This pull request is focused and addresses a single problem.
- [ ] If this PR modifies the Widget API or adds new features that require documentation, I have updated the documentation in the [public-docs](https://github.com/lifinance/public-docs) repository.
