### PR TITLE
feat(widget)!: rename useRecommendedRoute to showSingleRoute

### DIFF
--- a/examples/deposit-flow/src/App.tsx
+++ b/examples/deposit-flow/src/App.tsx
@@ -28,7 +28,7 @@ export function App() {
       integrator: 'ProtocolName',
       disabledUI: [DisabledUI.ToAddress],
       hiddenUI: [HiddenUI.Appearance, HiddenUI.Language],
-      useRecommendedRoute: true,
+      showSingleRoute: true,
       theme: {
         container: {
           border: '1px solid rgb(234, 234, 234)',

--- a/packages/widget-light/src/shared/widgetConfig.ts
+++ b/packages/widget-light/src/shared/widgetConfig.ts
@@ -368,7 +368,13 @@ export interface WidgetLightConfig {
   hiddenUI?: WidgetHiddenUI[]
   requiredUI?: WidgetRequiredUI[]
   defaultUI?: WidgetDefaultUI
-  useRecommendedRoute?: boolean
+  /**
+   * When true, shows only the recommended route and hides the route
+   * selector UI. Distinct from `routePriority`, which sets the SDK
+   * ranking order across multiple displayed routes.
+   * @default false
+   */
+  showSingleRoute?: boolean
   useRelayerRoutes?: boolean
 
   // -- Wallet / SDK --

--- a/packages/widget-playground/src/defaultWidgetConfig.ts
+++ b/packages/widget-playground/src/defaultWidgetConfig.ts
@@ -74,7 +74,7 @@ export const widgetBaseConfig: WidgetConfig = {
   //   showFeePercentage: true,
   //   showFeeTooltip: true,
   // },
-  // useRecommendedRoute: true,
+  // showSingleRoute: true,
   useRelayerRoutes: true,
   buildUrl: true,
   // hiddenUI: ['poweredBy', 'language', 'appearance', 'drawerButton', 'toAddress'],

--- a/packages/widget/src/components/Routes/Routes.tsx
+++ b/packages/widget/src/components/Routes/Routes.tsx
@@ -16,8 +16,7 @@ import { RouteNotFoundCard } from '../RouteCard/RouteNotFoundCard.js'
 export const Routes: React.FC<CardProps> = (props) => {
   const { t } = useTranslation()
   const navigate = useNavigate()
-  const { subvariant, subvariantOptions, useRecommendedRoute } =
-    useWidgetConfig()
+  const { subvariant, subvariantOptions, showSingleRoute } = useWidgetConfig()
   const {
     routes,
     isLoading,
@@ -39,9 +38,9 @@ export const Routes: React.FC<CardProps> = (props) => {
   }
 
   const routeNotFound = !currentRoute && !isLoading && !isFetching
-  const onlyRecommendedRoute = subvariant === 'refuel' || useRecommendedRoute
+  const onlySingleRoute = subvariant === 'refuel' || showSingleRoute
   const showAll =
-    !onlyRecommendedRoute && !routeNotFound && (routes?.length ?? 0) > 1
+    !onlySingleRoute && !routeNotFound && (routes?.length ?? 0) > 1
 
   const title =
     subvariant === 'custom'

--- a/packages/widget/src/hooks/useWideVariant.ts
+++ b/packages/widget/src/hooks/useWideVariant.ts
@@ -5,9 +5,9 @@ import { useWidgetConfig } from '../providers/WidgetProvider/WidgetProvider.js'
 const defaultExpandableWidth = 852
 
 export const useWideVariant = (): boolean => {
-  const { variant, useRecommendedRoute } = useWidgetConfig()
+  const { variant, showSingleRoute } = useWidgetConfig()
   const expandableAllowed = useMediaQuery((theme: Theme) =>
     theme.breakpoints.up(defaultExpandableWidth)
   )
-  return variant === 'wide' && expandableAllowed && !useRecommendedRoute
+  return variant === 'wide' && expandableAllowed && !showSingleRoute
 }

--- a/packages/widget/src/types/widget.ts
+++ b/packages/widget/src/types/widget.ts
@@ -348,7 +348,13 @@ export interface WidgetConfig {
   hiddenUI?: HiddenUIType[]
   requiredUI?: RequiredUIType[]
   defaultUI?: DefaultUI
-  useRecommendedRoute?: boolean
+  /**
+   * When true, shows only the recommended route and hides the route
+   * selector UI. Distinct from `routePriority`, which sets the SDK
+   * ranking order across multiple displayed routes.
+   * @default false
+   */
+  showSingleRoute?: boolean
   useRelayerRoutes?: boolean
 
   walletConfig?: WidgetWalletConfig


### PR DESCRIPTION
## Which Linear task is linked to this PR?
[EMB-389](https://linear.app/lifi-linear/issue/EMB-389/v4-widgetconfig-api-upgrade) — Wave 1, item #6

## Why was it implemented this way?
`useRecommendedRoute` is a boolean toggle that hides the route selector and shows only one route. The name implies it controls route **priority** (which is actually what `routePriority` does), but its effect is to **collapse the UI to a single route view**.

Verified the two semantics are distinct:
- `routePriority` → which route to rank first (passed to the SDK).
- `useRecommendedRoute` / `showSingleRoute` → whether to hide the route selector and show only the recommended one (`Routes.tsx:42`, `useWideVariant.ts:12`).

`showSingleRoute` matches the actual effect.

**Alternatives considered:**
- `hideRouteSelector` — describes the consequence, not the intent.
- `disableRouteSelection` — implies the selector is interactive but disabled, which is misleading.
- `singleRoute: boolean` — terser but loses the verb that hints at the UI behavior.

## Visual showcase
N/A — pure rename. Smoke test confirms the playground loads with widget mounted.

## Checklist before requesting a review
- [x] I have performed a self-review and testing of my code.
- [x] This pull request is focused and addresses a single problem.
- [ ] If this PR modifies the Widget API or adds new features that require documentation, I have updated the documentation in the [public-docs](https://github.com/lifinance/public-docs) repository.

## Breaking change

Migration:
\`\`\`diff
- useRecommendedRoute: true,
+ showSingleRoute: true,
\`\`\`