### PR TITLE
Transfer crypto: route terminal substatuses to deposit-error pages

### DIFF
--- a/packages/widget-checkout/src/pages/TransferDepositPage/useTransferStatusPoll.ts
+++ b/packages/widget-checkout/src/pages/TransferDepositPage/useTransferStatusPoll.ts
@@ -16,6 +16,24 @@ import {
   depositAddressQueryKey,
 } from '../../utils/statusPolling.js'
 import { getTransferReceiptSimulation } from '../../utils/transactionStatusSimulation.js'
+import type { DepositErrorKind } from '../DepositErrorPages/DepositErrorPages.js'
+
+/**
+ * Terminal substatus → deposit-error page kind. Refund substatuses
+ * (REFUND_IN_PROGRESS, REFUNDED) intentionally fall through to the status
+ * page — they use the shared refund variants, not the deposit-error pages.
+ */
+function resolveDepositErrorKind(
+  data: StatusResponse
+): DepositErrorKind | null {
+  if (data.status !== 'FAILED' && data.status !== 'INVALID') {
+    return null
+  }
+  if (data.substatus === 'EXPIRED') {
+    return 'address-expired'
+  }
+  return 'unexpected'
+}
 
 export interface UseTransferStatusPollArgs {
   depositAddress: string | null
@@ -95,6 +113,14 @@ export function useTransferStatusPoll({
       return
     }
     if (data.status === 'NOT_FOUND') {
+      return
+    }
+    const depositErrorKind = resolveDepositErrorKind(data)
+    if (depositErrorKind) {
+      navigate({
+        to: checkoutNavigationRoutes.depositError,
+        params: { kind: depositErrorKind },
+      })
       return
     }
     const receivingTxHash = getReceivingTxHash(data)


### PR DESCRIPTION
## Which Linear task is linked to this PR?

https://linear.app/lifi-linear/issue/EMB-374

## Why was it implemented this way?

Extends `useTransferStatusPoll` to detect terminal failure substatuses and route to the matching `DepositErrorRoutePage` instead of the generic status page:

- `EXPIRED` → `address-expired`
- `UNKNOWN_FAILED_ERROR` (and other failed substatuses) → `unexpected`
- `REFUND_IN_PROGRESS` / `REFUNDED` → fall through to the foundation status page (refund variants)
- `INTENT_FAILED_RETRYABLE` / `INTENT_SIMULATION_FAILURE` → still pending; foundation renders `pending-retrying`

**Deferred follow-up:** populating `DepositAmountTable` rows from frozen route + poll response, plus per-frame Figma copy audit. Most amount-low/excess-held/late-arrival pages aren't triggered by current backend signals (no received-amount field on `/v1/status` yet), so wiring is speculative until the API surfaces those fields.

## Visual showcase (Screenshots or Videos)

Figma error frames (11): see EMB-374 ticket description.

## Checklist before requesting a review

- [x] I have performed a self-review and testing of my code.
- [x] This pull request is focused and addresses a single problem.
- [ ] If this PR modifies the Widget API or adds new features that require documentation, I have updated the documentation in the [public-docs](https://github.com/lifinance/public-docs) repository.