### PR TITLE
fix: add strictExecutionOrder to example apps (rolldown rc.17 regression)

### DIFF
--- a/examples/connectkit/vite.config.ts
+++ b/examples/connectkit/vite.config.ts
@@ -4,6 +4,13 @@ import { defineConfig } from 'vite'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  build: {
+    rolldownOptions: {
+      output: {
+        strictExecutionOrder: true,
+      },
+    },
+  },
   server: {
     port: 3000,
     open: true,

--- a/examples/nft-checkout/vite.config.ts
+++ b/examples/nft-checkout/vite.config.ts
@@ -10,6 +10,11 @@ export default defineConfig({
   },
   build: {
     sourcemap: true,
+    rolldownOptions: {
+      output: {
+        strictExecutionOrder: true,
+      },
+    },
   },
   server: {
     port: 3000,

--- a/examples/privy-ethers/vite.config.ts
+++ b/examples/privy-ethers/vite.config.ts
@@ -5,6 +5,13 @@ import { nodePolyfills } from 'vite-plugin-node-polyfills'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react(), nodePolyfills()],
+  build: {
+    rolldownOptions: {
+      output: {
+        strictExecutionOrder: true,
+      },
+    },
+  },
   server: {
     port: 3000,
   },

--- a/examples/privy/vite.config.ts
+++ b/examples/privy/vite.config.ts
@@ -5,6 +5,13 @@ import { nodePolyfills } from 'vite-plugin-node-polyfills'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react(), nodePolyfills()],
+  build: {
+    rolldownOptions: {
+      output: {
+        strictExecutionOrder: true,
+      },
+    },
+  },
   server: {
     port: 3000,
   },

--- a/examples/rainbowkit/vite.config.ts
+++ b/examples/rainbowkit/vite.config.ts
@@ -5,4 +5,11 @@ import { nodePolyfills } from 'vite-plugin-node-polyfills'
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react(), nodePolyfills()],
+  build: {
+    rolldownOptions: {
+      output: {
+        strictExecutionOrder: true,
+      },
+    },
+  },
 })

--- a/examples/reown/vite.config.ts
+++ b/examples/reown/vite.config.ts
@@ -5,4 +5,11 @@ import EnvCompatible from 'vite-plugin-env-compatible'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react(), EnvCompatible()],
+  build: {
+    rolldownOptions: {
+      output: {
+        strictExecutionOrder: true,
+      },
+    },
+  },
 })

--- a/examples/vite-iframe/vite.config.ts
+++ b/examples/vite-iframe/vite.config.ts
@@ -9,6 +9,13 @@ export default defineConfig({
   oxc: {
     target: 'esnext',
   },
+  build: {
+    rolldownOptions: {
+      output: {
+        strictExecutionOrder: true,
+      },
+    },
+  },
   server: {
     port: 4000,
     open: true,

--- a/examples/vite/vite.config.ts
+++ b/examples/vite/vite.config.ts
@@ -9,6 +9,13 @@ export default defineConfig({
     target: 'esnext',
   },
 
+  build: {
+    rolldownOptions: {
+      output: {
+        strictExecutionOrder: true,
+      },
+    },
+  },
   server: {
     port: 3000,
     open: true,


### PR DESCRIPTION
## Which Linear task is linked to this PR?

n/a — follows up on #718

## Why was it implemented this way?

#718 added `strictExecutionOrder: true` to `widget-embedded` and `widget-playground-vite` to work around a Rolldown rc.17 regression (introduced in `vite@8.0.10`) that causes a circular chunk dependency at runtime:

> `Class extends value undefined is not a constructor or null`

The same fix is needed for all example apps that use `@wagmi/connectors` (walletConnect/reown), as they produce the same circular chunk dependency via `@walletconnect/sign-client → @noble/secp256k1`. Without it, these apps render a blank page.

Affected examples: `vite`, `connectkit`, `privy`, `privy-ethers`, `rainbowkit`, `reown`, `vite-iframe`, `nft-checkout`.

This workaround will be removed once the upstream fix lands in Rolldown.

## Visual showcase (Screenshots or Videos)

n/a

## Checklist before requesting a review
- [x] I have performed a self-review and testing of my code.
- [x] This pull request is focused and addresses a single problem.
- [ ] If this PR modifies the Widget API or adds new features that require documentation, I have updated the documentation in the [public-docs](https://github.com/lifinance/public-docs) repository.