### PR TITLE
feat: allow passing custom sdk providers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "4.0.0-alpha.5",
+  "version": "4.0.0-alpha.6",
   "private": true,
   "sideEffects": false,
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "4.0.0-beta.14",
+  "version": "4.0.0-alpha.5",
   "private": true,
   "sideEffects": false,
   "type": "module",

--- a/packages/wallet-management/package.json
+++ b/packages/wallet-management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifi/wallet-management",
-  "version": "4.0.0-alpha.5",
+  "version": "4.0.0-alpha.6",
   "description": "LI.FI Wallet Management solution.",
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/wallet-management/package.json
+++ b/packages/wallet-management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifi/wallet-management",
-  "version": "4.0.0-beta.12",
+  "version": "4.0.0-alpha.5",
   "description": "LI.FI Wallet Management solution.",
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/widget-provider-bitcoin/package.json
+++ b/packages/widget-provider-bitcoin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifi/widget-provider-bitcoin",
-  "version": "4.0.0-alpha.5",
+  "version": "4.0.0-alpha.6",
   "description": "LI.FI Widget Provider for Bitcoin blockchain integration.",
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/widget-provider-bitcoin/package.json
+++ b/packages/widget-provider-bitcoin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifi/widget-provider-bitcoin",
-  "version": "4.0.0-beta.11",
+  "version": "4.0.0-alpha.5",
   "description": "LI.FI Widget Provider for Bitcoin blockchain integration.",
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/widget-provider-bitcoin/src/index.ts
+++ b/packages/widget-provider-bitcoin/src/index.ts
@@ -1,2 +1,3 @@
 export { BitcoinProvider } from './providers/BitcoinProvider.js'
+export type { BitcoinProviderConfig } from './types.js'
 export { createDefaultBigmiConfig } from './utils/createDefaultBigmiConfig.js'

--- a/packages/widget-provider-bitcoin/src/index.ts
+++ b/packages/widget-provider-bitcoin/src/index.ts
@@ -1,3 +1,3 @@
 export { BitcoinProvider } from './providers/BitcoinProvider.js'
-export type { BitcoinProviderConfig } from './types.js'
+export type { BitcoinProviderConfig, BitcoinProviderDeps } from './types.js'
 export { createDefaultBigmiConfig } from './utils/createDefaultBigmiConfig.js'

--- a/packages/widget-provider-bitcoin/src/providers/BitcoinProvider.tsx
+++ b/packages/widget-provider-bitcoin/src/providers/BitcoinProvider.tsx
@@ -1,8 +1,13 @@
 import { BigmiContext } from '@bigmi/react'
 import type { WidgetProviderProps } from '@lifi/widget-provider'
 import { type JSX, type PropsWithChildren, useContext } from 'react'
+import type { BitcoinProviderConfig } from '../types.js'
 import { BitcoinBaseProvider } from './BitcoinBaseProvider.js'
 import { BitcoinProviderValues } from './BitcoinProviderValues.js'
+
+interface BitcoinWidgetProviderProps extends WidgetProviderProps {
+  config?: BitcoinProviderConfig
+}
 
 function useInBitcoinContext(): boolean {
   const context = useContext(BigmiContext)
@@ -14,13 +19,17 @@ const BitcoinWidgetProvider = ({
   forceInternalWalletManagement,
   isExternalContext = false,
   children,
-}: PropsWithChildren<WidgetProviderProps>) => {
+  config,
+}: PropsWithChildren<BitcoinWidgetProviderProps>) => {
   const inBitcoinContext = useInBitcoinContext()
   const effectiveIsExternal = isExternalContext || inBitcoinContext
 
   if (inBitcoinContext && !forceInternalWalletManagement) {
     return (
-      <BitcoinProviderValues isExternalContext={effectiveIsExternal}>
+      <BitcoinProviderValues
+        isExternalContext={effectiveIsExternal}
+        config={config}
+      >
         {children}
       </BitcoinProviderValues>
     )
@@ -28,17 +37,22 @@ const BitcoinWidgetProvider = ({
 
   return (
     <BitcoinBaseProvider>
-      <BitcoinProviderValues isExternalContext={effectiveIsExternal}>
+      <BitcoinProviderValues
+        isExternalContext={effectiveIsExternal}
+        config={config}
+      >
         {children}
       </BitcoinProviderValues>
     </BitcoinBaseProvider>
   )
 }
 
-export const BitcoinProvider = (): ((
-  props: PropsWithChildren<WidgetProviderProps>
-) => JSX.Element) => {
+export const BitcoinProvider = (
+  config?: BitcoinProviderConfig
+): ((props: PropsWithChildren<WidgetProviderProps>) => JSX.Element) => {
   return ({ children, ...props }: PropsWithChildren<WidgetProviderProps>) => (
-    <BitcoinWidgetProvider {...props}>{children}</BitcoinWidgetProvider>
+    <BitcoinWidgetProvider {...props} config={config}>
+      {children}
+    </BitcoinWidgetProvider>
   )
 }

--- a/packages/widget-provider-bitcoin/src/providers/BitcoinProviderValues.tsx
+++ b/packages/widget-provider-bitcoin/src/providers/BitcoinProviderValues.tsx
@@ -37,14 +37,13 @@ export const BitcoinProviderValues: FC<
 
   const isConnected = account.isConnected
 
-  const sdkProvider = useMemo(
-    () =>
-      config?.sdkProvider ??
-      BitcoinSDKProvider({
-        getWalletClient: () => getBigmiConnectorClient(bigmiConfig),
-      }),
-    [bigmiConfig, config?.sdkProvider]
-  )
+  const sdkProvider = useMemo(() => {
+    const getWalletClient = () => getBigmiConnectorClient(bigmiConfig)
+    if (typeof config?.sdkProvider === 'function') {
+      return config.sdkProvider({ getWalletClient })
+    }
+    return config?.sdkProvider ?? BitcoinSDKProvider({ getWalletClient })
+  }, [bigmiConfig, config?.sdkProvider])
 
   const installedWallets = useMemo(
     () =>

--- a/packages/widget-provider-bitcoin/src/providers/BitcoinProviderValues.tsx
+++ b/packages/widget-provider-bitcoin/src/providers/BitcoinProviderValues.tsx
@@ -10,14 +10,16 @@ import { ChainId, ChainType } from '@lifi/sdk'
 import { BitcoinProvider as BitcoinSDKProvider } from '@lifi/sdk-provider-bitcoin'
 import { BitcoinContext, isWalletInstalled } from '@lifi/widget-provider'
 import { type FC, type PropsWithChildren, useCallback, useMemo } from 'react'
+import type { BitcoinProviderConfig } from '../types'
 
 interface BitcoinProviderValuesProps {
   isExternalContext: boolean
+  config?: BitcoinProviderConfig
 }
 
 export const BitcoinProviderValues: FC<
   PropsWithChildren<BitcoinProviderValuesProps>
-> = ({ children, isExternalContext }) => {
+> = ({ children, isExternalContext, config }) => {
   const bigmiConfig = useConfig()
   const { connectors } = useConnect()
   const currentWallet = useAccount()
@@ -37,10 +39,11 @@ export const BitcoinProviderValues: FC<
 
   const sdkProvider = useMemo(
     () =>
+      config?.sdkProvider ??
       BitcoinSDKProvider({
         getWalletClient: () => getBigmiConnectorClient(bigmiConfig),
       }),
-    [bigmiConfig]
+    [bigmiConfig, config?.sdkProvider]
   )
 
   const installedWallets = useMemo(

--- a/packages/widget-provider-bitcoin/src/types.ts
+++ b/packages/widget-provider-bitcoin/src/types.ts
@@ -1,3 +1,11 @@
-import type { WidgetProviderConfig } from '@lifi/widget-provider'
+import type { Client } from '@bigmi/core'
+import type { SDKProvider } from '@lifi/sdk'
+import type { SDKProviderFactory } from '@lifi/widget-provider'
 
-export interface BitcoinProviderConfig extends WidgetProviderConfig {}
+export interface BitcoinProviderDeps {
+  getWalletClient: () => Promise<Client>
+}
+
+export interface BitcoinProviderConfig {
+  sdkProvider?: SDKProvider | SDKProviderFactory<BitcoinProviderDeps>
+}

--- a/packages/widget-provider-bitcoin/src/types.ts
+++ b/packages/widget-provider-bitcoin/src/types.ts
@@ -1,0 +1,3 @@
+import type { WidgetProviderConfig } from '@lifi/widget-provider'
+
+export interface BitcoinProviderConfig extends WidgetProviderConfig {}

--- a/packages/widget-provider-ethereum/package.json
+++ b/packages/widget-provider-ethereum/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifi/widget-provider-ethereum",
-  "version": "4.0.0-alpha.5",
+  "version": "4.0.0-alpha.6",
   "description": "LI.FI Widget Provider for Ethereum blockchain integration.",
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/widget-provider-ethereum/package.json
+++ b/packages/widget-provider-ethereum/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifi/widget-provider-ethereum",
-  "version": "4.0.0-beta.11",
+  "version": "4.0.0-alpha.5",
   "description": "LI.FI Widget Provider for Ethereum blockchain integration.",
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/widget-provider-ethereum/src/index.ts
+++ b/packages/widget-provider-ethereum/src/index.ts
@@ -1,6 +1,9 @@
 export { useSyncWagmiConfig } from './hooks/useSyncWagmiConfig.js'
 export { EthereumProvider } from './providers/EthereumProvider.js'
-export type { EthereumProviderConfig } from './types.js'
+export type {
+  EthereumProviderConfig,
+  EthereumProviderDeps,
+} from './types.js'
 export {
   convertExtendedChain,
   isExtendedChain,

--- a/packages/widget-provider-ethereum/src/index.ts
+++ b/packages/widget-provider-ethereum/src/index.ts
@@ -1,5 +1,6 @@
 export { useSyncWagmiConfig } from './hooks/useSyncWagmiConfig.js'
 export { EthereumProvider } from './providers/EthereumProvider.js'
+export type { EthereumProviderConfig } from './types.js'
 export {
   convertExtendedChain,
   isExtendedChain,

--- a/packages/widget-provider-ethereum/src/providers/EthereumProviderValues.tsx
+++ b/packages/widget-provider-ethereum/src/providers/EthereumProviderValues.tsx
@@ -168,20 +168,29 @@ export const EthereumProviderValues: FC<
 
   const isConnected = account.isConnected
 
-  const sdkProvider = useMemo(
-    () =>
+  const sdkProvider = useMemo(() => {
+    const getWalletClient = () =>
+      getConnectorClient(wagmiConfig, { assertChainId: false })
+    const switchChainDep = async (chainId: number) => {
+      const chain = await switchChain(wagmiConfig, { chainId })
+      return getConnectorClient(wagmiConfig, { chainId: chain.id })
+    }
+    if (typeof config?.sdkProvider === 'function') {
+      return config.sdkProvider({
+        getWalletClient,
+        switchChain: switchChainDep,
+        disableMessageSigning: config?.disableMessageSigning,
+      })
+    }
+    return (
       config?.sdkProvider ??
       EthereumSDKProvider({
-        getWalletClient: () =>
-          getConnectorClient(wagmiConfig, { assertChainId: false }),
-        switchChain: async (chainId: number) => {
-          const chain = await switchChain(wagmiConfig, { chainId })
-          return getConnectorClient(wagmiConfig, { chainId: chain.id })
-        },
+        getWalletClient,
+        switchChain: switchChainDep,
         disableMessageSigning: config?.disableMessageSigning,
-      }),
-    [wagmiConfig, config?.disableMessageSigning, config?.sdkProvider]
-  )
+      })
+    )
+  }, [wagmiConfig, config?.disableMessageSigning, config?.sdkProvider])
 
   const installedWallets = useMemo(
     () =>

--- a/packages/widget-provider-ethereum/src/providers/EthereumProviderValues.tsx
+++ b/packages/widget-provider-ethereum/src/providers/EthereumProviderValues.tsx
@@ -170,6 +170,7 @@ export const EthereumProviderValues: FC<
 
   const sdkProvider = useMemo(
     () =>
+      config?.sdkProvider ??
       EthereumSDKProvider({
         getWalletClient: () =>
           getConnectorClient(wagmiConfig, { assertChainId: false }),
@@ -179,7 +180,7 @@ export const EthereumProviderValues: FC<
         },
         disableMessageSigning: config?.disableMessageSigning,
       }),
-    [wagmiConfig, config?.disableMessageSigning]
+    [wagmiConfig, config?.disableMessageSigning, config?.sdkProvider]
   )
 
   const installedWallets = useMemo(

--- a/packages/widget-provider-ethereum/src/types.ts
+++ b/packages/widget-provider-ethereum/src/types.ts
@@ -1,4 +1,6 @@
-import type { WidgetProviderConfig } from '@lifi/widget-provider'
+import type { SDKProvider } from '@lifi/sdk'
+import type { SDKProviderFactory } from '@lifi/widget-provider'
+import type { Client } from 'viem'
 import type { CreateConnectorFn } from 'wagmi'
 import type {
   BaseAccountParameters,
@@ -13,11 +15,18 @@ export interface CreateConnectorFnExtended extends CreateConnectorFn {
   displayName: string
 }
 
-export interface EthereumProviderConfig extends WidgetProviderConfig {
+export interface EthereumProviderDeps {
+  getWalletClient: () => Promise<Client>
+  switchChain: (chainId: number) => Promise<Client | undefined>
+  disableMessageSigning?: boolean
+}
+
+export interface EthereumProviderConfig {
   walletConnect?: WalletConnectParameters | boolean
   coinbase?: CoinbaseWalletParameters | boolean
   metaMask?: MetaMaskParameters | boolean
   baseAccount?: BaseAccountParameters | boolean
   porto?: Partial<PortoParameters> | boolean
   disableMessageSigning?: boolean
+  sdkProvider?: SDKProvider | SDKProviderFactory<EthereumProviderDeps>
 }

--- a/packages/widget-provider-ethereum/src/types.ts
+++ b/packages/widget-provider-ethereum/src/types.ts
@@ -1,3 +1,4 @@
+import type { WidgetProviderConfig } from '@lifi/widget-provider'
 import type { CreateConnectorFn } from 'wagmi'
 import type {
   BaseAccountParameters,
@@ -12,7 +13,7 @@ export interface CreateConnectorFnExtended extends CreateConnectorFn {
   displayName: string
 }
 
-export interface EthereumProviderConfig {
+export interface EthereumProviderConfig extends WidgetProviderConfig {
   walletConnect?: WalletConnectParameters | boolean
   coinbase?: CoinbaseWalletParameters | boolean
   metaMask?: MetaMaskParameters | boolean

--- a/packages/widget-provider-solana/package.json
+++ b/packages/widget-provider-solana/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifi/widget-provider-solana",
-  "version": "4.0.0-beta.11",
+  "version": "4.0.0-alpha.5",
   "description": "LI.FI Widget Provider for Solana blockchain integration.",
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/widget-provider-solana/package.json
+++ b/packages/widget-provider-solana/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifi/widget-provider-solana",
-  "version": "4.0.0-alpha.5",
+  "version": "4.0.0-alpha.6",
   "description": "LI.FI Widget Provider for Solana blockchain integration.",
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/widget-provider-solana/src/index.ts
+++ b/packages/widget-provider-solana/src/index.ts
@@ -3,7 +3,7 @@ export {
   useWalletAccount,
 } from './hooks/useWalletAccount.js'
 export { SolanaProvider } from './providers/SolanaProvider.js'
-export type { SolanaProviderConfig } from './types.js'
+export type { SolanaProviderConfig, SolanaProviderDeps } from './types.js'
 export type {
   AccountInfo,
   SolanaWalletStandardState,

--- a/packages/widget-provider-solana/src/index.ts
+++ b/packages/widget-provider-solana/src/index.ts
@@ -3,6 +3,7 @@ export {
   useWalletAccount,
 } from './hooks/useWalletAccount.js'
 export { SolanaProvider } from './providers/SolanaProvider.js'
+export type { SolanaProviderConfig } from './types.js'
 export type {
   AccountInfo,
   SolanaWalletStandardState,

--- a/packages/widget-provider-solana/src/providers/SolanaProvider.tsx
+++ b/packages/widget-provider-solana/src/providers/SolanaProvider.tsx
@@ -1,22 +1,30 @@
 import type { WidgetProviderProps } from '@lifi/widget-provider'
 import type { JSX, PropsWithChildren } from 'react'
+import type { SolanaProviderConfig } from '../types.js'
 import { SolanaProviderValues } from './SolanaProviderValues.js'
+
+interface SolanaWidgetProviderProps extends WidgetProviderProps {
+  config?: SolanaProviderConfig
+}
 
 const SolanaWidgetProvider = ({
   children,
   isExternalContext = false,
-}: PropsWithChildren<WidgetProviderProps>) => {
+  config,
+}: PropsWithChildren<SolanaWidgetProviderProps>) => {
   return (
-    <SolanaProviderValues isExternalContext={isExternalContext}>
+    <SolanaProviderValues isExternalContext={isExternalContext} config={config}>
       {children}
     </SolanaProviderValues>
   )
 }
 
-export const SolanaProvider = (): ((
-  props: PropsWithChildren<WidgetProviderProps>
-) => JSX.Element) => {
+export const SolanaProvider = (
+  config?: SolanaProviderConfig
+): ((props: PropsWithChildren<WidgetProviderProps>) => JSX.Element) => {
   return ({ children, ...props }: PropsWithChildren<WidgetProviderProps>) => (
-    <SolanaWidgetProvider {...props}>{children}</SolanaWidgetProvider>
+    <SolanaWidgetProvider {...props} config={config}>
+      {children}
+    </SolanaWidgetProvider>
   )
 }

--- a/packages/widget-provider-solana/src/providers/SolanaProviderValues.tsx
+++ b/packages/widget-provider-solana/src/providers/SolanaProviderValues.tsx
@@ -1,7 +1,13 @@
 import { ChainId, ChainType } from '@lifi/sdk'
 import { SolanaProvider as SolanaSDKProvider } from '@lifi/sdk-provider-solana'
 import { SolanaContext } from '@lifi/widget-provider'
-import { type FC, type PropsWithChildren, useCallback, useMemo } from 'react'
+import {
+  type FC,
+  type PropsWithChildren,
+  useCallback,
+  useMemo,
+  useRef,
+} from 'react'
 import { useWalletAccount } from '../hooks/useWalletAccount.js'
 import type { SolanaProviderConfig } from '../types.js'
 import { useSolanaWalletStandard as useWallet } from '../wallet-standard/useSolanaWalletStandard.js'
@@ -59,19 +65,22 @@ export const SolanaProviderValues: FC<
 
   const isConnected = account.isConnected
 
+  const walletRef = useRef(currentWallet)
+  walletRef.current = currentWallet
+
   const sdkProvider = useMemo(
     () =>
       config?.sdkProvider ??
       SolanaSDKProvider({
         async getWallet() {
-          if (!currentWallet) {
+          if (!walletRef.current) {
             throw new Error('Wallet not connected')
           }
 
-          return currentWallet
+          return walletRef.current
         },
       }),
-    [currentWallet, config?.sdkProvider]
+    [config?.sdkProvider]
   )
 
   // Convert Wallet Standard wallets to a format the UI expects

--- a/packages/widget-provider-solana/src/providers/SolanaProviderValues.tsx
+++ b/packages/widget-provider-solana/src/providers/SolanaProviderValues.tsx
@@ -1,5 +1,8 @@
 import { ChainId, ChainType } from '@lifi/sdk'
-import { SolanaProvider as SolanaSDKProvider } from '@lifi/sdk-provider-solana'
+import {
+  isSolanaProvider,
+  SolanaProvider as SolanaSDKProvider,
+} from '@lifi/sdk-provider-solana'
 import { SolanaContext } from '@lifi/widget-provider'
 import {
   type FC,
@@ -68,20 +71,19 @@ export const SolanaProviderValues: FC<
   const walletRef = useRef(currentWallet)
   walletRef.current = currentWallet
 
-  const sdkProvider = useMemo(
-    () =>
-      config?.sdkProvider ??
-      SolanaSDKProvider({
-        async getWallet() {
-          if (!walletRef.current) {
-            throw new Error('Wallet not connected')
-          }
-
-          return walletRef.current
-        },
-      }),
-    [config?.sdkProvider]
-  )
+  const sdkProvider = useMemo(() => {
+    const getWallet = async () => {
+      if (!walletRef.current) {
+        throw new Error('Wallet not connected')
+      }
+      return walletRef.current
+    }
+    const provider = config?.sdkProvider ?? SolanaSDKProvider({ getWallet })
+    if (isSolanaProvider(provider)) {
+      provider.setOptions({ getWallet })
+    }
+    return provider
+  }, [config?.sdkProvider])
 
   // Convert Wallet Standard wallets to a format the UI expects
   const installedWallets = useMemo(

--- a/packages/widget-provider-solana/src/providers/SolanaProviderValues.tsx
+++ b/packages/widget-provider-solana/src/providers/SolanaProviderValues.tsx
@@ -1,8 +1,5 @@
 import { ChainId, ChainType } from '@lifi/sdk'
-import {
-  isSolanaProvider,
-  SolanaProvider as SolanaSDKProvider,
-} from '@lifi/sdk-provider-solana'
+import { SolanaProvider as SolanaSDKProvider } from '@lifi/sdk-provider-solana'
 import { SolanaContext } from '@lifi/widget-provider'
 import {
   type FC,
@@ -78,11 +75,10 @@ export const SolanaProviderValues: FC<
       }
       return walletRef.current
     }
-    const provider = config?.sdkProvider ?? SolanaSDKProvider({ getWallet })
-    if (isSolanaProvider(provider)) {
-      provider.setOptions({ getWallet })
+    if (typeof config?.sdkProvider === 'function') {
+      return config.sdkProvider({ getWallet })
     }
-    return provider
+    return config?.sdkProvider ?? SolanaSDKProvider({ getWallet })
   }, [config?.sdkProvider])
 
   // Convert Wallet Standard wallets to a format the UI expects

--- a/packages/widget-provider-solana/src/providers/SolanaProviderValues.tsx
+++ b/packages/widget-provider-solana/src/providers/SolanaProviderValues.tsx
@@ -3,15 +3,17 @@ import { SolanaProvider as SolanaSDKProvider } from '@lifi/sdk-provider-solana'
 import { SolanaContext } from '@lifi/widget-provider'
 import { type FC, type PropsWithChildren, useCallback, useMemo } from 'react'
 import { useWalletAccount } from '../hooks/useWalletAccount.js'
+import type { SolanaProviderConfig } from '../types.js'
 import { useSolanaWalletStandard as useWallet } from '../wallet-standard/useSolanaWalletStandard.js'
 
 interface SolanaProviderValuesProps {
   isExternalContext: boolean
+  config?: SolanaProviderConfig
 }
 
 export const SolanaProviderValues: FC<
   PropsWithChildren<SolanaProviderValuesProps>
-> = ({ children, isExternalContext }) => {
+> = ({ children, isExternalContext, config }) => {
   const {
     wallets,
     selectedWallet: currentWallet,
@@ -59,6 +61,7 @@ export const SolanaProviderValues: FC<
 
   const sdkProvider = useMemo(
     () =>
+      config?.sdkProvider ??
       SolanaSDKProvider({
         async getWallet() {
           if (!currentWallet) {
@@ -68,7 +71,7 @@ export const SolanaProviderValues: FC<
           return currentWallet
         },
       }),
-    [currentWallet]
+    [currentWallet, config?.sdkProvider]
   )
 
   // Convert Wallet Standard wallets to a format the UI expects

--- a/packages/widget-provider-solana/src/types.ts
+++ b/packages/widget-provider-solana/src/types.ts
@@ -1,3 +1,11 @@
-import type { WidgetProviderConfig } from '@lifi/widget-provider'
+import type { SDKProvider } from '@lifi/sdk'
+import type { SDKProviderFactory } from '@lifi/widget-provider'
+import type { Wallet } from '@wallet-standard/base'
 
-export interface SolanaProviderConfig extends WidgetProviderConfig {}
+export interface SolanaProviderDeps {
+  getWallet: () => Promise<Wallet>
+}
+
+export interface SolanaProviderConfig {
+  sdkProvider?: SDKProvider | SDKProviderFactory<SolanaProviderDeps>
+}

--- a/packages/widget-provider-solana/src/types.ts
+++ b/packages/widget-provider-solana/src/types.ts
@@ -1,0 +1,3 @@
+import type { WidgetProviderConfig } from '@lifi/widget-provider'
+
+export interface SolanaProviderConfig extends WidgetProviderConfig {}

--- a/packages/widget-provider-sui/package.json
+++ b/packages/widget-provider-sui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifi/widget-provider-sui",
-  "version": "4.0.0-beta.11",
+  "version": "4.0.0-alpha.5",
   "description": "LI.FI Widget Provider for Sui blockchain integration.",
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/widget-provider-sui/package.json
+++ b/packages/widget-provider-sui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifi/widget-provider-sui",
-  "version": "4.0.0-alpha.5",
+  "version": "4.0.0-alpha.6",
   "description": "LI.FI Widget Provider for Sui blockchain integration.",
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/widget-provider-sui/src/index.ts
+++ b/packages/widget-provider-sui/src/index.ts
@@ -1,2 +1,3 @@
 export { SuiProvider } from './providers/SuiProvider.js'
+export type { SuiProviderConfig } from './types.js'
 export { WalletSigner } from './WalletSigner.js'

--- a/packages/widget-provider-sui/src/index.ts
+++ b/packages/widget-provider-sui/src/index.ts
@@ -1,3 +1,3 @@
 export { SuiProvider } from './providers/SuiProvider.js'
-export type { SuiProviderConfig } from './types.js'
+export type { SuiProviderConfig, SuiProviderDeps } from './types.js'
 export { WalletSigner } from './WalletSigner.js'

--- a/packages/widget-provider-sui/src/providers/SuiBaseProvider.tsx
+++ b/packages/widget-provider-sui/src/providers/SuiBaseProvider.tsx
@@ -7,17 +7,20 @@ import {
 import { SuiGrpcClient } from '@mysten/sui/grpc'
 import { getJsonRpcFullnodeUrl } from '@mysten/sui/jsonRpc'
 import { type FC, type PropsWithChildren, useRef } from 'react'
+import type { SuiProviderConfig } from '../types.js'
 import { SuiProviderValues } from './SuiProviderValues.js'
 
 interface SuiBaseProviderProps {
   chains?: ExtendedChain[]
   isExternalContext?: boolean
+  config?: SuiProviderConfig
 }
 
 export const SuiBaseProvider: FC<PropsWithChildren<SuiBaseProviderProps>> = ({
   chains,
   children,
   isExternalContext = false,
+  config,
 }) => {
   const storageKey = 'li.fi-sui-dapp-kit'
   const dappKit = useRef<DefaultExpectedDppKit>(null)
@@ -40,7 +43,7 @@ export const SuiBaseProvider: FC<PropsWithChildren<SuiBaseProviderProps>> = ({
 
   return (
     <DAppKitProvider dAppKit={dappKit.current}>
-      <SuiProviderValues isExternalContext={isExternalContext}>
+      <SuiProviderValues isExternalContext={isExternalContext} config={config}>
         {children}
       </SuiProviderValues>
     </DAppKitProvider>

--- a/packages/widget-provider-sui/src/providers/SuiProvider.tsx
+++ b/packages/widget-provider-sui/src/providers/SuiProvider.tsx
@@ -1,8 +1,13 @@
 import type { WidgetProviderProps } from '@lifi/widget-provider'
 import { DAppKitContext } from '@mysten/dapp-kit-react'
 import { type JSX, type PropsWithChildren, useContext } from 'react'
+import type { SuiProviderConfig } from '../types.js'
 import { SuiBaseProvider } from './SuiBaseProvider.js'
 import { SuiProviderValues } from './SuiProviderValues.js'
+
+interface SuiWidgetProviderProps extends WidgetProviderProps {
+  config?: SuiProviderConfig
+}
 
 function useInSuiContext(): boolean {
   const context = useContext(DAppKitContext)
@@ -14,29 +19,39 @@ const SuiWidgetProvider = ({
   isExternalContext = false,
   chains,
   children,
-}: PropsWithChildren<WidgetProviderProps>) => {
+  config,
+}: PropsWithChildren<SuiWidgetProviderProps>) => {
   const inSuiContext = useInSuiContext()
   const effectiveIsExternal = isExternalContext || inSuiContext
 
   if (inSuiContext && !forceInternalWalletManagement) {
     return (
-      <SuiProviderValues isExternalContext={effectiveIsExternal}>
+      <SuiProviderValues
+        isExternalContext={effectiveIsExternal}
+        config={config}
+      >
         {children}
       </SuiProviderValues>
     )
   }
 
   return (
-    <SuiBaseProvider chains={chains} isExternalContext={effectiveIsExternal}>
+    <SuiBaseProvider
+      chains={chains}
+      isExternalContext={effectiveIsExternal}
+      config={config}
+    >
       {children}
     </SuiBaseProvider>
   )
 }
 
-export const SuiProvider = (): ((
-  props: PropsWithChildren<WidgetProviderProps>
-) => JSX.Element) => {
+export const SuiProvider = (
+  config?: SuiProviderConfig
+): ((props: PropsWithChildren<WidgetProviderProps>) => JSX.Element) => {
   return ({ children, ...props }: PropsWithChildren<WidgetProviderProps>) => (
-    <SuiWidgetProvider {...props}>{children}</SuiWidgetProvider>
+    <SuiWidgetProvider {...props} config={config}>
+      {children}
+    </SuiWidgetProvider>
   )
 }

--- a/packages/widget-provider-sui/src/providers/SuiProviderValues.tsx
+++ b/packages/widget-provider-sui/src/providers/SuiProviderValues.tsx
@@ -52,15 +52,14 @@ export const SuiProviderValues: FC<
 
   const installedWallets = useMemo(() => wallets, [wallets])
 
-  const sdkProvider = useMemo(
-    () =>
-      config?.sdkProvider ??
-      SuiSDKProvider({
-        getClient: async () => dappKit.getClient(),
-        getSigner: async () => new WalletSigner(dappKit),
-      }),
-    [dappKit, config?.sdkProvider]
-  )
+  const sdkProvider = useMemo(() => {
+    const getClient = async () => dappKit.getClient()
+    const getSigner = async () => new WalletSigner(dappKit)
+    if (typeof config?.sdkProvider === 'function') {
+      return config.sdkProvider({ getClient, getSigner })
+    }
+    return config?.sdkProvider ?? SuiSDKProvider({ getClient, getSigner })
+  }, [dappKit, config?.sdkProvider])
 
   const handleConnect = useCallback(
     async (

--- a/packages/widget-provider-sui/src/providers/SuiProviderValues.tsx
+++ b/packages/widget-provider-sui/src/providers/SuiProviderValues.tsx
@@ -8,15 +8,17 @@ import {
   useWallets,
 } from '@mysten/dapp-kit-react'
 import { type FC, type PropsWithChildren, useCallback, useMemo } from 'react'
+import type { SuiProviderConfig } from '../types.js'
 import { WalletSigner } from '../WalletSigner.js'
 
 interface SuiProviderValuesProps {
   isExternalContext: boolean
+  config?: SuiProviderConfig
 }
 
 export const SuiProviderValues: FC<
   PropsWithChildren<SuiProviderValuesProps>
-> = ({ children, isExternalContext }) => {
+> = ({ children, isExternalContext, config }) => {
   const wallets = useWallets()
   const dappKit = useDAppKit()
   const { connectWallet: connect, disconnectWallet: disconnect } = dappKit
@@ -52,11 +54,12 @@ export const SuiProviderValues: FC<
 
   const sdkProvider = useMemo(
     () =>
+      config?.sdkProvider ??
       SuiSDKProvider({
         getClient: async () => dappKit.getClient(),
         getSigner: async () => new WalletSigner(dappKit),
       }),
-    [dappKit]
+    [dappKit, config?.sdkProvider]
   )
 
   const handleConnect = useCallback(

--- a/packages/widget-provider-sui/src/types.ts
+++ b/packages/widget-provider-sui/src/types.ts
@@ -1,3 +1,13 @@
-import type { WidgetProviderConfig } from '@lifi/widget-provider'
+import type { SDKProvider } from '@lifi/sdk'
+import type { SDKProviderFactory } from '@lifi/widget-provider'
+import type { ClientWithCoreApi } from '@mysten/sui/client'
+import type { Signer } from '@mysten/sui/cryptography'
 
-export interface SuiProviderConfig extends WidgetProviderConfig {}
+export interface SuiProviderDeps {
+  getClient: () => Promise<ClientWithCoreApi>
+  getSigner: () => Promise<Signer>
+}
+
+export interface SuiProviderConfig {
+  sdkProvider?: SDKProvider | SDKProviderFactory<SuiProviderDeps>
+}

--- a/packages/widget-provider-sui/src/types.ts
+++ b/packages/widget-provider-sui/src/types.ts
@@ -1,0 +1,3 @@
+import type { WidgetProviderConfig } from '@lifi/widget-provider'
+
+export interface SuiProviderConfig extends WidgetProviderConfig {}

--- a/packages/widget-provider/package.json
+++ b/packages/widget-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifi/widget-provider",
-  "version": "4.0.0-alpha.5",
+  "version": "4.0.0-alpha.6",
   "description": "LI.FI Widget Provider - base provider package for blockchain integrations.",
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/widget-provider/package.json
+++ b/packages/widget-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifi/widget-provider",
-  "version": "4.0.0-beta.11",
+  "version": "4.0.0-alpha.5",
   "description": "LI.FI Widget Provider - base provider package for blockchain integrations.",
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/widget-provider/src/index.ts
+++ b/packages/widget-provider/src/index.ts
@@ -10,8 +10,8 @@ export { useSDKProviders } from './hooks/useSDKProviders.js'
 export type {
   Account,
   EthereumProviderContext,
+  SDKProviderFactory,
   WalletConnector,
-  WidgetProviderConfig,
   WidgetProviderContext,
   WidgetProviderProps,
 } from './types.js'

--- a/packages/widget-provider/src/index.ts
+++ b/packages/widget-provider/src/index.ts
@@ -11,6 +11,7 @@ export type {
   Account,
   EthereumProviderContext,
   WalletConnector,
+  WidgetProviderConfig,
   WidgetProviderContext,
   WidgetProviderProps,
 } from './types.js'

--- a/packages/widget-provider/src/types.ts
+++ b/packages/widget-provider/src/types.ts
@@ -7,6 +7,8 @@ import type {
   SDKProvider,
 } from '@lifi/sdk'
 
+export type SDKProviderFactory<TDeps> = (deps: TDeps) => SDKProvider
+
 export type WalletConnector = {
   name: string
   id?: string
@@ -78,8 +80,4 @@ export interface WidgetProviderProps {
   forceInternalWalletManagement?: boolean
   isExternalContext?: boolean
   chains: ExtendedChain[]
-}
-
-export interface WidgetProviderConfig {
-  sdkProvider?: SDKProvider
 }

--- a/packages/widget-provider/src/types.ts
+++ b/packages/widget-provider/src/types.ts
@@ -79,3 +79,7 @@ export interface WidgetProviderProps {
   isExternalContext?: boolean
   chains: ExtendedChain[]
 }
+
+export interface WidgetProviderConfig {
+  sdkProvider?: SDKProvider
+}

--- a/packages/widget/package.json
+++ b/packages/widget/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifi/widget",
-  "version": "4.0.0-alpha.5",
+  "version": "4.0.0-alpha.6",
   "description": "LI.FI Widget for cross-chain bridging and swapping. It will drive your multi-chain strategy and attract new users from everywhere.",
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/widget/package.json
+++ b/packages/widget/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifi/widget",
-  "version": "4.0.0-beta.14",
+  "version": "4.0.0-alpha.5",
   "description": "LI.FI Widget for cross-chain bridging and swapping. It will drive your multi-chain strategy and attract new users from everywhere.",
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/widget/src/config/version.ts
+++ b/packages/widget/src/config/version.ts
@@ -1,2 +1,2 @@
 export const name = '@lifi/widget'
-export const version = '4.0.0-beta.14'
+export const version = '4.0.0-alpha.5'

--- a/packages/widget/src/config/version.ts
+++ b/packages/widget/src/config/version.ts
@@ -1,2 +1,2 @@
 export const name = '@lifi/widget'
-export const version = '4.0.0-alpha.5'
+export const version = '4.0.0-alpha.6'

--- a/packages/widget/src/types/widget.ts
+++ b/packages/widget/src/types/widget.ts
@@ -174,6 +174,7 @@ export interface WidgetSDKConfig
     | 'apiKey'
     | 'disableVersionCheck'
     | 'integrator'
+    | 'providers'
     | 'routeOptions'
     | 'widgetVersion'
   > {


### PR DESCRIPTION
## Which Linear task is linked to this PR?
https://linear.app/lifi-linear/issue/EMB-340/allow-passing-custom-sdk-providers-per-ecosystem

## Why was it implemented this way?

Each ecosystem provider (`SolanaProvider`, `EthereumProvider`, `BitcoinProvider`, `SuiProvider`) now accepts a custom `sdkProvider` in its config. It can be either:

1. An `SDKProvider` **instance** — for fully self-contained providers.
2. A **factory** `(deps) => SDKProvider` — to compose with the widget's wallet/state resolution.

The widget never mutates the integrator's provider. Each ecosystem exposes its own typed `*ProviderDeps`:

| Ecosystem | Deps |
|---|---|
| Solana   | `getWallet` |
| Ethereum | `getWalletClient`, `switchChain`, `disableMessageSigning` |
| Bitcoin  | `getWalletClient` |
| Sui      | `getClient`, `getSigner` |

**Example (Solana with the widget's wallet state):**
```ts
SolanaProvider({
  sdkProvider: ({ getWallet }) =>
    SolanaVaultProvider({ getWallet, vaultAddress: '0x…' }),
})
```

**Example (fully self-contained):**
```ts
SolanaProvider({ sdkProvider: MyStandaloneProvider() })
```

### Other changes

- Applies a `useRef` approach to Solana wallet resolution to prevent stale closures inside the SDK provider's `getWallet`.
- Removes `providers` from `WidgetSDKConfig`. It was inherited from the SDK type but always overwritten at runtime by `setProviders`, so passing providers via `sdkConfig` had no effect. Per-ecosystem `sdkProvider` is now the single source of truth.

## Checklist before requesting a review
- [x] I have performed a self-review and testing of my code.
- [x] This pull request is focused and addresses a single problem.
