### PR TITLE
feat: add checkbox confirmation to high value loss bottom sheet

### DIFF
--- a/packages/widget/src/i18n/en.json
+++ b/packages/widget/src/i18n/en.json
@@ -132,6 +132,9 @@
       "slippageOutsideRecommendedLimits": "High slippage tolerance may result in unfavorable trade caused by front-running.",
       "slippageUnderRecommendedLimits": "Low slippage tolerance may cause transaction delays or failures."
     },
+    "checkbox": {
+      "highValueLoss": "I accept the high value loss"
+    },
     "title": {
       "clearFailedTransactions": "Clear all failed transactions?",
       "highValueLoss": "High value loss",

--- a/packages/widget/src/pages/TransactionPage/TokenValueBottomSheet.tsx
+++ b/packages/widget/src/pages/TransactionPage/TokenValueBottomSheet.tsx
@@ -188,12 +188,12 @@ const TokenValueBottomSheetContent: React.FC<TokenValueBottomSheetProps> = ({
           />
         }
         label={t('warning.checkbox.highValueLoss')}
-        sx={{ mt: 2 }}
+        sx={{ mt: 1 }}
       />
       <Box
         sx={{
           display: 'flex',
-          mt: 2,
+          mt: 1,
         }}
       >
         <Button variant="text" onClick={onCancel} fullWidth>

--- a/packages/widget/src/pages/TransactionPage/TokenValueBottomSheet.tsx
+++ b/packages/widget/src/pages/TransactionPage/TokenValueBottomSheet.tsx
@@ -1,8 +1,14 @@
 import type { Route } from '@lifi/sdk'
 import WarningRounded from '@mui/icons-material/WarningRounded'
-import { Box, Button, Typography } from '@mui/material'
+import {
+  Box,
+  Button,
+  Checkbox,
+  FormControlLabel,
+  Typography,
+} from '@mui/material'
 import type { ForwardRefExoticComponent, RefAttributes, RefObject } from 'react'
-import { forwardRef, useRef } from 'react'
+import { forwardRef, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { BottomSheet } from '../../components/BottomSheet/BottomSheet.js'
 import type { BottomSheetBase } from '../../components/BottomSheet/types.js'
@@ -44,6 +50,7 @@ const TokenValueBottomSheetContent: React.FC<TokenValueBottomSheetProps> = ({
   onCancel,
   onContinue,
 }) => {
+  const [accepted, setAccepted] = useState(false)
   const { t } = useTranslation()
   const ref = useRef<HTMLElement>(null)
   useSetContentHeight(ref)
@@ -173,10 +180,20 @@ const TokenValueBottomSheetContent: React.FC<TokenValueBottomSheetProps> = ({
           %
         </Typography>
       </Box>
+      <FormControlLabel
+        control={
+          <Checkbox
+            checked={accepted}
+            onChange={(_, checked) => setAccepted(checked)}
+          />
+        }
+        label={t('warning.checkbox.highValueLoss')}
+        sx={{ mt: 2 }}
+      />
       <Box
         sx={{
           display: 'flex',
-          mt: 3,
+          mt: 2,
         }}
       >
         <Button variant="text" onClick={onCancel} fullWidth>
@@ -188,7 +205,12 @@ const TokenValueBottomSheetContent: React.FC<TokenValueBottomSheetProps> = ({
             p: 1,
           }}
         />
-        <Button variant="contained" onClick={onContinue} fullWidth>
+        <Button
+          variant="contained"
+          onClick={onContinue}
+          disabled={!accepted}
+          fullWidth
+        >
           {t('button.continue')}
         </Button>
       </Box>


### PR DESCRIPTION
## Which Linear task is linked to this PR?
https://linear.app/lifi-linear/issue/EMB-318/widget-add-checkbox-confirmation-to-high-value-loss-bottom-sheet

## Why was it implemented this way?
Added a checkbox inside the existing `TokenValueBottomSheet` that must be checked before the "Continue" button becomes enabled. This adds deliberate friction for transactions with 10%+ value loss without changing the existing flow or introducing new screens.

## Visual showcase (Screenshots or Videos)
https://github.com/user-attachments/assets/a6fbddb0-0f24-4363-848f-f3c80a752166

## Checklist before requesting a review
- [x] I have performed a self-review and testing of my code.
- [x] This pull request is focused and addresses a single problem.
- [ ] If this PR modifies the Widget API or adds new features that require documentation, I have updated the documentation in the [public-docs](https://github.com/lifinance/public-docs) repository.