### PR TITLE
ci: simplify preview deploy workflow and refresh pinned actions

### DIFF
--- a/.github/actions/pnpm-install/action.yaml
+++ b/.github/actions/pnpm-install/action.yaml
@@ -1,5 +1,5 @@
 name: 'PNPM install'
-description: 'Run pnpm install with node_modules and cache enabled'
+description: 'Run pnpm install with node_modules + store cache'
 
 runs:
   using: 'composite'
@@ -9,11 +9,23 @@ runs:
     - name: Set up Node.js
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
-        node-version: lts/*
+        node-version: '22'
         registry-url: 'https://registry.npmjs.org'
-        cache: 'pnpm' # https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-dependencies
+    - name: Resolve pnpm store path
+      id: pnpm-store
+      shell: bash
+      run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+    - name: Cache pnpm store and node_modules
+      id: cache
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: |
+          ${{ steps.pnpm-store.outputs.path }}
+          **/node_modules
+        key: pnpm-${{ runner.os }}-node22-${{ hashFiles('pnpm-lock.yaml', 'pnpm-workspace.yaml') }}
     - name: Install dependencies
+      if: steps.cache.outputs.cache-hit != 'true'
       env:
         HUSKY: '0' # By default do not run HUSKY install
       shell: bash
-      run: pnpm install --frozen-lockfile
+      run: pnpm install --frozen-lockfile --prefer-offline

--- a/.github/actions/pnpm-install/action.yaml
+++ b/.github/actions/pnpm-install/action.yaml
@@ -5,9 +5,9 @@ runs:
   using: 'composite'
   steps:
     - name: Set up pnpm
-      uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+      uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
     - name: Set up Node.js
-      uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: lts/*
         registry-url: 'https://registry.npmjs.org'

--- a/.github/actions/pnpm-install/action.yaml
+++ b/.github/actions/pnpm-install/action.yaml
@@ -9,7 +9,7 @@ runs:
     - name: Set up Node.js
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
-        node-version: '22'
+        node-version: '24'
         registry-url: 'https://registry.npmjs.org'
     - name: Resolve pnpm store path
       id: pnpm-store
@@ -22,7 +22,7 @@ runs:
         path: |
           ${{ steps.pnpm-store.outputs.path }}
           **/node_modules
-        key: pnpm-${{ runner.os }}-node22-${{ hashFiles('pnpm-lock.yaml', 'pnpm-workspace.yaml') }}
+        key: pnpm-${{ runner.os }}-node24-${{ hashFiles('pnpm-lock.yaml', 'pnpm-workspace.yaml') }}
     - name: Install dependencies
       if: steps.cache.outputs.cache-hit != 'true'
       env:

--- a/.github/actions/pnpm-install/action.yaml
+++ b/.github/actions/pnpm-install/action.yaml
@@ -1,5 +1,5 @@
 name: 'PNPM install'
-description: 'Run pnpm install with node_modules + store cache'
+description: 'Run pnpm install with pnpm store cache'
 
 runs:
   using: 'composite'
@@ -11,20 +11,8 @@ runs:
       with:
         node-version: '24'
         registry-url: 'https://registry.npmjs.org'
-    - name: Resolve pnpm store path
-      id: pnpm-store
-      shell: bash
-      run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
-    - name: Cache pnpm store and node_modules
-      id: cache
-      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-      with:
-        path: |
-          ${{ steps.pnpm-store.outputs.path }}
-          **/node_modules
-        key: pnpm-${{ runner.os }}-node24-${{ hashFiles('pnpm-lock.yaml', 'pnpm-workspace.yaml') }}
+        cache: 'pnpm' # https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-dependencies
     - name: Install dependencies
-      if: steps.cache.outputs.cache-hit != 'true'
       env:
         HUSKY: '0' # By default do not run HUSKY install
       shell: bash

--- a/.github/workflows/delete-test-app.yaml
+++ b/.github/workflows/delete-test-app.yaml
@@ -23,7 +23,7 @@ jobs:
           echo "PROJECT_NAME=widget-${NAME:0:10}" >> $GITHUB_ENV
 
       - name: Delete project if present
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             fetch('https://api.cloudflare.com/client/v4/accounts/${{ secrets.CF_ACCOUNT_ID }}/pages/projects/${{ env.PROJECT_NAME }}', {

--- a/.github/workflows/deploy-test-app.yaml
+++ b/.github/workflows/deploy-test-app.yaml
@@ -113,9 +113,8 @@ jobs:
               })
             })
 
-      # Required to install wrangler during the next step
-      - name: Set pnpm config to ignore workspace root check
-        run: pnpm config set ignore-workspace-root-check true
+      - name: Install Wrangler
+        run: pnpm add -w --ignore-scripts wrangler@3
 
       - name: Deploy Page
         uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3.14.1

--- a/.github/workflows/deploy-test-app.yaml
+++ b/.github/workflows/deploy-test-app.yaml
@@ -37,7 +37,7 @@ jobs:
           echo "PROJECT_NAME=widget-${NAME:0:10}" >> $GITHUB_ENV
 
       - name: Create project if not present
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             fetch('https://api.cloudflare.com/client/v4/accounts/${{ secrets.CF_ACCOUNT_ID }}/pages/projects/${{ env.PROJECT_NAME }}', {
@@ -113,19 +113,15 @@ jobs:
               })
             })
 
-      - name: Install Wrangler
-        run: pnpm add -w --ignore-scripts wrangler@3
-
       - name: Deploy Page
-        uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3.14.1
-        with:
-          apiToken: ${{ secrets.CF_PAGES_API_TOKEN }}
-          accountId: ${{ secrets.CF_ACCOUNT_ID }}
-          command: |
-            pages deploy ./packages/widget-playground-vite/dist/ --project-name ${{ env.PROJECT_NAME }} --branch ${{ env.BRANCH_NAME }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_PAGES_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+        run: |
+          pnpm dlx --ignore-scripts wrangler@4.90.1 pages deploy ./packages/widget-playground-vite/dist/ --project-name ${{ env.PROJECT_NAME }} --branch ${{ env.BRANCH_NAME }}
 
       - name: Comment Test Endpoint
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             fetch("https://api.cloudflare.com/client/v4/accounts/${{ secrets.CF_ACCOUNT_ID }}/pages/projects/${{ env.PROJECT_NAME }}/deployments", {

--- a/.github/workflows/deploy-test-app.yaml
+++ b/.github/workflows/deploy-test-app.yaml
@@ -121,7 +121,7 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_PAGES_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
         run: |
-          pnpm dlx --ignore-scripts wrangler@4.90.1 pages deploy ./packages/widget-playground-vite/dist/ --project-name ${{ env.PROJECT_NAME }} --branch ${{ env.BRANCH_NAME }}
+          pnpm dlx wrangler@4.90.1 pages deploy ./packages/widget-playground-vite/dist/ --project-name ${{ env.PROJECT_NAME }} --branch ${{ env.BRANCH_NAME }}
 
       - name: Resolve preview URL
         id: preview-url

--- a/.github/workflows/deploy-test-app.yaml
+++ b/.github/workflows/deploy-test-app.yaml
@@ -16,7 +16,10 @@ jobs:
     permissions:
       contents: read
       deployments: write
-      pull-requests: write
+
+    environment:
+      name: widget-test-pr-${{ github.event.pull_request.number }}
+      url: ${{ steps.preview-url.outputs.url }}
 
     name: Publish to Cloudflare Pages
     steps:
@@ -120,27 +123,20 @@ jobs:
         run: |
           pnpm dlx --ignore-scripts wrangler@4.90.1 pages deploy ./packages/widget-playground-vite/dist/ --project-name ${{ env.PROJECT_NAME }} --branch ${{ env.BRANCH_NAME }}
 
-      - name: Comment Test Endpoint
+      - name: Resolve preview URL
+        id: preview-url
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
-            fetch("https://api.cloudflare.com/client/v4/accounts/${{ secrets.CF_ACCOUNT_ID }}/pages/projects/${{ env.PROJECT_NAME }}/deployments", {
+            const res = await fetch(`https://api.cloudflare.com/client/v4/accounts/${{ secrets.CF_ACCOUNT_ID }}/pages/projects/${{ env.PROJECT_NAME }}/deployments`, {
               headers: {
                 'Content-Type': 'application/json',
                 'Authorization': 'Bearer ${{ secrets.CF_PAGES_API_TOKEN }}'
               }
             })
-            .then((r) => r.json())
-            .then((r) => {
-              if (!r.success) {
-                console.log(r)
-                process.exit(1)
-              }
-              const obj = r.result[0]
-              github.rest.issues.createComment({
-                issue_number: context.issue.number,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                body: `Hey! This is your new endpoint: [${obj.url}](${obj.url})`
-              })
-            })
+            const data = await res.json()
+            if (!data.success) {
+              console.log(data)
+              process.exit(1)
+            }
+            core.setOutput('url', data.result[0].url)

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+        uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885 # v6.1.1
         with:
           role-to-assume: arn:aws:iam::403372804574:role/github-actions
           role-session-name: github-actions-role-session
@@ -23,7 +23,7 @@ jobs:
       
       - name: Amazon ECR login
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@183a1442edf41672e66566b7fc560e297a290896 # v2.1.1
+        uses: aws-actions/amazon-ecr-login@fa648b43de3d4d023bcb3f89ed6940096949c419 # v2.1.5
       
       - name: Install dependencies
         uses: ./.github/actions/pnpm-install

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
## Summary
- `pnpm config set ignore-workspace-root-check true` fails in pnpm v11 with `ERR_PNPM_CONFIG_SET_UNSUPPORTED_YAML_CONFIG_KEY`
- Replace the broken config step with a `pnpm add -w --ignore-scripts wrangler@3` pre-install step
- `-w` permits root-level installs, `--ignore-scripts` skips `workerd` build scripts (not needed for `pages deploy`)
- The wrangler-action detects the pre-installed wrangler and skips its own install

## Test plan
- [ ] Trigger the `deploy-test` workflow by adding the `testing` label to a PR
- [ ] Verify the Deploy Page step completes without errors