### PR TITLE
fix: add strictExecutionOrder to work around rolldown rc.17 regression

### DIFF
--- a/packages/widget-embedded/vite.config.ts
+++ b/packages/widget-embedded/vite.config.ts
@@ -11,6 +11,9 @@ export default defineConfig({
     sourcemap: true,
     chunkSizeWarningLimit: 5000,
     rolldownOptions: {
+      output: {
+        strictExecutionOrder: true,
+      },
       onwarn(warning, defaultHandler) {
         if (
           warning.code === 'EVAL' ||

--- a/packages/widget-playground-vite/vite.config.ts
+++ b/packages/widget-playground-vite/vite.config.ts
@@ -18,6 +18,9 @@ export default defineConfig({
     sourcemap: true,
     chunkSizeWarningLimit: 5000,
     rolldownOptions: {
+      output: {
+        strictExecutionOrder: true,
+      },
       onwarn(warning, defaultHandler) {
         if (
           warning.code === 'EVAL' ||


### PR DESCRIPTION
## Summary

- Fixes `Uncaught TypeError: Class extends value undefined is not a constructor or null at blob.js:3:1` when running the built vite playground
- Adds `output.strictExecutionOrder: true` to rolldown options in both `widget-playground-vite` and `widget-embedded` vite configs

## Root cause

Rolldown rc.17 (shipped in Vite 8.0.10) introduced a regression where circular chunk imports cause classes to be evaluated before their parent class is defined (temporal dead zone). Specifically, viem's `BlobSizeTooLargeError` tries to extend `BaseError`, but `BaseError` is `undefined` at evaluation time because it lives in a different chunk that hasn't finished initializing due to the circular import.

Tracked upstream:
- https://github.com/vitejs/vite/issues/22307
- https://github.com/rolldown/rolldown/issues/9161

## Fix

`strictExecutionOrder: true` forces rolldown to preserve original module evaluation order, preventing the circular TDZ issue. The tradeoff is slightly less aggressive code-splitting, which is negligible for these app packages.

This can be removed once rolldown ships the fix (rc.18+).

## Test plan

- [ ] `pnpm build` succeeds
- [ ] `pnpm preview` in `widget-playground-vite` loads without the blob.js TypeError
- [ ] `widget-embedded` builds and loads correctly in iframe