### PR TITLE
Pay from wallet: error states and disconnect handling

### DIFF
--- a/packages/widget-checkout/src/pages/CheckoutTransactionPage.tsx
+++ b/packages/widget-checkout/src/pages/CheckoutTransactionPage.tsx
@@ -1,4 +1,5 @@
 import type { ExchangeRateUpdateParams, RouteExtended } from '@lifi/sdk'
+import { useAccount } from '@lifi/wallet-management'
 import type {
   BottomSheetBase,
   ExchangeRateBottomSheetBase,
@@ -39,6 +40,7 @@ import { Box, Button, Tooltip } from '@mui/material'
 import { useLocation, useNavigate } from '@tanstack/react-router'
 import { type JSX, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useCheckoutFlowStore } from '../stores/useCheckoutFlowStore.js'
 import { checkoutNavigationRoutes } from '../utils/navigationRoutes.js'
 
 function CheckoutDepositAutoStarter({
@@ -133,6 +135,24 @@ export const CheckoutTransactionPage = (): JSX.Element | null => {
       routeId: routeId,
       onAcceptExchangeRateUpdate,
     })
+
+  const fundingSource = useCheckoutFlowStore((s) => s.fundingSource)
+  const { account } = useAccount()
+
+  // Detect wallet disconnect during active execution and surface the error screen.
+  useEffect(() => {
+    if (
+      fundingSource !== 'wallet' ||
+      account.address !== undefined ||
+      !hasEnumFlag(status ?? 0, RouteExecutionStatus.Pending)
+    ) {
+      return
+    }
+    navigate({
+      to: `/${navigationRoutes.transactionExecution}/${checkoutNavigationRoutes.transactionStatus}`,
+      search: { walletDisconnected: true },
+    })
+  }, [fundingSource, account.address, status, navigate])
 
   const {
     toAddress,

--- a/packages/widget-checkout/src/pages/CheckoutTransactionStatusPage/CheckoutTransactionStatusPage.tsx
+++ b/packages/widget-checkout/src/pages/CheckoutTransactionStatusPage/CheckoutTransactionStatusPage.tsx
@@ -23,6 +23,7 @@ interface StatusSearch {
   depositAddress?: string
   fromChain?: number
   simulateTransactionStatus?: string
+  walletDisconnected?: boolean
 }
 
 /**
@@ -46,6 +47,7 @@ export const CheckoutTransactionStatusPage: React.FC = (): JSX.Element => {
   )
     ? search.simulateTransactionStatus
     : null
+  const walletDisconnected = search.walletDisconnected === true
 
   // Active deposit session for the current funding source. The provider
   // may emit a real on-chain hash (driving polling) or a terminal
@@ -143,6 +145,18 @@ export const CheckoutTransactionStatusPage: React.FC = (): JSX.Element => {
           variant={variant}
           description={deposit.failure.message}
           primaryAction={{ tryAgain: deposit.failure.retry }}
+        />
+      </PageContainer>
+    )
+  }
+
+  if (walletDisconnected) {
+    const variant = resolveStatusVariant({ fundingSource, walletDisconnected })
+    return (
+      <PageContainer bottomGutters>
+        <CheckoutStatusScreen
+          variant={variant}
+          primaryAction={{ tryAgain: () => window.history.back() }}
         />
       </PageContainer>
     )

--- a/packages/widget-checkout/src/pages/CheckoutTransactionStatusPage/statusVariants.ts
+++ b/packages/widget-checkout/src/pages/CheckoutTransactionStatusPage/statusVariants.ts
@@ -29,6 +29,8 @@ export interface ResolveStatusVariantArgs {
   substatus?: Substatus
   fundingSource: CheckoutFundingSource | null
   onRampFailureKind?: OnRampFailureKind
+  /** Wallet was disconnected mid-execution; maps to error-connection with wallet-disconnect copy. */
+  walletDisconnected?: boolean
 }
 
 /**
@@ -51,7 +53,22 @@ export function resolveStatusVariant({
   substatus,
   fundingSource,
   onRampFailureKind,
+  walletDisconnected,
 }: ResolveStatusVariantArgs): StatusVariant {
+  const isWallet = fundingSource === 'wallet'
+
+  // Wallet disconnect during execution — surfaces before any status check.
+  if (walletDisconnected) {
+    return {
+      tone: 'error',
+      icon: 'error',
+      titleKey: 'checkout.status.walletDisconnected.title',
+      descriptionKey: 'checkout.status.walletDisconnected.description',
+      primaryAction: 'tryAgain',
+      secondaryAction: 'contactSupport',
+    }
+  }
+
   // Pre-hash provider failure takes priority — polling hasn't started yet.
   if (onRampFailureKind) {
     return resolveOnRampFailureVariant(onRampFailureKind, fundingSource)
@@ -64,8 +81,12 @@ export function resolveStatusVariant({
       return {
         tone: 'success',
         icon: 'refund',
-        titleKey: 'checkout.status.successRefund.title',
-        descriptionKey: 'checkout.status.successRefund.description',
+        titleKey: isWallet
+          ? 'checkout.status.walletSuccessRefund.title'
+          : 'checkout.status.successRefund.title',
+        descriptionKey: isWallet
+          ? 'checkout.status.walletSuccessRefund.description'
+          : 'checkout.status.successRefund.description',
         primaryAction: 'viewRefund',
         secondaryAction: 'done',
       }
@@ -86,8 +107,12 @@ export function resolveStatusVariant({
       return {
         tone: 'pending',
         icon: 'refund',
-        titleKey: 'checkout.status.pendingRefund.title',
-        descriptionKey: 'checkout.status.pendingRefund.description',
+        titleKey: isWallet
+          ? 'checkout.status.walletPendingRefund.title'
+          : 'checkout.status.pendingRefund.title',
+        descriptionKey: isWallet
+          ? 'checkout.status.walletPendingRefund.description'
+          : 'checkout.status.pendingRefund.description',
         primaryAction: 'contactSupport',
       }
     }
@@ -118,8 +143,12 @@ export function resolveStatusVariant({
       return {
         tone: 'error',
         icon: 'error',
-        titleKey: 'checkout.status.errorExpired.title',
-        descriptionKey: 'checkout.status.errorExpired.description',
+        titleKey: isWallet
+          ? 'checkout.status.walletErrorExpired.title'
+          : 'checkout.status.errorExpired.title',
+        descriptionKey: isWallet
+          ? 'checkout.status.walletErrorExpired.description'
+          : 'checkout.status.errorExpired.description',
         primaryAction: 'tryAgain',
         secondaryAction: 'contactSupport',
       }
@@ -128,10 +157,14 @@ export function resolveStatusVariant({
     return {
       tone: 'error',
       icon: 'error',
-      titleKey: 'checkout.status.errorFailed.title',
-      descriptionKey: 'checkout.status.errorFailed.description',
+      titleKey: isWallet
+        ? 'checkout.status.walletErrorFailed.title'
+        : 'checkout.status.errorFailed.title',
+      descriptionKey: isWallet
+        ? 'checkout.status.walletErrorFailed.description'
+        : 'checkout.status.errorFailed.description',
       primaryAction: 'tryAgain',
-      secondaryAction: 'contactSupport',
+      secondaryAction: isWallet ? 'viewDetails' : 'contactSupport',
     }
   }
 

--- a/packages/widget/src/i18n/en.json
+++ b/packages/widget/src/i18n/en.json
@@ -555,6 +555,26 @@
           "title": "Card payment unavailable",
           "description": "Card payments are temporarily unavailable. Try again later or use a different method."
         }
+      },
+      "walletDisconnected": {
+        "title": "Wallet disconnected",
+        "description": "Your wallet was disconnected during the transaction. Reconnect and try again."
+      },
+      "walletErrorFailed": {
+        "title": "Transaction failed",
+        "description": "We couldn't complete your transaction. View the details or try again."
+      },
+      "walletErrorExpired": {
+        "title": "Order expired",
+        "description": "The transaction window expired before your order could be processed. Please try again."
+      },
+      "walletPendingRefund": {
+        "title": "Refund in progress",
+        "description": "Your transaction could not be completed. Your funds are being returned to your wallet."
+      },
+      "walletSuccessRefund": {
+        "title": "Funds refunded",
+        "description": "Your transaction could not be completed and your funds have been refunded to your wallet."
       }
     }
   }


### PR DESCRIPTION
## Which Linear task is linked to this PR?

https://linear.app/lifi-linear/issue/EMB-383

## Why was it implemented this way?

Wires wallet-specific error states on top of the shared status-screen primitive (EMB-382). Watches `account.address` against `RouteExecutionStatus` so wallet disconnects during execution route to the connection-error variant with wallet-disconnect copy. Refund/expired/failed substatuses pass through to the foundation resolver — wallet copy diverges via `fundingSource` interpolation rather than parallel variant keys.

Per product, `FAILED_FINAL` and `REFUND_FAILED` collapse into the same `UNKNOWN_FAILED_ERROR` substatus and share copy — no client-side disambiguation.

## Visual showcase (Screenshots or Videos)

Figma: https://www.figma.com/design/6Y6yJNHvj1tEkyrEfFDE1J/Checkout?node-id=22420-21341 (status + edge cases) and https://www.figma.com/design/6Y6yJNHvj1tEkyrEfFDE1J/Checkout?node-id=22673-20372 (refund pages)

## Checklist before requesting a review

- [x] I have performed a self-review and testing of my code.
- [x] This pull request is focused and addresses a single problem.
- [ ] If this PR modifies the Widget API or adds new features that require documentation, I have updated the documentation in the [public-docs](https://github.com/lifinance/public-docs) repository.