### PR TITLE
feat(widget)!: remove deprecated _vcComponent from WidgetFeeConfig

### DIFF
--- a/packages/widget-light/src/shared/widgetConfig.ts
+++ b/packages/widget-light/src/shared/widgetConfig.ts
@@ -219,7 +219,7 @@ export type WidgetTokens = {
 
 // ---------------------------------------------------------------------------
 // Fee configuration — serializable subset.
-// Excluded: feeTooltipComponent (ReactNode), calculateFee (fn), _vcComponent
+// Excluded: feeTooltipComponent (ReactNode), calculateFee (fn)
 // ---------------------------------------------------------------------------
 
 export interface WidgetFeeConfig {

--- a/packages/widget/src/pages/TransactionPage/StatusBottomSheet.tsx
+++ b/packages/widget/src/pages/TransactionPage/StatusBottomSheet.tsx
@@ -73,7 +73,6 @@ const StatusBottomSheetContent: React.FC<StatusBottomSheetContentProps> = ({
     subvariantOptions,
     contractSecondaryComponent,
     contractCompactComponent,
-    feeConfig,
   } = useWidgetConfig()
   const { getChainById } = useAvailableChains()
 
@@ -207,9 +206,6 @@ const StatusBottomSheetContent: React.FC<StatusBottomSheetContentProps> = ({
     hasEnumFlag(status, RouteExecutionStatus.Done) &&
     (contractCompactComponent || contractSecondaryComponent)
 
-  const VcComponent =
-    status === RouteExecutionStatus.Done ? feeConfig?._vcComponent : undefined
-
   return (
     <Box
       ref={ref}
@@ -264,7 +260,7 @@ const StatusBottomSheetContent: React.FC<StatusBottomSheetContentProps> = ({
             flexDirection: 'column',
             gap: 2,
             marginTop: 2,
-            marginBottom: VcComponent ? 2 : 3,
+            marginBottom: 3,
           }}
         >
           <Card
@@ -294,7 +290,6 @@ const StatusBottomSheetContent: React.FC<StatusBottomSheetContentProps> = ({
               </Typography>
             )}
           </Card>
-          {VcComponent ? <VcComponent route={route} /> : null}
         </Box>
       ) : null}
       <Box sx={{ display: 'flex', marginTop: 2, gap: 1.5 }}>

--- a/packages/widget/src/types/widget.ts
+++ b/packages/widget/src/types/widget.ts
@@ -6,7 +6,6 @@ import type {
   ExtendedChain,
   Order,
   Route,
-  RouteExtended,
   RouteOptions,
   SDKConfig,
   StaticToken,
@@ -25,7 +24,6 @@ import type {
 import type { TypographyVariantsOptions } from '@mui/material/styles'
 import type {
   CSSProperties,
-  FC,
   PropsWithChildren,
   ReactNode,
   RefObject,
@@ -223,10 +221,6 @@ export interface WidgetFeeConfig {
    * @returns A promise that resolves to the calculated fee as a number (e.g., 0.03 represents a 3% fee)
    */
   calculateFee?(params: CalculateFeeParams): Promise<number | undefined>
-  /**
-   * @internal
-   */
-  _vcComponent?: FC<{ route: RouteExtended }>
 }
 
 export interface ToAddress {


### PR DESCRIPTION
## Which Linear task is linked to this PR?
[EMB-389](https://linear.app/lifi-linear/issue/EMB-389/v4-widgetconfig-api-upgrade) — Wave 1, item #5

## Why was it implemented this way?
`WidgetFeeConfig._vcComponent` was marked `@internal` but still appeared in generated `.d.ts` files and IntelliSense — and is no longer needed. This PR deletes the field and its rendering branch in `StatusBottomSheet.tsx` entirely. No replacement.

**Why a clean delete (not a deprecate-then-remove cycle):** the field was prefixed with `_` and marked `@internal`, so no external integrator should have a legitimate dependency on it. v4 is the right window to remove leaked internals before they ossify.

## Migration
If you were depending on the internal `_vcComponent` field on `WidgetFeeConfig` (prefixed with `_` and marked `@internal`), it has been removed with no replacement. Remove any `feeConfig._vcComponent` references from your config.

## Visual showcase
N/A — removing an unused render branch. Smoke test confirms the transaction success state renders with the correct margin (was conditionally 2 or 3, now unconditionally 3 — the pre-_vcComponent default).

## Checklist before requesting a review
- [x] I have performed a self-review and testing of my code.
- [x] This pull request is focused and addresses a single problem.
- [ ] If this PR modifies the Widget API or adds new features that require documentation, I have updated the documentation in the [public-docs](https://github.com/lifinance/public-docs) repository.