### PR TITLE
feat: allow passing custom sdk provider for Tron ecosystem

### DIFF
--- a/packages/widget-provider-tron/src/index.ts
+++ b/packages/widget-provider-tron/src/index.ts
@@ -1,3 +1,3 @@
 export { createTronAdapters } from './config/adapters.js'
 export { TronProvider } from './providers/TronProvider.js'
-export type { TronProviderConfig } from './types.js'
+export type { TronProviderConfig, TronProviderDeps } from './types.js'

--- a/packages/widget-provider-tron/src/providers/TronProvider.tsx
+++ b/packages/widget-provider-tron/src/providers/TronProvider.tsx
@@ -30,7 +30,10 @@ const TronWidgetProvider = ({
 
   if (inTronContext && !forceInternalWalletManagement) {
     return (
-      <TronProviderValues isExternalContext={effectiveIsExternal}>
+      <TronProviderValues
+        isExternalContext={effectiveIsExternal}
+        config={config}
+      >
         {children}
       </TronProviderValues>
     )
@@ -38,7 +41,10 @@ const TronWidgetProvider = ({
 
   return (
     <TronBaseProvider config={config}>
-      <TronProviderValues isExternalContext={effectiveIsExternal}>
+      <TronProviderValues
+        isExternalContext={effectiveIsExternal}
+        config={config}
+      >
         {children}
       </TronProviderValues>
     </TronBaseProvider>

--- a/packages/widget-provider-tron/src/providers/TronProviderValues.tsx
+++ b/packages/widget-provider-tron/src/providers/TronProviderValues.tsx
@@ -6,15 +6,23 @@ import {
   WalletReadyState,
 } from '@tronweb3/tronwallet-abstract-adapter'
 import { useWallet } from '@tronweb3/tronwallet-adapter-react-hooks'
-import { type FC, type PropsWithChildren, useCallback, useMemo } from 'react'
+import {
+  type FC,
+  type PropsWithChildren,
+  useCallback,
+  useMemo,
+  useRef,
+} from 'react'
+import type { TronProviderConfig } from '../types.js'
 
 interface TronProviderValuesProps {
   isExternalContext: boolean
+  config?: TronProviderConfig
 }
 
 export const TronProviderValues: FC<
   PropsWithChildren<TronProviderValuesProps>
-> = ({ children, isExternalContext }) => {
+> = ({ children, isExternalContext, config }) => {
   const {
     address,
     connected: isConnected,
@@ -63,19 +71,27 @@ export const TronProviderValues: FC<
     [address, connector, isConnected, connecting]
   )
 
-  const sdkProvider = useMemo(
-    () =>
-      TronSDKProvider({
+  const walletRef = useRef(currentWallet)
+  walletRef.current = currentWallet
+
+  const sdkProvider = useMemo(() => {
+    const getWallet = async () => {
+      if (!walletRef.current?.adapter) {
+        throw new Error('No Tron wallet connected')
+      }
+      return walletRef.current.adapter
+    }
+    if (typeof config?.sdkProvider === 'function') {
+      return config.sdkProvider({ getWallet })
+    }
+    return (
+      config?.sdkProvider ??
+      (TronSDKProvider({
+        getWallet,
         multicallBatchSize: 40,
-        getWallet: async () => {
-          if (!currentWallet?.adapter) {
-            throw new Error('No Tron wallet connected')
-          }
-          return currentWallet.adapter
-        },
-      }) as SDKProvider,
-    [currentWallet]
-  )
+      }) as SDKProvider)
+    )
+  }, [config?.sdkProvider])
 
   const installedWallets = useMemo(
     () =>

--- a/packages/widget-provider-tron/src/types.ts
+++ b/packages/widget-provider-tron/src/types.ts
@@ -1,5 +1,13 @@
+import type { SDKProvider } from '@lifi/sdk'
+import type { SDKProviderFactory } from '@lifi/widget-provider'
+import type { Adapter } from '@tronweb3/tronwallet-abstract-adapter'
 import type { WalletConnectAdapterConfig } from '@tronweb3/tronwallet-adapters'
+
+export interface TronProviderDeps {
+  getWallet: () => Promise<Adapter>
+}
 
 export interface TronProviderConfig {
   walletConnect?: WalletConnectAdapterConfig | boolean
+  sdkProvider?: SDKProvider | SDKProviderFactory<TronProviderDeps>
 }


### PR DESCRIPTION
## Which Linear task is linked to this PR?
https://linear.app/lifi-linear/issue/EMB-340/allow-passing-custom-sdk-providers-per-ecosystem

## Why was it implemented this way?
PR #702 introduced the custom `sdkProvider` pattern for Bitcoin, Ethereum, Solana, and Sui but missed the Tron ecosystem. This PR aligns Tron with the same approach:

- `TronProviderConfig` now accepts `sdkProvider` as either an `SDKProvider` instance or a `(deps) => SDKProvider` factory
- `TronProviderDeps` exposes `{ getWallet: () => Promise<Adapter> }`
- `TronProviderValues` implements the same 3-way resolution (factory → instance → default)
- Config is now passed through to `TronProviderValues` in both code paths (external context and base provider)
- Applies `useRef` for `currentWallet` to prevent stale closures (same fix applied to Solana in #702)

## Checklist before requesting a review
- [x] I have performed a self-review and testing of my code.
- [x] This pull request is focused and addresses a single problem.