### PR TITLE
feat: add match function to route label rules

### DIFF
--- a/packages/widget-light/src/shared/widgetConfig.ts
+++ b/packages/widget-light/src/shared/widgetConfig.ts
@@ -292,7 +292,7 @@ export type WidgetExplorerUrl =
 
 // ---------------------------------------------------------------------------
 // Route labels — serializable subset.
-// Excluded: RouteLabel.sx (SxProps<Theme>)
+// Excluded: RouteLabel.sx (SxProps<Theme>), RouteLabelRule.match (function)
 // ---------------------------------------------------------------------------
 
 export interface WidgetRouteLabel {

--- a/packages/widget-playground/src/defaultWidgetConfig.ts
+++ b/packages/widget-playground/src/defaultWidgetConfig.ts
@@ -299,6 +299,13 @@ export const widgetBaseConfig: WidgetConfig = {
   //       allow: ['lifidexaggregator'],
   //     },
   //   },
+  //   {
+  //     label: { text: 'Low gas' },
+  //     // Custom match function — AND'd with the other criteria on the rule.
+  //     // Useful for matching on fields the built-in criteria don't cover.
+  //     match: (route) =>
+  //       route.gasCostUSD ? Number(route.gasCostUSD) < 1 : false,
+  //   },
   // ],
 }
 

--- a/packages/widget/src/components/RouteCard/getMatchingLabels.ts
+++ b/packages/widget/src/components/RouteCard/getMatchingLabels.ts
@@ -54,6 +54,11 @@ export const getMatchingLabels = (
         conditions.push(rule.toChainId.includes(route.toChainId))
       }
 
+      // Evaluate custom match function if specified
+      if (rule.match) {
+        conditions.push(rule.match(route))
+      }
+
       // Must have at least one condition and all conditions must be true
       return conditions.length && conditions.every(Boolean)
     })

--- a/packages/widget/src/types/widget.ts
+++ b/packages/widget/src/types/widget.ts
@@ -5,6 +5,7 @@ import type {
   ExecutionOptions,
   ExtendedChain,
   Order,
+  Route,
   RouteExtended,
   RouteOptions,
   SDKConfig,
@@ -286,6 +287,14 @@ export interface RouteLabelRule {
   toChainId?: number[]
   fromTokenAddress?: string[]
   toTokenAddress?: string[]
+  /**
+   * Custom match function evaluated against the route. When provided, its
+   * result is AND'd with the other matching criteria — all specified
+   * conditions must pass for the label to apply. Use this for matching logic
+   * that the built-in fields cannot express (gas costs, step count, route
+   * tags, etc.).
+   */
+  match?: (route: Route) => boolean
 }
 
 export type ExplorerUrl =


### PR DESCRIPTION
## Which Linear task is linked to this PR?
[EMB-358](https://linear.app/lifi-linear/issue/EMB-358/extend-custom-route-labels-functionality-to-support-predicate)

## Why was it implemented this way?
Adds an optional `match?: (route: Route) => boolean` to `RouteLabelRule` so integrators can label routes using logic the built-in fields can't express — gas costs, step counts, route tags, anything on the `Route` object.

The match function is pushed into the same `conditions[]` array as the existing field criteria, so it AND's with them under the rule's existing semantics. A rule with only `match` (no other fields) works because the `conditions.length` guard accepts a single condition.

Alternative considered: a separate "predicate-only rule" type. Rejected — adds a parallel code path and a second public type for one extra field. The match-function-as-another-condition slots into the existing AND model with one `if` block.

`Route` (not `RouteExtended`) was chosen because `RouteCardProps.route` is typed as `Route` at the call site — exposing `RouteExtended` would lie about what's actually passed.

`widget-light` cannot expose `match` because functions don't survive `postMessage`. The exclusion comment in `widget-light/src/shared/widgetConfig.ts` is updated so the boundary doesn't drift.

A commented predicate example was added next to the existing `routeLabels` examples in the playground default config — that block is the de-facto doc for this feature.

## Visual showcase (Screenshots or Videos)
N/A — type-level / config API addition. No UI change.

## Checklist before requesting a review
- [x] I have performed a self-review and testing of my code.
- [x] This pull request is focused and addresses a single problem.
- [x] If this PR modifies the Widget API or adds new features that require documentation, I have updated the documentation in the [public-docs](https://github.com/lifinance/public-docs) repository.