### PR TITLE
fix: load MetaMask Connect EVM SDK connector for extension & mobile

### DIFF
--- a/packages/wallet-management/src/hooks/useCombinedWallets.ts
+++ b/packages/wallet-management/src/hooks/useCombinedWallets.ts
@@ -45,7 +45,20 @@ const combineWalletLists = (
       icon: getConnectorIcon(ethereum),
       connectors: [] as CombinedWalletConnector[],
     }
-    existing.connectors.push({ connector: ethereum, chainType: ChainType.EVM })
+    // A single wallet can surface more than one EVM connector (for example a
+    // configured SDK connector and its matching EIP-6963 announcement). Keep
+    // only the first one we see for a given wallet entry so the picker shows
+    // it once. Configured connectors are unshifted to the front of the wagmi
+    // connector list, so they take precedence over auto-discovered ones.
+    const hasEvmConnector = existing.connectors.some(
+      (c) => c.chainType === ChainType.EVM
+    )
+    if (!hasEvmConnector) {
+      existing.connectors.push({
+        connector: ethereum,
+        chainType: ChainType.EVM,
+      })
+    }
     walletMap.set(normalizedName, existing)
   })
 

--- a/packages/wallet-management/src/utils/walletTags.ts
+++ b/packages/wallet-management/src/utils/walletTags.ts
@@ -1,3 +1,4 @@
+import { isWalletInstalled } from '@lifi/widget-provider'
 import type { CombinedWallet } from '../hooks/useCombinedWallets.js'
 import { WalletTagType } from '../types/walletTagType.js'
 import { getConnectorId } from './getConnectorId.js'
@@ -14,8 +15,18 @@ export const getConnectorTagType = (
     return WalletTagType.QrCode
   }
 
+  // The MetaMask SDK connector wraps an installed extension when one is
+  // present (transport: eip1193) and only falls back to the QR/relay
+  // transport when no extension is detected. Tag it as `Installed` in the
+  // former case so it sorts and labels alongside other installed wallets;
+  // otherwise show the `GetStarted` (install prompt) tag.
+  if (connectorId === 'metaMaskSDK') {
+    return isWalletInstalled('metaMask')
+      ? WalletTagType.Installed
+      : WalletTagType.GetStarted
+  }
+
   if (
-    connectorId === 'metaMaskSDK' ||
     connectorId === 'coinbaseWalletSDK' ||
     connectorId === 'baseAccount' ||
     connectorId === 'xyz.ithaca.porto'

--- a/packages/widget-provider-ethereum/src/utils/createDefaultWagmiConfig.ts
+++ b/packages/widget-provider-ethereum/src/utils/createDefaultWagmiConfig.ts
@@ -107,10 +107,16 @@ export function createDefaultWagmiConfig(
     connectors.unshift(createCoinbaseConnector(props.coinbase))
   }
 
+  // MetaMask SDK connector is always added when configured. The lazy-load gate
+  // matches any prior MetaMask connection (EIP-6963 announcement id
+  // `io.metamask` or our own `metaMaskSDK` id) so that once a user has
+  // connected MetaMask via any path, subsequent visits load the SDK and route
+  // events through it. With both connectors present in the wagmi config, the
+  // widget's wallet picker keeps the SDK entry (it is unshifted first), so
+  // SDK-level events fire consistently across desktop and mobile.
   if (
     props?.metaMask &&
-    !isWalletInstalled('metaMask') &&
-    (recentConnectorId?.includes?.('metaMaskSDK') || !props.lazy)
+    (recentConnectorId?.toLowerCase?.().includes?.('metamask') || !props.lazy)
   ) {
     connectors.unshift(createMetaMaskConnector(props.metaMask))
   }


### PR DESCRIPTION
Make the `@metamask/connect-evm` wagmi connector the canonical MetaMask entry whether or not the extension is installed. Previously the SDK connector was skipped when the extension was detected, leaving desktop on wagmi's EIP-6963 (`io.metamask`) path and mobile on the SDK path - divergent connector behavior across the two.

`createDefaultWagmiConfig`: drop the extension-presence gate. Wagmi's `multiInjectedProviderDiscovery` uses the connector's `rdns: 'io.metamask'` to dedupe against the EIP-6963 announcement, so no extra entry is added by wagmi itself. Broaden the lazy-load gate to match any prior MetaMask connection (`io.metamask` or `metaMaskSDK`) so a user who first connects via EIP-6963 still gets the SDK connector loaded on subsequent visits.

`useCombinedWallets`: keep only the first EVM connector per wallet entry. Configured connectors are unshifted to the front of the wagmi connector list, so they take precedence over auto-discovered EIP-6963 announcements. Fixes the duplicate-key React warning under MetaMask.

`walletTags`: tag `metaMaskSDK` as `Installed` (instead of `GetStarted`) when the extension is detected so MetaMask sorts to the top of the multi-ecosystem picker.

## Which Linear task is linked to this PR?  

## Why was it implemented this way?  
_Explain the reasoning behind the implementation. Were there alternative approaches? Why was this solution chosen?_  

## Visual showcase (Screenshots or Videos)  
_If applicable, attach screenshots, GIFs, or videos to showcase the functionality, UI changes, or bug fixes._  

## Checklist before requesting a review  
- [ ] I have performed a self-review and testing of my code.  
- [ ] This pull request is focused and addresses a single problem.  
- [ ] If this PR modifies the Widget API or adds new features that require documentation, I have updated the documentation in the [public-docs](https://github.com/lifinance/public-docs) repository.
