### PR TITLE
fix: route store migration

### DIFF
--- a/packages/widget/src/components/Header/ActivitiesButton.tsx
+++ b/packages/widget/src/components/Header/ActivitiesButton.tsx
@@ -25,6 +25,7 @@ export const ActivitiesButton = (): JSX.Element => {
         active={indicator.active || indicator.failed}
         size="medium"
         onClick={() => navigate({ to: navigationRoutes.activities })}
+        disableRipple
       >
         <ErrorBadge
           invisible={!indicator.failed}

--- a/packages/widget/src/components/RouteCard/RouteTokens.tsx
+++ b/packages/widget/src/components/RouteCard/RouteTokens.tsx
@@ -9,7 +9,7 @@ export const RouteTokens: React.FC<{
   route: RouteExtended
   showEssentials?: boolean
 }> = ({ route, showEssentials }) => {
-  const { subvariant, defaultUI } = useWidgetConfig()
+  const { subvariant } = useWidgetConfig()
 
   const fromToken = {
     ...route.steps[0].action.fromToken,
@@ -46,7 +46,6 @@ export const RouteTokens: React.FC<{
           route={route}
           token={toToken}
           impactToken={fromToken}
-          defaultExpanded={defaultUI?.transactionDetailsExpanded}
           showEssentials={showEssentials}
         />
       ) : null}

--- a/packages/widget/src/stores/routes/createRouteExecutionStore.ts
+++ b/packages/widget/src/stores/routes/createRouteExecutionStore.ts
@@ -129,8 +129,10 @@ export const createRouteExecutionStore = ({
       }),
       {
         name: `${namePrefix || 'li.fi'}-widget-routes`,
-        version: 3,
-        migrate: (persistedState: any) => persistedState,
+        // Bump version on breaking changes to the stored structure.
+        version: 4,
+        // Clear stored routes on any version mismatch to avoid errors from incompatible data shapes.
+        migrate: () => ({ routes: {} }),
         partialize: (state) => ({ routes: state.routes }),
         merge: (persistedState: any, currentState: RouteExecutionState) => {
           const state = {

--- a/packages/widget/src/stores/routes/utils.ts
+++ b/packages/widget/src/stores/routes/utils.ts
@@ -55,7 +55,7 @@ export const getUpdatedAction = (
 
 export const getSourceTxHash = (route?: RouteExtended): string | undefined => {
   const sourceAction = route?.steps[0].execution?.actions
-    .filter(
+    ?.filter(
       (action) => !['RESET_ALLOWANCE', 'SET_ALLOWANCE'].includes(action.type)
     )
     .find((action) => action.txHash || action.taskId)


### PR DESCRIPTION
## Why was it implemented this way?  
- Clears routes store on version mismatch
- Expands transaction details by default only on execution page

## Checklist before requesting a review  
- [x] I have performed a self-review and testing of my code.  
- [x] This pull request is focused and addresses a single problem.  
