### PR TITLE
[EMB-359] feat(ci): add Agent Review Request label trigger for Zeus QA review

### DIFF
--- a/.github/workflows/qa-review-trigger.yml
+++ b/.github/workflows/qa-review-trigger.yml
@@ -1,0 +1,28 @@
+name: Trigger Zeus QA Review
+
+on:
+  pull_request:
+    types: [labeled]
+
+jobs:
+  trigger-zeus:
+    if: github.event.label.name == 'Agent review'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: lifinance
+
+      - name: Trigger Zeus QA review
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          repository: lifinance/QA
+          event-type: qa-review-embeddables
+          client-payload: '{"pr_url": "${{ github.event.pull_request.html_url }}"}'

--- a/.github/workflows/qa-review-trigger.yml
+++ b/.github/workflows/qa-review-trigger.yml
@@ -16,12 +16,13 @@ jobs:
         env:
           KEY: ${{ secrets.QA_APP_PRIVATE_KEY }}
         run: |
-          echo "pem<<KEYEOF" >> $GITHUB_OUTPUT
-          printf '%s' "$KEY" \
+          FORMATTED=$(printf '%s' "$KEY" \
             | sed 's/-----BEGIN RSA PRIVATE KEY----- /-----BEGIN RSA PRIVATE KEY-----\n/' \
             | sed 's/ -----END RSA PRIVATE KEY-----/\n-----END RSA PRIVATE KEY-----/' \
-            | awk '/^-----/{print; next} {gsub(/ /,"\n"); print}' \
-            >> $GITHUB_OUTPUT
+            | awk '/^-----/{print; next} {gsub(/ /,"\n"); print}')
+          echo "::add-mask::$FORMATTED"
+          echo "pem<<KEYEOF" >> $GITHUB_OUTPUT
+          echo "$FORMATTED" >> $GITHUB_OUTPUT
           echo "KEYEOF" >> $GITHUB_OUTPUT
 
       - name: Create GitHub App token

--- a/.github/workflows/qa-review-trigger.yml
+++ b/.github/workflows/qa-review-trigger.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   trigger-zeus:
-    if: github.event.label.name == 'Agent review'
+    if: ${{ github.event.label.name == 'Agent review' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -18,6 +18,7 @@ jobs:
           app-id: ${{ secrets.QA_APP_ID }}
           private-key: ${{ secrets.QA_APP_PRIVATE_KEY }}
           owner: lifinance
+          repositories: QA
 
       - name: Trigger Zeus QA review
         env:

--- a/.github/workflows/qa-review-trigger.yml
+++ b/.github/workflows/qa-review-trigger.yml
@@ -4,10 +4,15 @@ on:
   pull_request:
     types: [labeled]
 
+concurrency:
+  group: qa-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   trigger-zeus:
     if: ${{ github.event.label.name == 'Agent review' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       contents: read
     steps:

--- a/.github/workflows/qa-review-trigger.yml
+++ b/.github/workflows/qa-review-trigger.yml
@@ -15,8 +15,8 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
         with:
-          app-id: ${{ vars.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.QA_APP_ID }}
+          private-key: ${{ secrets.QA_APP_PRIVATE_KEY }}
           owner: lifinance
 
       - name: Trigger Zeus QA review

--- a/.github/workflows/qa-review-trigger.yml
+++ b/.github/workflows/qa-review-trigger.yml
@@ -5,16 +5,17 @@ on:
     types: [labeled]
 
 concurrency:
-  group: qa-review-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  group: qa-review-${{ github.repository }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
 
 jobs:
-  trigger-zeus:
-    if: ${{ github.event.label.name == 'Agent review' }}
+  trigger:
+    if: github.event.label.name == 'Agent Review Request'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
-      contents: read
+      pull-requests: write
+
     steps:
       - name: Create GitHub App token
         id: app-token
@@ -25,11 +26,41 @@ jobs:
           owner: lifinance
           repositories: QA
 
-      - name: Trigger Zeus QA review
+      - name: Swap labels
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh api --method DELETE "repos/$REPO/issues/$PR_NUMBER/labels/Agent%20Review%20Request" || true
+          gh api --method DELETE "repos/$REPO/issues/$PR_NUMBER/labels/QA%20AI%20Approved" || true
+          if ! gh api --method POST "repos/$REPO/issues/$PR_NUMBER/labels" \
+            --field "labels[]=QA AI Reviewing"; then
+            echo "❌ Failed to apply QA AI Reviewing label — aborting"
+            exit 1
+          fi
+
+      - name: Dispatch to QA repo
+        id: dispatch
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_URL: ${{ github.event.pull_request.html_url }}
         run: |
-          jq -n --arg url "$PR_URL" \
-            '{"event_type":"qa-review-embeddables","client_payload":{"pr_url":$url}}' | \
-            gh api repos/lifinance/QA/dispatches --method POST --input -
+          gh api repos/lifinance/QA/actions/workflows/qa-run.yml/dispatches \
+            --method POST \
+            --field ref=main \
+            --field "inputs[scenario]=QAReviewEmbeddables.md" \
+            --field "inputs[agent]=zeus" \
+            --field "inputs[ticket]=$PR_URL"
+
+      - name: Restore labels on dispatch failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh api --method DELETE "repos/$REPO/issues/$PR_NUMBER/labels/QA%20AI%20Reviewing" || true
+          gh api --method POST "repos/$REPO/issues/$PR_NUMBER/labels" \
+            --field "labels[]=Agent Review Request" || true
+          echo "⚠️ Dispatch failed — restored Agent Review Request label"

--- a/.github/workflows/qa-review-trigger.yml
+++ b/.github/workflows/qa-review-trigger.yml
@@ -11,33 +11,19 @@ jobs:
     permissions:
       contents: read
     steps:
-      - name: Format private key
-        id: format-key
-        env:
-          KEY: ${{ secrets.QA_APP_PRIVATE_KEY }}
-        run: |
-          FORMATTED=$(printf '%s' "$KEY" \
-            | sed 's/-----BEGIN RSA PRIVATE KEY----- /-----BEGIN RSA PRIVATE KEY-----\n/' \
-            | sed 's/ -----END RSA PRIVATE KEY-----/\n-----END RSA PRIVATE KEY-----/' \
-            | awk '/^-----/{print; next} {gsub(/ /,"\n"); print}')
-          echo "::add-mask::$FORMATTED"
-          echo "pem<<KEYEOF" >> $GITHUB_OUTPUT
-          echo "$FORMATTED" >> $GITHUB_OUTPUT
-          echo "KEYEOF" >> $GITHUB_OUTPUT
-
       - name: Create GitHub App token
         id: app-token
         uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
         with:
           app-id: ${{ secrets.QA_APP_ID }}
-          private-key: ${{ steps.format-key.outputs.pem }}
+          private-key: ${{ secrets.QA_APP_PRIVATE_KEY }}
           owner: lifinance
 
       - name: Trigger Zeus QA review
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
         run: |
-          gh api repos/lifinance/QA/dispatches \
-            --method POST \
-            --field event_type=qa-review-embeddables \
-            --raw-field client_payload='{"pr_url":"${{ github.event.pull_request.html_url }}"}'
+          jq -n --arg url "$PR_URL" \
+            '{"event_type":"qa-review-embeddables","client_payload":{"pr_url":$url}}' | \
+            gh api repos/lifinance/QA/dispatches --method POST --input -

--- a/.github/workflows/qa-review-trigger.yml
+++ b/.github/workflows/qa-review-trigger.yml
@@ -20,9 +20,10 @@ jobs:
           owner: lifinance
 
       - name: Trigger Zeus QA review
-        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
-        with:
-          token: ${{ steps.app-token.outputs.token }}
-          repository: lifinance/QA
-          event-type: qa-review-embeddables
-          client-payload: '{"pr_url": "${{ github.event.pull_request.html_url }}"}'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          gh api repos/lifinance/QA/dispatches \
+            --method POST \
+            --field event_type=qa-review-embeddables \
+            --raw-field client_payload='{"pr_url":"${{ github.event.pull_request.html_url }}"}'

--- a/.github/workflows/qa-review-trigger.yml
+++ b/.github/workflows/qa-review-trigger.yml
@@ -11,12 +11,25 @@ jobs:
     permissions:
       contents: read
     steps:
+      - name: Format private key
+        id: format-key
+        env:
+          KEY: ${{ secrets.QA_APP_PRIVATE_KEY }}
+        run: |
+          echo "pem<<KEYEOF" >> $GITHUB_OUTPUT
+          printf '%s' "$KEY" \
+            | sed 's/-----BEGIN RSA PRIVATE KEY----- /-----BEGIN RSA PRIVATE KEY-----\n/' \
+            | sed 's/ -----END RSA PRIVATE KEY-----/\n-----END RSA PRIVATE KEY-----/' \
+            | awk '/^-----/{print; next} {gsub(/ /,"\n"); print}' \
+            >> $GITHUB_OUTPUT
+          echo "KEYEOF" >> $GITHUB_OUTPUT
+
       - name: Create GitHub App token
         id: app-token
         uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
         with:
           app-id: ${{ secrets.QA_APP_ID }}
-          private-key: ${{ secrets.QA_APP_PRIVATE_KEY }}
+          private-key: ${{ steps.format-key.outputs.pem }}
           owner: lifinance
 
       - name: Trigger Zeus QA review


### PR DESCRIPTION
## Which Linear task is linked to this PR?

[EMB-359 — feat: add "Agent Review Request" label and Zeus QA trigger workflow](https://linear.app/lifi-linear/issue/EMB-359/feat-add-agent-review-label-and-zeus-qa-trigger-workflow)

## Why was it implemented this way?

Adds `.github/workflows/qa-review-trigger.yml`, which fires when the **"Agent Review Request"** label is applied to a PR. It swaps the label to **"QA AI Reviewing"** and dispatches the shared `qa-run.yml` workflow in `lifinance/QA` (`scenario=QAReviewEmbeddables.md`, `agent=zeus`), where Zeus runs the review.

This follows the canonical **solver/backend** pattern: source-repo triggers dispatch to the shared `qa-run.yml` rather than a team-specific dispatch workflow. The QA-side counterpart — deleting the old `qa-review-embeddables-dispatch.yml` and moving GitHub PR label management into the Zeus skill — is **QA-101 / lifinance/QA PR #96**, which must land alongside this.

**Implementation notes:**
- **Label swap** (`Agent Review Request` → `QA AI Reviewing`) uses the repo's own `GITHUB_TOKEN`. The QA app token (`QA_APP_ID` / `QA_APP_PRIVATE_KEY`, scoped to `repositories: QA`) is used **only** for the cross-repo dispatch.
- Native `gh api` for the dispatch — no third-party action.
- Restores `Agent Review Request` if the dispatch fails.
- All verdict-dependent label transitions (→ `QA AI Approved`, or staying on `QA AI Reviewing`) are handled by the Zeus skill in the QA repo, not here — a workflow job only sees pass/fail of the process, not the review verdict.

**Prerequisite (org admin):** provision `secrets.QA_APP_ID` and `secrets.QA_APP_PRIVATE_KEY` in `lifinance/widget`, and create the `Agent Review Request` label.

## Checklist before requesting a review

- [x] I have performed a self-review and testing of my code.
- [x] This pull request is focused and addresses a single problem.
- [ ] If this PR modifies the Widget API or adds new features that require documentation, I have updated the documentation in the [public-docs](https://github.com/lifinance/public-docs) repository.