### PR TITLE
fix: update link scripts for pnpm v11

### DIFF
--- a/scripts/linkBigmi.js
+++ b/scripts/linkBigmi.js
@@ -1,17 +1,21 @@
 // biome-ignore-all lint/suspicious/noConsole: allowed in scripts
 import fs from 'node:fs'
+import os from 'node:os'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
-const packageJsonPath = path.resolve(__dirname, '..', 'package.json')
+const workspacePath = path.resolve(__dirname, '..', 'pnpm-workspace.yaml')
+// NB: macOS path
+const globalModules = path.join(
+  os.homedir(),
+  'Library/pnpm/global/5/node_modules'
+)
 
-const bigmiOverrides = {
-  '@bigmi/client':
-    'link:../../Library/pnpm/global/5/node_modules/@bigmi/client',
-  '@bigmi/core': 'link:../../Library/pnpm/global/5/node_modules/@bigmi/core',
-  '@bigmi/react': 'link:../../Library/pnpm/global/5/node_modules/@bigmi/react',
-}
+const bigmiPackages = ['@bigmi/client', '@bigmi/core', '@bigmi/react']
+const bigmiOverrides = Object.fromEntries(
+  bigmiPackages.map((pkg) => [pkg, `link:${path.join(globalModules, pkg)}`])
+)
 
 const action = process.argv[2]
 
@@ -20,25 +24,37 @@ if (!['link', 'unlink'].includes(action)) {
   process.exit(1)
 }
 
-const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'))
+let content = fs.readFileSync(workspacePath, 'utf-8')
 
-if (!packageJson.pnpm) {
-  packageJson.pnpm = {}
+function removeOverrides(yaml) {
+  for (const pkg of bigmiPackages) {
+    const escaped = pkg.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    yaml = yaml.replace(new RegExp(`^  '${escaped}':.*\\n`, 'gm'), '')
+  }
+  return yaml
 }
-if (!packageJson.pnpm.overrides) {
-  packageJson.pnpm.overrides = {}
-}
+
+content = removeOverrides(content)
 
 if (action === 'link') {
-  for (const [pkg, value] of Object.entries(bigmiOverrides)) {
-    packageJson.pnpm.overrides[pkg] = value
+  const lines = bigmiPackages.map(
+    (pkg) => `  '${pkg}': '${bigmiOverrides[pkg]}'`
+  )
+  const overridesBlock = lines.join('\n')
+
+  if (content.includes('overrides:')) {
+    const insertPoint = content.indexOf('overrides:') + 'overrides:\n'.length
+    content =
+      content.slice(0, insertPoint) +
+      overridesBlock +
+      '\n' +
+      content.slice(insertPoint)
+  } else {
+    content += `overrides:\n${overridesBlock}\n`
   }
-  console.log('Linked bigmi packages via pnpm overrides')
+  console.log('Linked bigmi packages via pnpm-workspace.yaml overrides')
 } else {
-  for (const pkg of Object.keys(bigmiOverrides)) {
-    delete packageJson.pnpm.overrides[pkg]
-  }
-  console.log('Unlinked bigmi packages from pnpm overrides')
+  console.log('Unlinked bigmi packages from pnpm-workspace.yaml overrides')
 }
 
-fs.writeFileSync(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`)
+fs.writeFileSync(workspacePath, content)

--- a/scripts/linkBigmi.js
+++ b/scripts/linkBigmi.js
@@ -24,35 +24,46 @@ if (!['link', 'unlink'].includes(action)) {
   process.exit(1)
 }
 
+const MARKER = '  # LOCAL ONLY — do not commit (bigmi link)'
+
 let content = fs.readFileSync(workspacePath, 'utf-8')
 
 function removeOverrides(yaml) {
+  let next = yaml.replace(/^\s*# LOCAL ONLY.*\(bigmi link\).*\r?\n/gm, '')
   for (const pkg of bigmiPackages) {
     const escaped = pkg.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-    yaml = yaml.replace(new RegExp(`^  '${escaped}':.*\\n`, 'gm'), '')
+    next = next.replace(
+      new RegExp(`^\\s+['"]?${escaped}['"]?\\s*:.*\\r?\\n`, 'gm'),
+      ''
+    )
   }
-  return yaml
+  return next
 }
 
 content = removeOverrides(content)
+
+if (!content.endsWith('\n')) {
+  content += '\n'
+}
 
 if (action === 'link') {
   const lines = bigmiPackages.map(
     (pkg) => `  '${pkg}': '${bigmiOverrides[pkg]}'`
   )
-  const overridesBlock = lines.join('\n')
+  const block = `${MARKER}\n${lines.join('\n')}\n`
 
-  if (content.includes('overrides:')) {
-    const insertPoint = content.indexOf('overrides:') + 'overrides:\n'.length
-    content =
-      content.slice(0, insertPoint) +
-      overridesBlock +
-      '\n' +
-      content.slice(insertPoint)
+  // Anchor on a real top-level "overrides:" key. Tolerates trailing whitespace
+  // and CRLF on the header line.
+  const headerMatch = content.match(/^overrides:[ \t]*\r?\n/m)
+  if (headerMatch) {
+    const insertPoint = headerMatch.index + headerMatch[0].length
+    content = content.slice(0, insertPoint) + block + content.slice(insertPoint)
   } else {
-    content += `overrides:\n${overridesBlock}\n`
+    content += `overrides:\n${block}`
   }
-  console.log('Linked bigmi packages via pnpm-workspace.yaml overrides')
+  console.log(
+    'Linked bigmi packages via pnpm-workspace.yaml overrides. DO NOT commit pnpm-workspace.yaml while linked.'
+  )
 } else {
   console.log('Unlinked bigmi packages from pnpm-workspace.yaml overrides')
 }

--- a/scripts/linkBigmi.js
+++ b/scripts/linkBigmi.js
@@ -1,21 +1,6 @@
-// biome-ignore-all lint/suspicious/noConsole: allowed in scripts
-import fs from 'node:fs'
-import os from 'node:os'
-import path from 'node:path'
-import { fileURLToPath } from 'node:url'
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url))
-const workspacePath = path.resolve(__dirname, '..', 'pnpm-workspace.yaml')
-// NB: macOS path
-const globalModules = path.join(
-  os.homedir(),
-  'Library/pnpm/global/5/node_modules'
-)
+import { applyOverrides } from './workspaceOverrides.js'
 
 const bigmiPackages = ['@bigmi/client', '@bigmi/core', '@bigmi/react']
-const bigmiOverrides = Object.fromEntries(
-  bigmiPackages.map((pkg) => [pkg, `link:${path.join(globalModules, pkg)}`])
-)
 
 const action = process.argv[2]
 
@@ -24,48 +9,4 @@ if (!['link', 'unlink'].includes(action)) {
   process.exit(1)
 }
 
-const MARKER = '  # LOCAL ONLY — do not commit (bigmi link)'
-
-let content = fs.readFileSync(workspacePath, 'utf-8')
-
-function removeOverrides(yaml) {
-  let next = yaml.replace(/^\s*# LOCAL ONLY.*\(bigmi link\).*\r?\n/gm, '')
-  for (const pkg of bigmiPackages) {
-    const escaped = pkg.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-    next = next.replace(
-      new RegExp(`^\\s+['"]?${escaped}['"]?\\s*:.*\\r?\\n`, 'gm'),
-      ''
-    )
-  }
-  return next
-}
-
-content = removeOverrides(content)
-
-if (!content.endsWith('\n')) {
-  content += '\n'
-}
-
-if (action === 'link') {
-  const lines = bigmiPackages.map(
-    (pkg) => `  '${pkg}': '${bigmiOverrides[pkg]}'`
-  )
-  const block = `${MARKER}\n${lines.join('\n')}\n`
-
-  // Anchor on a real top-level "overrides:" key. Tolerates trailing whitespace
-  // and CRLF on the header line.
-  const headerMatch = content.match(/^overrides:[ \t]*\r?\n/m)
-  if (headerMatch) {
-    const insertPoint = headerMatch.index + headerMatch[0].length
-    content = content.slice(0, insertPoint) + block + content.slice(insertPoint)
-  } else {
-    content += `overrides:\n${block}`
-  }
-  console.log(
-    'Linked bigmi packages via pnpm-workspace.yaml overrides. DO NOT commit pnpm-workspace.yaml while linked.'
-  )
-} else {
-  console.log('Unlinked bigmi packages from pnpm-workspace.yaml overrides')
-}
-
-fs.writeFileSync(workspacePath, content)
+applyOverrides(bigmiPackages, 'bigmi', action)

--- a/scripts/linkSdk.js
+++ b/scripts/linkSdk.js
@@ -31,33 +31,44 @@ if (!['link', 'unlink'].includes(action)) {
   process.exit(1)
 }
 
+const MARKER = '  # LOCAL ONLY — do not commit (sdk link)'
+
 let content = fs.readFileSync(workspacePath, 'utf-8')
 
 function removeOverrides(yaml) {
+  let next = yaml.replace(/^\s*# LOCAL ONLY.*\(sdk link\).*\r?\n/gm, '')
   for (const pkg of sdkPackages) {
     const escaped = pkg.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-    yaml = yaml.replace(new RegExp(`^  '${escaped}':.*\\n`, 'gm'), '')
+    next = next.replace(
+      new RegExp(`^\\s+['"]?${escaped}['"]?\\s*:.*\\r?\\n`, 'gm'),
+      ''
+    )
   }
-  return yaml
+  return next
 }
 
 content = removeOverrides(content)
 
+if (!content.endsWith('\n')) {
+  content += '\n'
+}
+
 if (action === 'link') {
   const lines = sdkPackages.map((pkg) => `  '${pkg}': '${sdkOverrides[pkg]}'`)
-  const overridesBlock = lines.join('\n')
+  const block = `${MARKER}\n${lines.join('\n')}\n`
 
-  if (content.includes('overrides:')) {
-    const insertPoint = content.indexOf('overrides:') + 'overrides:\n'.length
-    content =
-      content.slice(0, insertPoint) +
-      overridesBlock +
-      '\n' +
-      content.slice(insertPoint)
+  // Anchor on a real top-level "overrides:" key. Tolerates trailing whitespace
+  // and CRLF on the header line.
+  const headerMatch = content.match(/^overrides:[ \t]*\r?\n/m)
+  if (headerMatch) {
+    const insertPoint = headerMatch.index + headerMatch[0].length
+    content = content.slice(0, insertPoint) + block + content.slice(insertPoint)
   } else {
-    content += `overrides:\n${overridesBlock}\n`
+    content += `overrides:\n${block}`
   }
-  console.log('Linked SDK packages via pnpm-workspace.yaml overrides')
+  console.log(
+    'Linked SDK packages via pnpm-workspace.yaml overrides. DO NOT commit pnpm-workspace.yaml while linked.'
+  )
 } else {
   console.log('Unlinked SDK packages from pnpm-workspace.yaml overrides')
 }

--- a/scripts/linkSdk.js
+++ b/scripts/linkSdk.js
@@ -1,16 +1,4 @@
-// biome-ignore-all lint/suspicious/noConsole: allowed in scripts
-import fs from 'node:fs'
-import os from 'node:os'
-import path from 'node:path'
-import { fileURLToPath } from 'node:url'
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url))
-const workspacePath = path.resolve(__dirname, '..', 'pnpm-workspace.yaml')
-// NB: macOS path
-const globalModules = path.join(
-  os.homedir(),
-  'Library/pnpm/global/5/node_modules'
-)
+import { applyOverrides } from './workspaceOverrides.js'
 
 const sdkPackages = [
   '@lifi/sdk',
@@ -20,9 +8,6 @@ const sdkPackages = [
   '@lifi/sdk-provider-sui',
   '@lifi/sdk-provider-tron',
 ]
-const sdkOverrides = Object.fromEntries(
-  sdkPackages.map((pkg) => [pkg, `link:${path.join(globalModules, pkg)}`])
-)
 
 const action = process.argv[2]
 
@@ -31,46 +16,4 @@ if (!['link', 'unlink'].includes(action)) {
   process.exit(1)
 }
 
-const MARKER = '  # LOCAL ONLY — do not commit (sdk link)'
-
-let content = fs.readFileSync(workspacePath, 'utf-8')
-
-function removeOverrides(yaml) {
-  let next = yaml.replace(/^\s*# LOCAL ONLY.*\(sdk link\).*\r?\n/gm, '')
-  for (const pkg of sdkPackages) {
-    const escaped = pkg.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-    next = next.replace(
-      new RegExp(`^\\s+['"]?${escaped}['"]?\\s*:.*\\r?\\n`, 'gm'),
-      ''
-    )
-  }
-  return next
-}
-
-content = removeOverrides(content)
-
-if (!content.endsWith('\n')) {
-  content += '\n'
-}
-
-if (action === 'link') {
-  const lines = sdkPackages.map((pkg) => `  '${pkg}': '${sdkOverrides[pkg]}'`)
-  const block = `${MARKER}\n${lines.join('\n')}\n`
-
-  // Anchor on a real top-level "overrides:" key. Tolerates trailing whitespace
-  // and CRLF on the header line.
-  const headerMatch = content.match(/^overrides:[ \t]*\r?\n/m)
-  if (headerMatch) {
-    const insertPoint = headerMatch.index + headerMatch[0].length
-    content = content.slice(0, insertPoint) + block + content.slice(insertPoint)
-  } else {
-    content += `overrides:\n${block}`
-  }
-  console.log(
-    'Linked SDK packages via pnpm-workspace.yaml overrides. DO NOT commit pnpm-workspace.yaml while linked.'
-  )
-} else {
-  console.log('Unlinked SDK packages from pnpm-workspace.yaml overrides')
-}
-
-fs.writeFileSync(workspacePath, content)
+applyOverrides(sdkPackages, 'sdk', action)

--- a/scripts/linkSdk.js
+++ b/scripts/linkSdk.js
@@ -1,24 +1,28 @@
 // biome-ignore-all lint/suspicious/noConsole: allowed in scripts
 import fs from 'node:fs'
+import os from 'node:os'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
-const packageJsonPath = path.resolve(__dirname, '..', 'package.json')
+const workspacePath = path.resolve(__dirname, '..', 'pnpm-workspace.yaml')
+// NB: macOS path
+const globalModules = path.join(
+  os.homedir(),
+  'Library/pnpm/global/5/node_modules'
+)
 
-const sdkOverrides = {
-  '@lifi/sdk': 'link:../../Library/pnpm/global/5/node_modules/@lifi/sdk',
-  '@lifi/sdk-provider-bitcoin':
-    'link:../../Library/pnpm/global/5/node_modules/@lifi/sdk-provider-bitcoin',
-  '@lifi/sdk-provider-ethereum':
-    'link:../../Library/pnpm/global/5/node_modules/@lifi/sdk-provider-ethereum',
-  '@lifi/sdk-provider-solana':
-    'link:../../Library/pnpm/global/5/node_modules/@lifi/sdk-provider-solana',
-  '@lifi/sdk-provider-sui':
-    'link:../../Library/pnpm/global/5/node_modules/@lifi/sdk-provider-sui',
-  '@lifi/sdk-provider-tron':
-    'link:../../Library/pnpm/global/5/node_modules/@lifi/sdk-provider-tron',
-}
+const sdkPackages = [
+  '@lifi/sdk',
+  '@lifi/sdk-provider-bitcoin',
+  '@lifi/sdk-provider-ethereum',
+  '@lifi/sdk-provider-solana',
+  '@lifi/sdk-provider-sui',
+  '@lifi/sdk-provider-tron',
+]
+const sdkOverrides = Object.fromEntries(
+  sdkPackages.map((pkg) => [pkg, `link:${path.join(globalModules, pkg)}`])
+)
 
 const action = process.argv[2]
 
@@ -27,25 +31,35 @@ if (!['link', 'unlink'].includes(action)) {
   process.exit(1)
 }
 
-const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'))
+let content = fs.readFileSync(workspacePath, 'utf-8')
 
-if (!packageJson.pnpm) {
-  packageJson.pnpm = {}
+function removeOverrides(yaml) {
+  for (const pkg of sdkPackages) {
+    const escaped = pkg.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    yaml = yaml.replace(new RegExp(`^  '${escaped}':.*\\n`, 'gm'), '')
+  }
+  return yaml
 }
-if (!packageJson.pnpm.overrides) {
-  packageJson.pnpm.overrides = {}
-}
+
+content = removeOverrides(content)
 
 if (action === 'link') {
-  for (const [pkg, value] of Object.entries(sdkOverrides)) {
-    packageJson.pnpm.overrides[pkg] = value
+  const lines = sdkPackages.map((pkg) => `  '${pkg}': '${sdkOverrides[pkg]}'`)
+  const overridesBlock = lines.join('\n')
+
+  if (content.includes('overrides:')) {
+    const insertPoint = content.indexOf('overrides:') + 'overrides:\n'.length
+    content =
+      content.slice(0, insertPoint) +
+      overridesBlock +
+      '\n' +
+      content.slice(insertPoint)
+  } else {
+    content += `overrides:\n${overridesBlock}\n`
   }
-  console.log('Linked SDK packages via pnpm overrides')
+  console.log('Linked SDK packages via pnpm-workspace.yaml overrides')
 } else {
-  for (const pkg of Object.keys(sdkOverrides)) {
-    delete packageJson.pnpm.overrides[pkg]
-  }
-  console.log('Unlinked SDK packages from pnpm overrides')
+  console.log('Unlinked SDK packages from pnpm-workspace.yaml overrides')
 }
 
-fs.writeFileSync(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`)
+fs.writeFileSync(workspacePath, content)

--- a/scripts/workspaceOverrides.js
+++ b/scripts/workspaceOverrides.js
@@ -1,0 +1,78 @@
+// biome-ignore-all lint/suspicious/noConsole: allowed in scripts
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const workspacePath = path.resolve(__dirname, '..', 'pnpm-workspace.yaml')
+// NB: macOS path
+const globalModules = path.join(
+  os.homedir(),
+  'Library/pnpm/global/5/node_modules'
+)
+
+export function applyOverrides(packages, label, action) {
+  const overrides = Object.fromEntries(
+    packages.map((pkg) => [pkg, `link:${path.join(globalModules, pkg)}`])
+  )
+  const marker = `  # LOCAL ONLY — do not commit (${label} link)`
+
+  let content = fs.readFileSync(workspacePath, 'utf-8')
+
+  const { cleaned, blockStart } = removeOverrides(content, packages, label)
+  content = cleaned
+
+  if (!content.endsWith('\n')) {
+    content += '\n'
+  }
+
+  if (action === 'link') {
+    const lines = packages.map((pkg) => `  '${pkg}': '${overrides[pkg]}'`)
+    const block = `${marker}\n${lines.join('\n')}\n`
+
+    if (blockStart !== -1) {
+      content = content.slice(0, blockStart) + block + content.slice(blockStart)
+    } else {
+      content += `overrides:\n${block}`
+    }
+    console.log(
+      `Linked ${label} packages via pnpm-workspace.yaml overrides. DO NOT commit pnpm-workspace.yaml while linked.`
+    )
+  } else {
+    console.log(`Unlinked ${label} packages from pnpm-workspace.yaml overrides`)
+  }
+
+  fs.writeFileSync(workspacePath, content)
+}
+
+function removeOverrides(yaml, packages, label) {
+  const header = yaml.match(/^overrides:[ \t]*\r?\n/m)
+  if (!header) {
+    return { cleaned: yaml, blockStart: -1 }
+  }
+
+  const blockStart = header.index + header[0].length
+  const nextKey = yaml.slice(blockStart).match(/^[^\s#]/m)
+  const blockEnd = nextKey ? blockStart + nextKey.index : yaml.length
+
+  const before = yaml.slice(0, blockStart)
+  let block = yaml.slice(blockStart, blockEnd)
+  const after = yaml.slice(blockEnd)
+
+  const escapedLabel = label.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  block = block.replace(
+    new RegExp(`^\\s*# LOCAL ONLY.*\\(${escapedLabel} link\\).*\\r?\\n`, 'gm'),
+    ''
+  )
+  for (const pkg of packages) {
+    const escaped = pkg.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    block = block.replace(
+      new RegExp(`^\\s+['"]?${escaped}['"]?\\s*:.*\\r?\\n`, 'gm'),
+      ''
+    )
+  }
+
+  const cleaned = before + block + after
+  return { cleaned, blockStart: before.length }
+}


### PR DESCRIPTION
## Which Linear task is linked to this PR?
https://linear.app/lifi-linear/issue/EMB-379/update-local-sdk-linking-script-for-pnpm-v11

## Why was it implemented this way?
pnpm v11 ignores `pnpm.overrides` in `package.json` — overrides must live in `pnpm-workspace.yaml`. Both `linkSdk.js` and `linkBigmi.js` are updated to read/write the workspace file instead. 

## Checklist before requesting a review
- [x] I have performed a self-review and testing of my code.
- [x] This pull request is focused and addresses a single problem.