### PR TITLE
feat(widget): allow contract calls in default and split modes

### DIFF
--- a/packages/widget-light/src/shared/widgetConfig.ts
+++ b/packages/widget-light/src/shared/widgetConfig.ts
@@ -342,6 +342,7 @@ export interface WidgetLightConfig {
 
   // -- Contract calls --
   contractCalls?: WidgetContractCall[]
+  enableContractCallsForAllModes?: boolean
   contractTool?: WidgetContractTool
 
   // -- API / fees --

--- a/packages/widget-playground/src/defaultWidgetConfig.ts
+++ b/packages/widget-playground/src/defaultWidgetConfig.ts
@@ -300,6 +300,15 @@ export const widgetBaseConfig: WidgetConfig = {
   //     },
   //   },
   // ],
+  // contractCalls: [
+  //   {
+  //     toContractAddress: '0x0000000000000000000000000000000000000000',
+  //     toContractCallData: '0x',
+  //     toContractGasLimit: '300000',
+  //     toTokenAddress: '0x0000000000000000000000000000000000000000',
+  //   },
+  // ],
+  // enableContractCallsForAllModes: true,
 }
 
 export const defaultWidgetConfig: Partial<WidgetConfig> = {

--- a/packages/widget/src/components/RouteCard/RouteTokens.tsx
+++ b/packages/widget/src/components/RouteCard/RouteTokens.tsx
@@ -10,6 +10,9 @@ export const RouteTokens: React.FC<{
   showEssentials?: boolean
 }> = ({ route, showEssentials }) => {
   const { subvariant } = useWidgetConfig()
+  const hasCustomRouteStep = route.steps.some((step) =>
+    step.includedSteps.some((includedStep) => includedStep.type === 'custom')
+  )
 
   const fromToken = {
     ...route.steps[0].action.fromToken,
@@ -22,7 +25,7 @@ export const RouteTokens: React.FC<{
       route.steps[lastStepIndex].action.toToken),
     amount: route.steps[lastStepIndex].execution?.toAmount
       ? BigInt(route.steps[lastStepIndex].execution.toAmount)
-      : subvariant === 'custom'
+      : subvariant === 'custom' || hasCustomRouteStep
         ? BigInt(route.toAmount)
         : BigInt(route.steps[lastStepIndex].estimate.toAmount),
   }

--- a/packages/widget/src/components/Step/StepActions.tsx
+++ b/packages/widget/src/components/Step/StepActions.tsx
@@ -1,4 +1,4 @@
-import type { LiFiStep, RouteExtended, StepExtended } from '@lifi/sdk'
+import type { RouteExtended, StepExtended } from '@lifi/sdk'
 import { useEthereumContext } from '@lifi/widget-provider'
 import ArrowForward from '@mui/icons-material/ArrowForward'
 import { Box, Divider, Tooltip } from '@mui/material'
@@ -17,6 +17,18 @@ import {
   StepActionsTitle,
   StepLabelTypography,
 } from './StepActions.style.js'
+
+type StepLikeWithIncludedSteps = {
+  toolDetails: StepExtended['toolDetails']
+  includedSteps?: Array<Pick<StepExtended, 'type' | 'toolDetails'>>
+}
+
+const getCustomToolDetails = (step: StepLikeWithIncludedSteps) =>
+  step.includedSteps?.find(
+    (includedStep) =>
+      includedStep.type === 'custom' &&
+      includedStep.toolDetails.key !== 'custom'
+  )?.toolDetails
 
 export const StepActions: React.FC<{
   route: RouteExtended
@@ -79,7 +91,7 @@ export const StepActions: React.FC<{
               <Box
                 sx={{ display: 'flex', flexDirection: 'column', minHeight: 32 }}
               >
-                {step.type === 'custom' && subvariant === 'custom' ? (
+                {step.type === 'custom' ? (
                   <CustomStepDetailsLabel
                     step={step}
                     subvariant={subvariant}
@@ -243,21 +255,19 @@ const CustomStepDetailsLabel: React.FC<StepDetailsLabelProps> = ({
 }) => {
   const { t } = useTranslation()
 
-  if (!subvariant) {
-    return null
+  const toolDetails = getCustomToolDetails(step) || step.toolDetails
+
+  if (subvariant !== 'custom') {
+    return (
+      <StepLabelTypography>
+        {t('main.stepDetails', {
+          tool: toolDetails.name,
+        })}
+      </StepLabelTypography>
+    )
   }
 
-  // FIXME: step transaction request overrides step tool details, but not included step tool details
-  const toolDetails =
-    subvariant === 'custom' &&
-    (step as unknown as LiFiStep).includedSteps?.length > 0
-      ? (step as unknown as LiFiStep).includedSteps.find(
-          (step) => step.tool === 'custom' && step.toolDetails.key !== 'custom'
-        )?.toolDetails || step.toolDetails
-      : step.toolDetails
-
-  const stepDetailsKey =
-    (subvariant === 'custom' && subvariantOptions?.custom) || 'checkout'
+  const stepDetailsKey = subvariantOptions?.custom || 'checkout'
 
   return (
     <StepLabelTypography>

--- a/packages/widget/src/components/Step/StepList.tsx
+++ b/packages/widget/src/components/Step/StepList.tsx
@@ -7,8 +7,12 @@ import { Step } from './Step.js'
 export const getStepList = (
   route?: RouteExtended,
   subvariant?: WidgetSubvariant
-): JSX.Element[] | undefined =>
-  route?.steps.map((step, index, steps) => {
+): JSX.Element[] | undefined => {
+  const hasCustomRouteStep = route?.steps.some((step) =>
+    step.includedSteps.some((includedStep) => includedStep.type === 'custom')
+  )
+
+  return route?.steps.map((step, index, steps) => {
     const lastIndex = steps.length - 1
     const fromToken: TokenAmount | undefined =
       index === 0
@@ -24,7 +28,7 @@ export const getStepList = (
         ...(step.execution?.toToken ?? step.action.toToken),
         amount: step.execution?.toAmount
           ? BigInt(step.execution.toAmount)
-          : subvariant === 'custom'
+          : subvariant === 'custom' || hasCustomRouteStep
             ? BigInt(route.toAmount)
             : BigInt(step.estimate.toAmount),
       }
@@ -52,3 +56,4 @@ export const getStepList = (
       </Fragment>
     )
   })
+}

--- a/packages/widget/src/components/StepActions/StepActions.tsx
+++ b/packages/widget/src/components/StepActions/StepActions.tsx
@@ -1,4 +1,4 @@
-import type { LiFiStep, StepExtended } from '@lifi/sdk'
+import type { StepExtended } from '@lifi/sdk'
 import { useEthereumContext } from '@lifi/widget-provider'
 import ArrowForward from '@mui/icons-material/ArrowForward'
 import ExpandLess from '@mui/icons-material/ExpandLess'
@@ -35,13 +35,24 @@ import type {
   StepDetailsLabelProps,
 } from './types.js'
 
+type StepLikeWithIncludedSteps = {
+  toolDetails: StepExtended['toolDetails']
+  includedSteps?: Array<Pick<StepExtended, 'type' | 'toolDetails'>>
+}
+
+const getCustomToolDetails = (step: StepLikeWithIncludedSteps) =>
+  step.includedSteps?.find(
+    (includedStep) =>
+      includedStep.type === 'custom' &&
+      includedStep.toolDetails.key !== 'custom'
+  )?.toolDetails
+
 export const StepActions: React.FC<StepActionsProps> = ({
   step,
   dense,
   ...other
 }) => {
   const { t } = useTranslation()
-  const { subvariant } = useWidgetConfig()
   const [cardExpanded, setCardExpanded] = useState(false)
 
   const handleExpand: MouseEventHandler<HTMLButtonElement> = (e) => {
@@ -50,12 +61,7 @@ export const StepActions: React.FC<StepActionsProps> = ({
   }
 
   // FIXME: step transaction request overrides step tool details, but not included step tool details
-  const toolDetails =
-    subvariant === 'custom'
-      ? step.includedSteps.find(
-          (step) => step.tool === 'custom' && step.toolDetails.key !== 'custom'
-        )?.toolDetails || step.toolDetails
-      : step.toolDetails
+  const toolDetails = getCustomToolDetails(step) || step.toolDetails
 
   return (
     <Box {...other}>
@@ -184,7 +190,7 @@ const IncludedSteps: React.FC<IncludedStepsProps> = ({ step }) => {
                 stepIcon: StepIconComponent,
               }}
             >
-              {step.type === 'custom' && subvariant === 'custom' ? (
+              {step.type === 'custom' ? (
                 <CustomStepDetailsLabel
                   step={step}
                   subvariant={subvariant}
@@ -301,21 +307,20 @@ const CustomStepDetailsLabel: React.FC<StepDetailsLabelProps> = ({
 }) => {
   const { t } = useTranslation()
 
-  if (!subvariant) {
-    return null
+  // FIXME: step transaction request overrides step tool details, but not included step tool details
+  const toolDetails = getCustomToolDetails(step) || step.toolDetails
+
+  if (subvariant !== 'custom') {
+    return (
+      <StepLabelTypography>
+        {t('main.stepDetails', {
+          tool: toolDetails.name,
+        })}
+      </StepLabelTypography>
+    )
   }
 
-  // FIXME: step transaction request overrides step tool details, but not included step tool details
-  const toolDetails =
-    subvariant === 'custom' &&
-    (step as unknown as LiFiStep).includedSteps?.length > 0
-      ? (step as unknown as LiFiStep).includedSteps.find(
-          (step) => step.tool === 'custom' && step.toolDetails.key !== 'custom'
-        )?.toolDetails || step.toolDetails
-      : step.toolDetails
-
-  const stepDetailsKey =
-    (subvariant === 'custom' && subvariantOptions?.custom) || 'checkout'
+  const stepDetailsKey = subvariantOptions?.custom || 'checkout'
 
   return (
     <StepLabelTypography>

--- a/packages/widget/src/components/StepActions/types.ts
+++ b/packages/widget/src/components/StepActions/types.ts
@@ -13,7 +13,7 @@ export interface StepActionsProps extends BoxProps {
 
 export interface StepDetailsLabelProps {
   step: Step
-  subvariant?: Extract<WidgetSubvariant, 'custom'>
+  subvariant?: WidgetSubvariant
   subvariantOptions?: SubvariantOptions
   feeConfig?: WidgetFeeConfig
   relayerSupport?: boolean

--- a/packages/widget/src/hooks/useRoutes.ts
+++ b/packages/widget/src/hooks/useRoutes.ts
@@ -59,6 +59,7 @@ export const useRoutes = ({
     subvariant,
     subvariantOptions,
     contractTool,
+    enableContractCallsForAllModes,
     bridges,
     exchanges,
     fee,
@@ -120,8 +121,13 @@ export const useRoutes = ({
 
   const hasAmount = Number(fromTokenAmount) > 0 || Number(toTokenAmount) > 0
 
-  const contractCallQuoteEnabled: boolean =
-    subvariant === 'custom' ? Boolean(contractCalls && account.address) : true
+  const shouldUseContractCallsQuote =
+    Boolean(contractCalls?.length) &&
+    (subvariant === 'custom' || enableContractCallsForAllModes)
+
+  const contractCallQuoteEnabled: boolean = shouldUseContractCallsQuote
+    ? Boolean(account.address)
+    : true
 
   // When we bridge between ecosystems we need to be sure toAddress is set and has the same chainType as toChain
   // If toAddress is set, it must have the same chainType as toChain
@@ -179,6 +185,7 @@ export const useRoutes = ({
         allowedExchanges,
         routePriority,
         subvariant,
+        enableContractCallsForAllModes,
         allowSwitchChain,
         enabledRefuel && enabledAutoRefuel,
         gasRecommendationFromAmount,
@@ -206,6 +213,7 @@ export const useRoutes = ({
       allowedExchanges,
       routePriority,
       subvariant,
+      enableContractCallsForAllModes,
       allowSwitchChain,
       enabledRefuel,
       enabledAutoRefuel,
@@ -244,6 +252,7 @@ export const useRoutes = ({
           allowedExchanges,
           routePriority,
           subvariant,
+          _enableContractCallsForAllModes,
           allowSwitchChain,
           enabledRefuel,
           gasRecommendationFromAmount,
@@ -296,7 +305,18 @@ export const useRoutes = ({
           slippage: formattedSlippage,
         })
 
-        if (subvariant === 'custom' && contractCalls && toAmount) {
+        const hasToAmount = Number(toTokenAmount) > 0
+        const hasFromAmount = Number(fromTokenAmount) > 0
+
+        if (
+          shouldUseContractCallsQuote &&
+          contractCalls &&
+          (hasToAmount || hasFromAmount)
+        ) {
+          const amountRequest = hasToAmount
+            ? { toAmount: toAmount.toString() }
+            : { fromAmount: fromAmount.toString() }
+
           const contractCallQuote = await getContractCallsQuote(
             sdkClient,
             {
@@ -304,7 +324,6 @@ export const useRoutes = ({
               fromAddress: fromAddress as string,
               fromChain: fromChainId,
               fromToken: fromTokenAddress,
-              toAmount: toAmount.toString(),
               toChain: toChainId,
               toToken: toTokenAddress,
               contractCalls,
@@ -317,18 +336,16 @@ export const useRoutes = ({
               toFallbackAddress: toAddress,
               slippage: formattedSlippage,
               fee: calculatedFee || fee,
+              ...amountRequest,
             },
             { signal }
           )
 
           contractCallQuote.action.toToken = toToken!
 
-          const customStep =
-            subvariant === 'custom'
-              ? contractCallQuote.includedSteps?.find(
-                  (step) => step.type === 'custom'
-                )
-              : undefined
+          const customStep = contractCallQuote.includedSteps?.find(
+            (step) => step.type === 'custom'
+          )
 
           if (customStep && contractTool) {
             const toolDetails = {

--- a/packages/widget/src/types/widget.ts
+++ b/packages/widget/src/types/widget.ts
@@ -315,6 +315,7 @@ export interface WidgetConfig {
   providers?: WidgetProvider[]
 
   contractCalls?: ContractCall[]
+  enableContractCallsForAllModes?: boolean
   contractComponent?: ReactNode
   contractSecondaryComponent?: ReactNode
   contractCompactComponent?: ReactNode


### PR DESCRIPTION
## Which Linear task is linked to this PR?
N/A (community contribution)

## Why was it implemented this way?
The widget already supports contractCalls in custom mode, but the route generation and step rendering logic still assumes custom-only behavior. This change adds an opt-in flag for default and split modes, supports both romAmount and 	oAmount quote paths, and keeps route UI rendering consistent when custom steps are present.

## Visual showcase (Screenshots or Videos)
N/A

## Checklist before requesting a review
- [x] I have performed a self-review and testing of my code.
- [x] This pull request is focused and addresses a single problem.
- [ ] If this PR modifies the Widget API or adds new features that require documentation, I have updated the documentation in the public-docs repository.