### PR TITLE
fix: emit FormFieldChanged event from formRef.setFieldValue

### DIFF
--- a/packages/widget/src/stores/form/useFormRef.ts
+++ b/packages/widget/src/stores/form/useFormRef.ts
@@ -1,8 +1,15 @@
 import { useImperativeHandle } from 'react'
+import { widgetEvents } from '../../hooks/useWidgetEvents.js'
 import { useBookmarkActions } from '../../stores/bookmarks/useBookmarkActions.js'
 import { formDefaultValues } from '../../stores/form/createFormStore.js'
+import type { FormFieldChanged } from '../../types/events.js'
+import { WidgetEvent } from '../../types/events.js'
 import type { FormRef } from '../../types/widget.js'
-import type { FormStoreStore, GenericFormValue } from './types.js'
+import type {
+  FormFieldNames,
+  FormStoreStore,
+  GenericFormValue,
+} from './types.js'
 
 export const useFormRef = (
   formStore: FormStoreStore,
@@ -48,9 +55,21 @@ export const useFormRef = (
           ? { isTouched: options?.setUrlSearchParam }
           : undefined
 
+        const oldValue = formStore
+          .getState()
+          .getFieldValues(fieldName as FormFieldNames)[0]
+
         formStore
           .getState()
           .setFieldValue(fieldName, sanitizedValue, fieldValueOptions)
+
+        if (sanitizedValue !== oldValue) {
+          widgetEvents.emit(WidgetEvent.FormFieldChanged, {
+            fieldName,
+            newValue: sanitizedValue,
+            oldValue,
+          } as FormFieldChanged)
+        }
       },
     }
   }, [formStore, setSelectedBookmark])


### PR DESCRIPTION
## Which Linear task is linked to this PR?

## Why was it implemented this way?
The form ref's `setFieldValue` (`useFormRef.ts`) was calling the Zustand store directly via `formStore.getState().setFieldValue()`, which is a pure state mutation with no event emission. The `FormFieldChanged` widget event is only emitted through `useFieldActions`, which internal widget components use — but the external `formRef` API bypassed this entirely.

The fix captures the old value before the store update, then emits `WidgetEvent.FormFieldChanged` after the update if the value changed — matching the exact same pattern used internally by `useFieldActions`.

## Visual showcase (Screenshots or Videos)
N/A — behavioral fix, no UI changes.

## Checklist before requesting a review
- [x] I have performed a self-review and testing of my code.
- [x] This pull request is focused and addresses a single problem.
- [ ] If this PR modifies the Widget API or adds new features that require documentation, I have updated the documentation in the [public-docs](https://github.com/lifinance/public-docs) repository.