### PR TITLE
fix: show custom labels only on last step

### DIFF
--- a/packages/widget/src/hooks/useActionMessage.ts
+++ b/packages/widget/src/hooks/useActionMessage.ts
@@ -7,7 +7,8 @@ import { useAvailableChains } from './useAvailableChains.js'
 
 export const useActionMessage = (
   step?: LiFiStepExtended,
-  action?: ExecutionAction
+  action?: ExecutionAction,
+  defaultLabelsOnly?: boolean
 ): { title?: string; message?: string } => {
   const { subvariant, subvariantOptions } = useWidgetConfig()
   const { t } = useTranslation()
@@ -27,7 +28,7 @@ export const useActionMessage = (
     action.type,
     action.status,
     action.substatus,
-    subvariant,
-    subvariantOptions
+    defaultLabelsOnly ? undefined : subvariant,
+    defaultLabelsOnly ? undefined : subvariantOptions
   )
 }

--- a/packages/widget/src/pages/TransactionDetailsPage/StepActionRow.tsx
+++ b/packages/widget/src/pages/TransactionDetailsPage/StepActionRow.tsx
@@ -10,8 +10,9 @@ export const StepActionRow: React.FC<{
   step: LiFiStepExtended
   action: ExecutionAction
   href: string
-}> = ({ step, action, href }) => {
-  const { title } = useActionMessage(step, action)
+  defaultLabelsOnly?: boolean
+}> = ({ step, action, href, defaultLabelsOnly }) => {
+  const { title } = useActionMessage(step, action, defaultLabelsOnly)
   const isFailed = action?.status === 'FAILED'
   return (
     <ActionRow

--- a/packages/widget/src/pages/TransactionDetailsPage/StepActionsList.tsx
+++ b/packages/widget/src/pages/TransactionDetailsPage/StepActionsList.tsx
@@ -46,20 +46,27 @@ export const StepActionsList: React.FC<StepActionsListProps> = ({
     return null
   }
 
+  const lastStepIndex = stepRows.length - 1
+
   return (
     <TransactionList>
-      {stepRows.map(({ step, rows }) => (
-        <TransactionList key={step.id}>
-          {rows.map(({ action, href }, index) => (
-            <StepActionRow
-              key={index}
-              step={step}
-              action={action!}
-              href={href!}
-            />
-          ))}
-        </TransactionList>
-      ))}
+      {stepRows.map(({ step, rows }, stepIndex) => {
+        const lastRowIndex = rows.length - 1
+        const isLastStep = stepIndex === lastStepIndex
+        return (
+          <TransactionList key={step.id}>
+            {rows.map(({ action, href }, rowIndex) => (
+              <StepActionRow
+                key={rowIndex}
+                step={step}
+                action={action!}
+                href={href!}
+                defaultLabelsOnly={!(isLastStep && rowIndex === lastRowIndex)}
+              />
+            ))}
+          </TransactionList>
+        )
+      })}
       {toAddress ? (
         <SentToWalletRow toAddress={toAddress} toChainId={route.toChainId} />
       ) : null}


### PR DESCRIPTION
## Which Linear task is linked to this PR?  
https://linear.app/lifi-linear/issue/JUM-828/weird-ui-after-a-tx-when-clicking-on-view-details

## Why was it implemented this way?  
When the widget is used with a custom `subvariant` (e.g. earn deposits), the `SWAP` and `RECEIVING_CHAIN` action message handlers resolve to custom labels like "Deposit completed" instead of the default "Swap completed" / "Bridge completed". In a multi-step earn flow (swap → approve → deposit), every step with a SWAP or RECEIVING_CHAIN action ends up showing the same custom label (e.g. three rows all saying "Deposit completed"), making it impossible to tell the steps apart.

The fix applies custom labels (`subvariant`/`subvariantOptions`) only to the very last action of the last step — the one that actually represents the final operation (e.g. the deposit). All preceding steps use default labels ("Swap completed", "Token allowance approved", etc.), so each row in the transaction details view is distinguishable.

## Visual showcase (Screenshots or Videos)  
See screenshot in the linked Linear issue.

## Checklist before requesting a review  
- [x] I have performed a self-review and testing of my code.  
- [x] This pull request is focused and addresses a single problem.  
- [ ] If this PR modifies the Widget API or adds new features that require documentation, I have updated the documentation in the [public-docs](https://github.com/lifinance/public-docs) repository.