### PR TITLE
refactor: remove deprecated code

### DIFF
--- a/packages/widget-embedded/README.md
+++ b/packages/widget-embedded/README.md
@@ -351,7 +351,6 @@ function TransactionTracker() {
 | `FormFieldChanged` | `WidgetLightFormFieldChanged` | Any form field changed |
 | `WalletConnected` | `WidgetLightWalletConnected` | Wallet connected |
 | `WalletDisconnected` | `WidgetLightWalletDisconnected` | Wallet disconnected |
-| `ReviewTransactionPageEntered` | — | User entered review page |
 | `ContactSupport` | `WidgetLightContactSupport` | User clicked contact support |
 | `AvailableRoutes` | — | Routes fetched and available |
 | `PageEntered` | — | Page navigation |

--- a/packages/widget-light/src/shared/widgetLightEvents.ts
+++ b/packages/widget-light/src/shared/widgetLightEvents.ts
@@ -19,7 +19,6 @@ export enum WidgetLightEvent {
   FormFieldChanged = 'formFieldChanged',
   LowAddressActivityConfirmed = 'lowAddressActivityConfirmed',
   PageEntered = 'pageEntered',
-  ReviewTransactionPageEntered = 'reviewTransactionPageEntered',
   RouteExecutionCompleted = 'routeExecutionCompleted',
   RouteExecutionFailed = 'routeExecutionFailed',
   RouteExecutionStarted = 'routeExecutionStarted',
@@ -124,7 +123,6 @@ export interface WidgetLightEvents {
   formFieldChanged: WidgetLightFormFieldChanged
   lowAddressActivityConfirmed: WidgetLightLowAddressActivityConfirmed
   pageEntered: string
-  reviewTransactionPageEntered: unknown
   routeExecutionCompleted: unknown
   routeExecutionFailed: WidgetLightRouteExecutionUpdate
   routeExecutionStarted: unknown

--- a/packages/widget-playground/src/store/widgetConfig/utils/getLocalStorageOutput.ts
+++ b/packages/widget-playground/src/store/widgetConfig/utils/getLocalStorageOutput.ts
@@ -34,10 +34,10 @@ export const getLocalStorageOutput = (
                   },
                 }
               : {}),
-            ...(config.theme.palette
+            ...(config.theme.colorSchemes
               ? {
-                  palette: {
-                    ...config.theme.palette,
+                  colorSchemes: {
+                    ...config.theme.colorSchemes,
                   },
                 }
               : {}),

--- a/packages/widget-playground/src/utils/cloneStructuredConfig.test.ts
+++ b/packages/widget-playground/src/utils/cloneStructuredConfig.test.ts
@@ -6,9 +6,13 @@ describe('cloneStructuredConfig', () => {
   test('performs a deep clone', () => {
     const config = {
       theme: {
-        palette: {
-          primary: {
-            main: '#5C67FF',
+        colorSchemes: {
+          light: {
+            palette: {
+              primary: {
+                main: '#5C67FF',
+              },
+            },
           },
         },
       },
@@ -18,18 +22,22 @@ describe('cloneStructuredConfig', () => {
 
     expect(copy).toEqual({
       theme: {
-        palette: {
-          primary: {
-            main: '#5C67FF',
+        colorSchemes: {
+          light: {
+            palette: {
+              primary: {
+                main: '#5C67FF',
+              },
+            },
           },
         },
       },
     })
 
     expect(copy.theme).not.toBe(config.theme)
-    expect(copy.theme?.palette).not.toBe(config.theme?.palette)
-    expect(copy.theme?.palette?.primary).not.toBe(
-      config.theme?.palette?.primary
+    expect(copy.theme?.colorSchemes).not.toBe(config.theme?.colorSchemes)
+    expect(copy.theme?.colorSchemes?.light?.palette?.primary).not.toBe(
+      config.theme?.colorSchemes?.light?.palette?.primary
     )
   })
 

--- a/packages/widget/src/pages/TransactionPage/TransactionPage.tsx
+++ b/packages/widget/src/pages/TransactionPage/TransactionPage.tsx
@@ -2,7 +2,7 @@ import type { ExchangeRateUpdateParams } from '@lifi/sdk'
 import Delete from '@mui/icons-material/Delete'
 import { Box, Button, Tooltip } from '@mui/material'
 import { useLocation, useNavigate } from '@tanstack/react-router'
-import { type JSX, useEffect, useMemo, useRef, useState } from 'react'
+import { type JSX, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { BottomSheetBase } from '../../components/BottomSheet/types.js'
 import { ContractComponent } from '../../components/ContractComponent/ContractComponent.js'
@@ -105,13 +105,6 @@ export const TransactionPage = (): JSX.Element | null => {
   )
 
   useHeader(getHeaderTitle(), headerAction)
-
-  // biome-ignore lint/correctness/useExhaustiveDependencies: We want to emit event only when the page is mounted
-  useEffect(() => {
-    if (status === RouteExecutionStatus.Idle) {
-      emitter.emit(WidgetEvent.ReviewTransactionPageEntered, route)
-    }
-  }, [])
 
   if (!route) {
     return null

--- a/packages/widget/src/stores/settings/createSettingsStore.ts
+++ b/packages/widget/src/stores/settings/createSettingsStore.ts
@@ -177,15 +177,7 @@ export const createSettingsStore = (
           })
           return state
         },
-        migrate: (persistedState: any, version) => {
-          if (version === 1) {
-            persistedState.slippage = defaultConfigurableSettings.slippage
-          }
-          if (version <= 3) {
-            persistedState.routePriority = 'CHEAPEST'
-          }
-          return persistedState as SettingsState
-        },
+        migrate: () => ({}),
         onRehydrateStorage: () => {
           const initializeLanguageSettings = async (
             state: SettingsState,

--- a/packages/widget/src/themes/createTheme.ts
+++ b/packages/widget/src/themes/createTheme.ts
@@ -38,10 +38,8 @@ const enterKeyframe = keyframes`
 `
 
 export const createTheme = (widgetTheme: WidgetTheme = {}): Theme => {
-  const configuredPaletteLight =
-    widgetTheme.colorSchemes?.light?.palette ?? widgetTheme.palette
-  const configuredPaletteDark =
-    widgetTheme.colorSchemes?.dark?.palette ?? widgetTheme.palette
+  const configuredPaletteLight = widgetTheme.colorSchemes?.light?.palette
+  const configuredPaletteDark = widgetTheme.colorSchemes?.dark?.palette
 
   const primaryMainColorLight =
     (configuredPaletteLight?.primary as SimplePaletteColorOptions)?.main ??
@@ -90,7 +88,7 @@ export const createTheme = (widgetTheme: WidgetTheme = {}): Theme => {
         palette: {
           ...palette,
           ...paletteLight,
-          ...(widgetTheme.colorSchemes?.light?.palette ?? widgetTheme.palette),
+          ...widgetTheme.colorSchemes?.light?.palette,
           primary: {
             main: primaryMainColorLight,
             light: primaryLightenColorLight,
@@ -107,7 +105,7 @@ export const createTheme = (widgetTheme: WidgetTheme = {}): Theme => {
         palette: {
           ...palette,
           ...paletteDark,
-          ...(widgetTheme.colorSchemes?.dark?.palette ?? widgetTheme.palette),
+          ...widgetTheme.colorSchemes?.dark?.palette,
           primary: {
             main: primaryMainColorDark,
             light: primaryLightenColorDark,

--- a/packages/widget/src/types/events.ts
+++ b/packages/widget/src/types/events.ts
@@ -12,10 +12,6 @@ export enum WidgetEvent {
   FormFieldChanged = 'formFieldChanged',
   LowAddressActivityConfirmed = 'lowAddressActivityConfirmed',
   PageEntered = 'pageEntered',
-  /**
-   * @deprecated Use `PageEntered` event instead.
-   */
-  ReviewTransactionPageEntered = 'reviewTransactionPageEntered',
   RouteExecutionCompleted = 'routeExecutionCompleted',
   RouteExecutionFailed = 'routeExecutionFailed',
   RouteExecutionStarted = 'routeExecutionStarted',
@@ -37,7 +33,6 @@ export type WidgetEvents = {
   formFieldChanged: FormFieldChanged
   lowAddressActivityConfirmed: LowAddressActivityConfirmed
   pageEntered: NavigationRouteType
-  reviewTransactionPageEntered?: Route
   routeExecutionCompleted: Route
   routeExecutionFailed: RouteExecutionUpdate
   routeExecutionStarted: Route

--- a/packages/widget/src/types/widget.ts
+++ b/packages/widget/src/types/widget.ts
@@ -81,10 +81,6 @@ export type WidgetThemeComponents = Partial<
 >
 
 export type WidgetTheme = {
-  /**
-   * @deprecated Use `colorScheme` instead.
-   */
-  palette?: PaletteOptions
   colorSchemes?: {
     light?: {
       palette: PaletteOptions


### PR DESCRIPTION
## Which Linear task is linked to this PR?  
https://linear.app/lifi-linear/issue/EMB-162/remove-deprecated-code-from-the-widget

## Why was it implemented this way?
- Drop `ReviewTransactionPageEntered` event.
- `palette` is deprecated and replaced with `colorSchemes`.
- The settings store migration logic for versions 1–3 is no longer needed as those versions are far behind the current user base, so it is replaced with a clean reset.

## Checklist before requesting a review  
- [x] I have performed a self-review and testing of my code.  
- [x] This pull request is focused and addresses a single problem.  