### PR TITLE
fix(widget): support page container theming and zero-padding headers

### DIFF
--- a/packages/widget-light/src/shared/widgetConfig.ts
+++ b/packages/widget-light/src/shared/widgetConfig.ts
@@ -106,6 +106,7 @@ export interface WidgetNavigationProps {
 
 export interface WidgetTheme {
   container?: WidgetCSSProperties
+  pageContainer?: WidgetCSSProperties
   routesContainer?: WidgetCSSProperties
   chainSidebarContainer?: WidgetCSSProperties
   header?: WidgetCSSProperties

--- a/packages/widget-playground/src/defaultWidgetConfig.ts
+++ b/packages/widget-playground/src/defaultWidgetConfig.ts
@@ -335,6 +335,9 @@ export const defaultWidgetConfig: Partial<WidgetConfig> = {
       boxShadow: '0px 8px 32px rgba(0, 0, 0, 0.08)',
       borderRadius: '16px',
     },
+    // pageContainer: {
+    //   padding: 0,
+    // },
     // routesContainer: {
     //   boxShadow: '0px 8px 32px rgba(0, 0, 0, 0.08)',
     //   borderRadius: '16px',

--- a/packages/widget/src/components/Header/Header.style.ts
+++ b/packages/widget/src/components/Header/Header.style.ts
@@ -20,6 +20,8 @@ export const HeaderAppBar: React.FC<
   flexDirection: 'row',
   alignItems: 'center',
   position: 'relative',
+  width: '100%',
+  minWidth: 0,
 }))
 
 export const Container: React.FC<
@@ -36,7 +38,8 @@ export const Container: React.FC<
     zIndex: 1200,
     gap: theme.spacing(0.5),
     padding: theme.spacing(1.5, 3, 1.5, 3),
-    overflow: 'auto',
+    overflowX: 'clip',
+    overflowY: 'auto',
     borderRadius: theme.container?.borderRadius ?? 0,
     ...theme.header,
     ...(theme.header?.position === 'fixed'
@@ -87,6 +90,7 @@ export const DrawerWalletContainer: React.FC<
   width: '100%',
   display: 'flex',
   justifyContent: 'space-between',
+  minWidth: 0,
 
   ...(theme.navigation.edge && {
     '& button:first-of-type': {
@@ -103,6 +107,7 @@ export const HeaderControlsContainer: React.FC<
 > = styled(Box)(({ theme }) => ({
   display: 'flex',
   gap: theme.spacing(0.5),
+  flexShrink: 0,
   ...(theme.navigation.edge && {
     '& button:last-of-type': {
       marginRight: theme.spacing(-1.25),

--- a/packages/widget/src/components/Header/NavigationHeader.tsx
+++ b/packages/widget/src/components/Header/NavigationHeader.tsx
@@ -42,7 +42,7 @@ export const NavigationHeader: React.FC = () => {
     <HeaderAppBar elevation={0} sx={{ paddingTop: 1, paddingBottom: 0.5 }}>
       {backButtonRoutes.includes(path) ? <BackButton /> : null}
       {showSplitOptions ? (
-        <Box sx={{ flex: 1, marginRight: 1 }}>
+        <Box sx={{ flex: 1, marginRight: 1, minWidth: 0 }}>
           <SplitNavigationTabs />
         </Box>
       ) : (
@@ -53,6 +53,7 @@ export const NavigationHeader: React.FC = () => {
             fontSize: hasPath ? 18 : 24,
             fontWeight: '700',
             flex: 1,
+            minWidth: 0,
           }}
         >
           {title}

--- a/packages/widget/src/components/PageContainer.ts
+++ b/packages/widget/src/components/PageContainer.ts
@@ -23,6 +23,7 @@ export const PageContainer: React.FC<
     bottomGutters ? 3 : 0,
     halfGutters ? 1.5 : 3
   ),
+  ...theme.pageContainer,
   variants: [
     {
       props: ({ disableGutters }) => disableGutters,

--- a/packages/widget/src/themes/createTheme.ts
+++ b/packages/widget/src/themes/createTheme.ts
@@ -20,6 +20,62 @@ import { palette, paletteDark, paletteLight } from './palettes.js'
 import type {} from './types.js'
 import { getStyleOverrides } from './utils.js'
 
+const zeroCssValuePattern = /^0(?:[a-z%]+)?$/i
+
+const isZeroCssValue = (value: string | number | undefined): boolean => {
+  if (value === undefined) {
+    return false
+  }
+
+  if (typeof value === 'number') {
+    return value === 0
+  }
+
+  return zeroCssValuePattern.test(value.trim())
+}
+
+const hasZeroHorizontalPadding = (header?: WidgetTheme['header']): boolean => {
+  if (!header) {
+    return false
+  }
+
+  const explicitHorizontalValues = [
+    header.paddingInlineStart,
+    header.paddingLeft,
+    header.paddingInlineEnd,
+    header.paddingRight,
+  ].filter((value) => value !== undefined)
+
+  if (explicitHorizontalValues.length) {
+    return explicitHorizontalValues.every((value) => isZeroCssValue(value))
+  }
+
+  const shorthand = header.paddingInline ?? header.padding
+
+  if (shorthand === undefined) {
+    return false
+  }
+
+  if (typeof shorthand === 'number') {
+    return shorthand === 0
+  }
+
+  const parts = shorthand.trim().split(/\s+/).filter(Boolean)
+
+  if (parts.length === 0) {
+    return false
+  }
+
+  const horizontalParts =
+    parts.length === 1
+      ? [parts[0]]
+      : parts.length === 2 || parts.length === 3
+        ? [parts[1]]
+        : [parts[1], parts[3]]
+
+  return horizontalParts.every((value) => isZeroCssValue(value))
+}
+
 const shape: Shape = {
   borderRadius: 12,
   borderRadiusSecondary: 12,
@@ -120,11 +176,14 @@ export const createTheme = (widgetTheme: WidgetTheme = {}): Theme => {
       },
     },
     container: widgetTheme.container,
+    pageContainer: widgetTheme.pageContainer,
     routesContainer: widgetTheme.routesContainer,
     chainSidebarContainer: widgetTheme.chainSidebarContainer,
     header: widgetTheme.header,
     navigation: {
-      edge: true,
+      edge:
+        widgetTheme.navigation?.edge ??
+        !hasZeroHorizontalPadding(widgetTheme.header),
       ...widgetTheme.navigation,
     },
     typography: {

--- a/packages/widget/src/themes/types.ts
+++ b/packages/widget/src/themes/types.ts
@@ -20,6 +20,7 @@ declare module '@mui/material/styles' {
   interface Theme {
     shape: Shape
     container: CSSProperties
+    pageContainer: CSSProperties
     routesContainer: CSSProperties
     chainSidebarContainer: CSSProperties
     header: CSSProperties
@@ -28,6 +29,7 @@ declare module '@mui/material/styles' {
   interface ThemeOptions {
     shape?: Partial<Shape>
     container?: CSSProperties
+    pageContainer?: CSSProperties
     routesContainer?: CSSProperties
     chainSidebarContainer?: CSSProperties
     header?: CSSProperties

--- a/packages/widget/src/types/widget.ts
+++ b/packages/widget/src/types/widget.ts
@@ -93,6 +93,7 @@ export type WidgetTheme = {
   typography?: TypographyVariantsOptions
   components?: WidgetThemeComponents
   container?: CSSProperties
+  pageContainer?: CSSProperties
   routesContainer?: CSSProperties
   chainSidebarContainer?: CSSProperties
   header?: CSSProperties


### PR DESCRIPTION
 - 修复 LI.FI Widget 在 theme.header.padding = 0 时的头部布局溢出问题
  - 新增 theme.pageContainer 配置项，允许集成方直接控制主内容区的 padding
  - 这样既能安全移除 header padding，也能统一去掉页面内容区边距，提升主题定制能力