### PR TITLE
Mesh insufficient-funds alert and exchange error copy

### DIFF
--- a/packages/widget-checkout/package.json
+++ b/packages/widget-checkout/package.json
@@ -53,6 +53,7 @@
     "@lifi/wallet-management": "workspace:*",
     "@lifi/widget": "workspace:*",
     "@lifi/widget-provider": "workspace:*",
+    "@lifi/widget-provider-mesh": "workspace:*",
     "@mui/icons-material": "^9.0.1",
     "@mui/material": "^9.0.1",
     "@mui/system": "^9.0.1",

--- a/packages/widget-checkout/src/pages/CheckoutTransactionStatusPage/statusVariants.ts
+++ b/packages/widget-checkout/src/pages/CheckoutTransactionStatusPage/statusVariants.ts
@@ -150,6 +150,7 @@ function resolveOnRampFailureVariant(
   fundingSource: CheckoutFundingSource | null
 ): StatusVariant {
   const isCash = fundingSource === 'cash'
+  const isExchange = fundingSource === 'exchange'
   switch (kind) {
     case 'withdrawal':
       return {
@@ -157,10 +158,14 @@ function resolveOnRampFailureVariant(
         icon: 'error',
         titleKey: isCash
           ? 'checkout.status.errorWithdrawal.cash.title'
-          : 'checkout.status.errorWithdrawal.title',
+          : isExchange
+            ? 'checkout.status.errorWithdrawal.exchange.title'
+            : 'checkout.status.errorWithdrawal.title',
         descriptionKey: isCash
           ? 'checkout.status.errorWithdrawal.cash.description'
-          : 'checkout.status.errorWithdrawal.description',
+          : isExchange
+            ? 'checkout.status.errorWithdrawal.exchange.description'
+            : 'checkout.status.errorWithdrawal.description',
         primaryAction: 'tryAgain',
         secondaryAction: 'contactSupport',
       }
@@ -193,8 +198,12 @@ function resolveOnRampFailureVariant(
       return {
         tone: 'error',
         icon: 'error',
-        titleKey: 'checkout.status.errorConnection.title',
-        descriptionKey: 'checkout.status.errorConnection.description',
+        titleKey: isExchange
+          ? 'checkout.status.errorConnection.exchange.title'
+          : 'checkout.status.errorConnection.title',
+        descriptionKey: isExchange
+          ? 'checkout.status.errorConnection.exchange.description'
+          : 'checkout.status.errorConnection.description',
         primaryAction: 'tryAgain',
         secondaryAction: 'contactSupport',
       }

--- a/packages/widget-checkout/src/pages/SelectDepositTokenPage/SelectDepositTokenPage.tsx
+++ b/packages/widget-checkout/src/pages/SelectDepositTokenPage/SelectDepositTokenPage.tsx
@@ -1,13 +1,18 @@
 import {
   ChainSelect,
+  FormKeyHelper,
   FullPageContainer,
   HiddenUI,
   SearchTokenInput,
+  useChain,
+  useFieldValues,
   useHeader,
   useScrollableOverflowHidden,
+  useToken,
   useWidgetConfig,
 } from '@lifi/widget/shared'
-import { Box, type Theme, useMediaQuery } from '@mui/material'
+import { useMeshBalance } from '@lifi/widget-provider-mesh'
+import { Alert, Box, type Theme, useMediaQuery } from '@mui/material'
 import { useMemo, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useCheckoutNavigate } from '../../hooks/useCheckoutNavigate.js'
@@ -52,8 +57,44 @@ export const SelectDepositTokenPage: React.FC = () => {
     navigate({ to: checkoutNavigationRoutes.enterAmount })
   }
 
+  // Insufficient-funds alert for exchange flow
+  const [selectedChainId, selectedTokenAddress, fromAmountStr] = useFieldValues(
+    FormKeyHelper.getChainKey(formType),
+    FormKeyHelper.getTokenKey(formType),
+    FormKeyHelper.getAmountKey(formType)
+  )
+  const { token: selectedToken } = useToken(
+    isExchangeFlow ? selectedChainId : undefined,
+    isExchangeFlow ? selectedTokenAddress : undefined
+  )
+  const { chain: selectedChain } = useChain(
+    isExchangeFlow ? selectedChainId : undefined
+  )
+  const { balance: meshBalance } = useMeshBalance(
+    isExchangeFlow ? selectedTokenAddress : undefined,
+    isExchangeFlow ? selectedChainId : undefined
+  )
+
+  const requestedAmount =
+    fromAmountStr && fromAmountStr !== '' ? Number(fromAmountStr) : null
+  const showInsufficientFunds =
+    isExchangeFlow &&
+    meshBalance !== null &&
+    requestedAmount !== null &&
+    meshBalance < requestedAmount
+
   return (
     <FullPageContainer disableGutters>
+      {showInsufficientFunds && selectedToken && selectedChain ? (
+        <Box sx={{ px: 3, pt: 2 }}>
+          <Alert severity="warning">
+            {t('checkout.insufficientFunds', {
+              symbol: selectedToken.symbol,
+              chain: selectedChain.name,
+            })}
+          </Alert>
+        </Box>
+      ) : null}
       <Box
         ref={headerRef}
         sx={{

--- a/packages/widget-checkout/src/pages/SelectSourcePage/SelectSourcePage.tsx
+++ b/packages/widget-checkout/src/pages/SelectSourcePage/SelectSourcePage.tsx
@@ -1,6 +1,14 @@
 import { useAccount, useWalletMenu } from '@lifi/wallet-management'
-import { PoweredBy, useHeader } from '@lifi/widget/shared'
-import { Box } from '@mui/material'
+import {
+  FormKeyHelper,
+  PoweredBy,
+  useChain,
+  useFieldValues,
+  useHeader,
+  useToken,
+} from '@lifi/widget/shared'
+import { useMeshBalance } from '@lifi/widget-provider-mesh'
+import { Alert, Box } from '@mui/material'
 import { useCallback, useEffect, useMemo, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { formatOnRampError } from '../../components/formatOnRampError.js'
@@ -33,6 +41,37 @@ export const SelectSourcePage: React.FC = () => {
   const setFundingSource = useCheckoutFlowStore((s) => s.setFundingSource)
   const resetFlow = useCheckoutFlowStore((s) => s.reset)
   const overrideExchanges = useCheckoutExchangesOverride()
+
+  // Capture fundingSource before resetFlow fires (runs after first render).
+  const fundingSource = useCheckoutFlowStore((s) => s.fundingSource)
+  const wasExchangeFlow = fundingSource === 'exchange'
+
+  // Insufficient-funds shortfall check — only active when re-entering from exchange flow.
+  const formType = 'from' as const
+  const [prevChainId, prevTokenAddress, prevAmountStr] = useFieldValues(
+    FormKeyHelper.getChainKey(formType),
+    FormKeyHelper.getTokenKey(formType),
+    FormKeyHelper.getAmountKey(formType)
+  )
+  const { token: prevToken } = useToken(
+    wasExchangeFlow ? prevChainId : undefined,
+    wasExchangeFlow ? prevTokenAddress : undefined
+  )
+  const { chain: prevChain } = useChain(
+    wasExchangeFlow ? prevChainId : undefined
+  )
+  const { balance: meshBalance } = useMeshBalance(
+    wasExchangeFlow ? prevTokenAddress : undefined,
+    wasExchangeFlow ? prevChainId : undefined
+  )
+
+  const prevRequestedAmount =
+    prevAmountStr && prevAmountStr !== '' ? Number(prevAmountStr) : null
+  const showInsufficientFunds =
+    wasExchangeFlow &&
+    meshBalance !== null &&
+    prevRequestedAmount !== null &&
+    meshBalance < prevRequestedAmount
 
   useEffect(() => {
     resetFlow()
@@ -120,6 +159,14 @@ export const SelectSourcePage: React.FC = () => {
       })}
     >
       <SelectSourceMainColumn sx={{ flex: 1 }}>
+        {showInsufficientFunds && prevToken && prevChain ? (
+          <Alert severity="warning" sx={{ mb: 2 }}>
+            {t('checkout.insufficientFunds', {
+              symbol: prevToken.symbol,
+              chain: prevChain.name,
+            })}
+          </Alert>
+        ) : null}
         <SelectSourceFundingOptions
           onPayFromWallet={handlePayFromWallet}
           onTransferCrypto={handleTransferCrypto}

--- a/packages/widget-provider-mesh/src/index.ts
+++ b/packages/widget-provider-mesh/src/index.ts
@@ -1,6 +1,12 @@
 import type { OnRampProvider } from '@lifi/widget-provider/checkout'
 import { MeshHost } from './MeshHost.js'
 
+export type {
+  MeshBalanceResponse,
+  MeshBalanceResult,
+} from './useMeshBalance.js'
+export { useMeshBalance } from './useMeshBalance.js'
+
 export function meshProvider(): OnRampProvider {
   return {
     id: 'mesh',

--- a/packages/widget-provider-mesh/src/useMeshBalance.ts
+++ b/packages/widget-provider-mesh/src/useMeshBalance.ts
@@ -1,0 +1,115 @@
+'use client'
+import {
+  useCheckoutConfig,
+  useCheckoutUserId,
+} from '@lifi/widget-provider/checkout'
+import { useEffect, useRef, useState } from 'react'
+
+/**
+ * Expected shape returned by `GET /v1/checkout/cex/balance`.
+ *
+ * TODO: confirm exact field names with Core once the endpoint ships.
+ * The assumed shape is:
+ *   { balance: string; decimals: number }
+ * where `balance` is the raw integer amount as a decimal string (e.g. "1500000" for 1.5 USDC with 6 decimals).
+ */
+export interface MeshBalanceResponse {
+  /** Raw token balance as a decimal-string integer (unscaled by decimals). */
+  balance: string
+  decimals: number
+}
+
+export interface MeshBalanceResult {
+  /** Human-readable balance (already divided by decimals). */
+  balance: number | null
+  isLoading: boolean
+  error: string | null
+}
+
+interface FetchKey {
+  account: string
+  tokenAddress: string
+  chainId: number
+}
+
+function keyOf(k: FetchKey): string {
+  return `${k.account}:${k.tokenAddress}:${k.chainId}`
+}
+
+/**
+ * Fetch-once hook that retrieves the user's Mesh exchange balance for a
+ * specific token/chain combination. Re-fetches only when (account, token,
+ * chain) changes.
+ *
+ * Uses `GET /v1/checkout/cex/balance?tokenAddress=&chainId=&userId=`.
+ *
+ * TODO: replace stub with real fetch once Core ships the balance endpoint.
+ * Until then the hook returns `{ balance: null, isLoading: false, error: null }`
+ * so callers never show a false insufficient-funds alert.
+ */
+export function useMeshBalance(
+  tokenAddress: string | undefined,
+  chainId: number | undefined
+): MeshBalanceResult {
+  const { onrampSessionApiUrl } = useCheckoutConfig()
+  const userId = useCheckoutUserId()
+
+  const [result, setResult] = useState<MeshBalanceResult>({
+    balance: null,
+    isLoading: false,
+    error: null,
+  })
+
+  const lastKeyRef = useRef<string | null>(null)
+
+  useEffect(() => {
+    const apiUrl = onrampSessionApiUrl?.replace(/\/$/, '')
+    if (!apiUrl || !tokenAddress || !chainId || !userId) {
+      setResult({ balance: null, isLoading: false, error: null })
+      return
+    }
+
+    const key = keyOf({ account: userId, tokenAddress, chainId })
+    if (key === lastKeyRef.current) {
+      return
+    }
+    lastKeyRef.current = key
+
+    // TODO: remove stub and uncomment the fetch block below once Core ships
+    // the `/v1/checkout/cex/balance` endpoint.
+    setResult({ balance: null, isLoading: false, error: null })
+
+    /*
+    setResult({ balance: null, isLoading: true, error: null })
+
+    const params = new URLSearchParams({
+      tokenAddress,
+      chainId: String(chainId),
+      userId,
+      ...(integrator ? { integrator } : {}),
+    })
+
+    fetch(`${apiUrl}/v1/checkout/cex/balance?${params.toString()}`, {
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    })
+      .then(async (res) => {
+        if (!res.ok) {
+          setResult({ balance: null, isLoading: false, error: `HTTP ${res.status}` })
+          return
+        }
+        const data = (await res.json()) as MeshBalanceResponse
+        const raw = Number(data.balance)
+        const human = raw / 10 ** data.decimals
+        setResult({ balance: human, isLoading: false, error: null })
+      })
+      .catch((e: unknown) => {
+        const msg = e instanceof Error ? e.message : 'Network error fetching balance.'
+        setResult({ balance: null, isLoading: false, error: msg })
+      })
+    */
+  }, [userId, tokenAddress, chainId, onrampSessionApiUrl])
+
+  return result
+}

--- a/packages/widget/src/i18n/en.json
+++ b/packages/widget/src/i18n/en.json
@@ -459,6 +459,7 @@
       }
     },
     "chooseFundingSource": "Choose funding source",
+    "insufficientFunds": "Insufficient funds — You don't have enough {{symbol}} on {{chain}}. Select a different token to try again.",
     "useYourTokens": "Use your tokens",
     "buyTokens": "Buy tokens",
     "or": "or",
@@ -530,7 +531,11 @@
       },
       "errorConnection": {
         "title": "Connection failed",
-        "description": "We couldn't connect to the payment provider. Try again or contact support."
+        "description": "We couldn't connect to the payment provider. Try again or contact support.",
+        "exchange": {
+          "title": "Exchange connection failed",
+          "description": "We couldn't connect to your exchange account. Try again or contact support."
+        }
       },
       "errorWithdrawal": {
         "title": "Withdrawal failed",
@@ -538,6 +543,10 @@
         "cash": {
           "title": "Payment didn't complete",
           "description": "Your payment didn't go through. No funds were taken."
+        },
+        "exchange": {
+          "title": "Exchange withdrawal failed",
+          "description": "Your exchange couldn't process the withdrawal. Your funds remain in your exchange account."
         }
       },
       "errorCancelled": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1454,6 +1454,9 @@ importers:
       '@lifi/widget-provider':
         specifier: workspace:*
         version: link:../widget-provider
+      '@lifi/widget-provider-mesh':
+        specifier: workspace:*
+        version: link:../widget-provider-mesh
       '@mui/icons-material':
         specifier: ^9.0.1
         version: 9.0.1(@mui/material@9.0.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
@@ -20531,7 +20534,7 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 25.6.0
+      '@types/node': 25.9.0
       jest-mock: 29.7.0
 
   '@jest/expect-utils@30.3.0':
@@ -20542,7 +20545,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 25.6.0
+      '@types/node': 25.9.0
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -20587,7 +20590,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 25.6.0
+      '@types/node': 25.9.0
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
@@ -23238,7 +23241,7 @@ snapshots:
   '@react-native/codegen@0.84.1(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/parser': 7.29.2
+      '@babel/parser': 7.29.3
       hermes-parser: 0.32.0
       invariant: 2.2.4
       nullthrows: 1.1.1
@@ -26944,7 +26947,7 @@ snapshots:
 
   '@types/babel__core@7.20.5':
     dependencies:
-      '@babel/parser': 7.29.2
+      '@babel/parser': 7.29.3
       '@babel/types': 7.29.0
       '@types/babel__generator': 7.27.0
       '@types/babel__template': 7.4.4
@@ -26956,7 +26959,7 @@ snapshots:
 
   '@types/babel__template@7.4.4':
     dependencies:
-      '@babel/parser': 7.29.2
+      '@babel/parser': 7.29.3
       '@babel/types': 7.29.0
 
   '@types/babel__traverse@7.28.0':
@@ -27017,7 +27020,7 @@ snapshots:
 
   '@types/graceful-fs@4.1.9':
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 25.9.0
 
   '@types/hast@2.3.10':
     dependencies:
@@ -30809,7 +30812,7 @@ snapshots:
 
   chrome-launcher@0.15.2:
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 25.9.0
       escape-string-regexp: 4.0.0
       is-wsl: 2.2.0
       lighthouse-logger: 1.4.2
@@ -30818,7 +30821,7 @@ snapshots:
 
   chromium-edge-launcher@0.2.0:
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 25.9.0
       escape-string-regexp: 4.0.0
       is-wsl: 2.2.0
       lighthouse-logger: 1.4.2
@@ -33519,7 +33522,7 @@ snapshots:
   istanbul-lib-instrument@5.2.1:
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/parser': 7.29.2
+      '@babel/parser': 7.29.3
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
       semver: 6.3.1
@@ -33581,7 +33584,7 @@ snapshots:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 25.6.0
+      '@types/node': 25.9.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
@@ -33591,7 +33594,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.9
-      '@types/node': 25.6.0
+      '@types/node': 25.9.0
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -33637,7 +33640,7 @@ snapshots:
   jest-mock@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 25.6.0
+      '@types/node': 25.9.0
       jest-util: 29.7.0
 
   jest-mock@30.3.0:
@@ -33653,7 +33656,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 25.6.0
+      '@types/node': 25.9.0
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -33679,7 +33682,7 @@ snapshots:
 
   jest-worker@29.7.0:
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 25.9.0
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
@@ -34473,7 +34476,7 @@ snapshots:
       metro-cache: 0.83.5
       metro-core: 0.83.5
       metro-runtime: 0.83.5
-      yaml: 2.8.2
+      yaml: 2.9.0
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -34553,7 +34556,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.0
       '@babel/generator': 7.29.1
-      '@babel/parser': 7.29.2
+      '@babel/parser': 7.29.3
       '@babel/types': 7.29.0
       flow-enums-runtime: 0.0.6
       metro: 0.83.5(bufferutil@4.1.0)(utf-8-validate@6.0.6)
@@ -34574,7 +34577,7 @@ snapshots:
       '@babel/code-frame': 7.29.0
       '@babel/core': 7.29.0
       '@babel/generator': 7.29.1
-      '@babel/parser': 7.29.2
+      '@babel/parser': 7.29.3
       '@babel/template': 7.28.6
       '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0


### PR DESCRIPTION
## Which Linear task is linked to this PR?

https://linear.app/lifi-linear/issue/EMB-328

## Why was it implemented this way?

Adds the Mesh balance check + exchange-specific copy on top of the shared status-screen foundation (EMB-382). `useMeshBalance` lives in `@lifi/widget-provider-mesh` so the widget core stays balance-agnostic. The variant resolver picks exchange-specific keys via `fundingSource === 'exchange'` — keeps the variant table flat instead of adding parallel structures.

**Flagged:** `useMeshBalance` returns `{ balance: null }` unconditionally until Core ships `GET /v1/checkout/cex/balance`. The fetch implementation is fully written but stubbed behind a TODO documenting the expected `{ balance: string, decimals: number }` response shape. No false insufficient-funds alerts will fire until the stub is removed.

## Visual showcase (Screenshots or Videos)

Figma: https://www.figma.com/design/6Y6yJNHvj1tEkyrEfFDE1J/Checkout?node-id=22418-17240

## Checklist before requesting a review

- [x] I have performed a self-review and testing of my code.
- [x] This pull request is focused and addresses a single problem.
- [ ] If this PR modifies the Widget API or adds new features that require documentation, I have updated the documentation in the [public-docs](https://github.com/lifinance/public-docs) repository.