### PR TITLE
fix(widget): add Lighter explorer path override for address links

### DIFF
--- a/packages/widget/src/hooks/useExplorer.ts
+++ b/packages/widget/src/hooks/useExplorer.ts
@@ -10,6 +10,10 @@ const explorerPathOverrides: Partial<
   Record<ChainType | ChainId, { txPath: string; addressPath: string }>
 > = {
   [ChainId.SUI]: { txPath: 'txblock', addressPath: 'coin' },
+  [ChainId.LTR]: {
+    txPath: 'explorer/logs',
+    addressPath: 'explorer/accounts',
+  },
   [ChainType.TVM]: { txPath: '#/transaction', addressPath: '#/address' },
 }
 

--- a/packages/widget/src/hooks/useExplorer.ts
+++ b/packages/widget/src/hooks/useExplorer.ts
@@ -10,10 +10,7 @@ const explorerPathOverrides: Partial<
   Record<ChainType | ChainId, { txPath: string; addressPath: string }>
 > = {
   [ChainId.SUI]: { txPath: 'txblock', addressPath: 'coin' },
-  [ChainId.LTR]: {
-    txPath: 'explorer/logs',
-    addressPath: 'explorer/accounts',
-  },
+  [ChainId.LTR]: { txPath: 'logs', addressPath: 'accounts' },
   [ChainType.TVM]: { txPath: '#/transaction', addressPath: '#/address' },
 }
 


### PR DESCRIPTION
## Which Linear task is linked to this PR?

[EMB-395](https://linear.app/lifi-linear/issue/EMB-395/resolve-address-path-for-lighter)

## Why was it implemented this way?

Lighter's explorer doesn't expose `/address/<wallet>` — it only supports `/explorer/logs/<hash>` for transactions and `/explorer/accounts/<index>` for accounts. The widget built `https://lighter.exchange/explorer/address/<wallet>` from `blockExplorerUrls`, which 404'd.

Followed the existing `explorerPathOverrides` pattern in `useExplorer.ts` (already used for SUI and TVM) and added a `ChainId.LTR` entry. This keeps the resolution logic centralized and is the minimal, contained change.

**Caveat**: Lighter accounts are keyed by a numeric index resolved from the L1 wallet via an API call (`/api/v1/accountsByL1Address`). The widget can't do that resolution synchronously, so the address link won't deep-link to the exact account. It now lands on the `/explorer/accounts/<wallet>` route, which the SPA serves (no HTTP 404) — satisfying the ticket's acceptance criterion.

## Visual showcase (Screenshots or Videos)

N/A — link generation change only.

## Checklist before requesting a review
- [x] I have performed a self-review and testing of my code.
- [x] This pull request is focused and addresses a single problem.
- [ ] If this PR modifies the Widget API or adds new features that require documentation, I have updated the documentation in the [public-docs](https://github.com/lifinance/public-docs) repository.