### PR TITLE
fix: create router for each widget instance

### DIFF
--- a/packages/widget/src/AppDefault.tsx
+++ b/packages/widget/src/AppDefault.tsx
@@ -6,6 +6,7 @@ import {
   RouterProvider,
 } from '@tanstack/react-router'
 import type { JSX } from 'react'
+import { useState } from 'react'
 import { AppLayout } from './AppLayout.js'
 import { NotFound } from './components/NotFound.js'
 import { ActivitiesPage } from './pages/ActivitiesPage/ActivitiesPage.js'
@@ -247,22 +248,19 @@ const routeTree = rootRoute.addChildren([
   configuredWalletsRoute,
 ])
 
-const history = createMemoryHistory({
-  initialEntries: ['/'],
-})
-
-const router: ReturnType<typeof createRouter> = createRouter({
-  routeTree,
-  history,
-  defaultPreload: 'intent',
-})
-
 declare module '@tanstack/react-router' {
   interface Register {
-    router: typeof router
+    router: ReturnType<typeof createRouter>
   }
 }
 
 export const AppDefault = (): JSX.Element => {
+  const [router] = useState(() =>
+    createRouter({
+      routeTree,
+      history: createMemoryHistory({ initialEntries: ['/'] }),
+      defaultPreload: 'intent',
+    })
+  )
   return <RouterProvider router={router} />
 }


### PR DESCRIPTION
## Which Linear task is linked to this PR?  
https://linear.app/lifi-linear/issue/EMB-337/quick-deposit-opens-bridge-list-after-visiting-settings

## Why was it implemented this way?  
If there are multiple widget instances within 1 app (like on Jumper), this fix will make sure that each will have their own router history created (not a global one like before).

## Visual showcase (Screenshots or Videos)  
If placing 2 widgets on playground, each will have independent navigation history. Before, both widgets were synced.
https://github.com/user-attachments/assets/6bcd9703-a5fd-4a54-a846-9a5f5501bbc4

## Checklist before requesting a review  
- [x] I have performed a self-review and testing of my code.  
- [x] This pull request is focused and addresses a single problem.  
