### PR TITLE
fix: cap All Networks avatar to 4 icons

### DIFF
--- a/packages/widget/src/components/Chains/AllChainsAvatar.tsx
+++ b/packages/widget/src/components/Chains/AllChainsAvatar.tsx
@@ -46,7 +46,7 @@ const chainTypeIcons = [
   },
 ]
 
-const maxChainAvatarsCount = chainTypeIcons.length
+const maxChainAvatarsCount = 4
 
 export const AllChainsAvatar: React.NamedExoticComponent<AllChainsAvatarProps> =
   memo(({ chains, size }: AllChainsAvatarProps): JSX.Element => {


### PR DESCRIPTION
## Which Linear task is linked to this PR?  
[EMB-347](https://linear.app/lifi-linear/issue/EMB-347/all-networks-tab-shows-max-5-icons-instead-of-4)

## Why was it implemented this way?  
`maxChainAvatarsCount` was derived from `chainTypeIcons.length` (5), but the 2x2 grid layout only supports up to 4 icons. Hardcoding the cap to 4 keeps the avatar grid clean regardless of how many ecosystem types exist.

## Checklist before requesting a review  
- [x] I have performed a self-review and testing of my code.  
- [x] This pull request is focused and addresses a single problem.  