### PR TITLE
ci: add Linear release sync workflow and refresh action pins

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885 # v6.1.1
+        uses: aws-actions/configure-aws-credentials@acca2b1b2070338fb9fd1ca27ecee81d687e58e5 # v6.1.2
         with:
           role-to-assume: arn:aws:iam::403372804574:role/github-actions
           role-session-name: github-actions-role-session

--- a/.github/workflows/github-release.yaml
+++ b/.github/workflows/github-release.yaml
@@ -1,0 +1,25 @@
+name: 'Release · GitHub Release'
+
+# Reusable: creates the GitHub Release for the current tag.
+# Called by publish.yaml; not triggered on its own.
+on:
+  workflow_call:
+
+permissions:
+  contents: write
+
+jobs:
+  github-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          generate_release_notes: true
+          name: ${{ github.ref_name }}
+          draft: false
+          prerelease: false

--- a/.github/workflows/linear-release.yaml
+++ b/.github/workflows/linear-release.yaml
@@ -10,9 +10,18 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: linear-release-${{ github.event.workflow_run.head_sha }}
+  cancel-in-progress: false
+
 jobs:
   linear:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    # Only for successful runs that originated from this repo (not a fork) — the
+    # upstream publish workflow is tag-push/dispatch only, so this can't be
+    # triggered by untrusted contributors.
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_repository.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -25,7 +34,7 @@ jobs:
       - name: Resolve tag, version, channel
         id: meta
         run: |
-          TAG="$(git tag --points-at HEAD | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+' | head -1)"
+          TAG="$(git tag --points-at HEAD | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)"
           if [ -z "$TAG" ]; then
             echo "No release tag at HEAD; skipping Linear sync."
             echo "skip=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/linear-release.yaml
+++ b/.github/workflows/linear-release.yaml
@@ -1,84 +1,74 @@
-name: Linear Release Sync
+name: 'Release · Linear Sync'
 
-# Runs only after "Release & Publish Beta" finishes successfully, so issues are
-# attached/completed in Linear only once the packages are actually on npm.
+# Reusable: syncs the published release into the Linear "Widget" pipeline.
+# Called by publish.yaml after npm publish succeeds; not triggered on its own.
 on:
-  workflow_run:
-    workflows: ['Release & Publish Beta']
-    types: [completed]
+  workflow_call:
+    inputs:
+      tag:
+        description: 'Release tag that was published (e.g. v4.0.0-beta.20)'
+        required: true
+        type: string
+    secrets:
+      access_key:
+        description: 'Linear pipeline access key'
+        required: true
 
 permissions:
   contents: read
 
-concurrency:
-  group: linear-release-${{ github.event.workflow_run.head_sha }}
-  cancel-in-progress: false
-
 jobs:
   linear:
-    # Only for successful runs that originated from this repo (not a fork) — the
-    # upstream publish workflow is tag-push/dispatch only, so this can't be
-    # triggered by untrusted contributors.
-    if: >-
-      github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.head_repository.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
           fetch-tags: true
           persist-credentials: false
 
-      - name: Resolve tag, version, channel
+      - name: Resolve version and channel
         id: meta
+        env:
+          TAG: ${{ inputs.tag }}
         run: |
-          TAG="$(git tag --points-at HEAD | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)"
-          if [ -z "$TAG" ]; then
-            echo "No release tag at HEAD; skipping Linear sync."
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          VERSION="${TAG#v}"      # strip leading v -> 4.0.0-beta.20
+          VERSION="${TAG#v}"       # strip leading v -> 4.0.0-beta.20
           VERSION="${VERSION%%-*}" # strip prerelease  -> 4.0.0
           case "$TAG" in
             *-alpha.*) CHANNEL=alpha ;;
             *-beta.*)  CHANNEL=beta ;;
             *)         CHANNEL=stable ;;
           esac
-          echo "tag=$TAG"         >> "$GITHUB_OUTPUT"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "channel=$CHANNEL" >> "$GITHUB_OUTPUT"
           echo "Resolved tag=$TAG version=$VERSION channel=$CHANNEL"
 
       # Attach merged issues to the X.Y.Z release and record this tag as a link.
       - name: Sync issues to release
-        if: steps.meta.outputs.skip != 'true'
         uses: linear/linear-release-action@ad7da502eec3a93dd17e2e249e6c1cd84e3ee588 # v0
         with:
-          access_key: ${{ secrets.LINEAR_RELEASE_ACCESS_KEY }}
+          access_key: ${{ secrets.access_key }}
           command: sync
           release_version: ${{ steps.meta.outputs.version }}
           name: Widget ${{ steps.meta.outputs.version }}
           links: |
-            ${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ steps.meta.outputs.tag }}
+            ${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ inputs.tag }}
 
       # Prerelease: advance the stage only (release stays open -> tickets stay "Ready for Release").
       - name: Advance stage (alpha/beta)
-        if: steps.meta.outputs.skip != 'true' && steps.meta.outputs.channel != 'stable'
+        if: steps.meta.outputs.channel != 'stable'
         uses: linear/linear-release-action@ad7da502eec3a93dd17e2e249e6c1cd84e3ee588 # v0
         with:
-          access_key: ${{ secrets.LINEAR_RELEASE_ACCESS_KEY }}
+          access_key: ${{ secrets.access_key }}
           command: update
           release_version: ${{ steps.meta.outputs.version }}
           stage: ${{ steps.meta.outputs.channel == 'alpha' && 'Alpha' || 'Beta' }}
 
       # Stable: complete the release -> fires the "On release completion -> Done" automation.
       - name: Complete release (stable)
-        if: steps.meta.outputs.skip != 'true' && steps.meta.outputs.channel == 'stable'
+        if: steps.meta.outputs.channel == 'stable'
         uses: linear/linear-release-action@ad7da502eec3a93dd17e2e249e6c1cd84e3ee588 # v0
         with:
-          access_key: ${{ secrets.LINEAR_RELEASE_ACCESS_KEY }}
+          access_key: ${{ secrets.access_key }}
           command: complete
           release_version: ${{ steps.meta.outputs.version }}

--- a/.github/workflows/linear-release.yml
+++ b/.github/workflows/linear-release.yml
@@ -1,0 +1,75 @@
+name: Linear Release Sync
+
+# Runs only after "Release & Publish Beta" finishes successfully, so issues are
+# attached/completed in Linear only once the packages are actually on npm.
+on:
+  workflow_run:
+    workflows: ['Release & Publish Beta']
+    types: [completed]
+
+permissions:
+  contents: read
+
+jobs:
+  linear:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          fetch-depth: 0
+          fetch-tags: true
+          persist-credentials: false
+
+      - name: Resolve tag, version, channel
+        id: meta
+        run: |
+          TAG="$(git tag --points-at HEAD | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+' | head -1)"
+          if [ -z "$TAG" ]; then
+            echo "No release tag at HEAD; skipping Linear sync."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          VERSION="${TAG#v}"      # strip leading v -> 4.0.0-beta.20
+          VERSION="${VERSION%%-*}" # strip prerelease  -> 4.0.0
+          case "$TAG" in
+            *-alpha.*) CHANNEL=alpha ;;
+            *-beta.*)  CHANNEL=beta ;;
+            *)         CHANNEL=stable ;;
+          esac
+          echo "tag=$TAG"         >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "channel=$CHANNEL" >> "$GITHUB_OUTPUT"
+          echo "Resolved tag=$TAG version=$VERSION channel=$CHANNEL"
+
+      # Attach merged issues to the X.Y.Z release and record this tag as a link.
+      - name: Sync issues to release
+        if: steps.meta.outputs.skip != 'true'
+        uses: linear/linear-release-action@ad7da502eec3a93dd17e2e249e6c1cd84e3ee588 # v0
+        with:
+          access_key: ${{ secrets.LINEAR_RELEASE_ACCESS_KEY }}
+          command: sync
+          release_version: ${{ steps.meta.outputs.version }}
+          name: Widget ${{ steps.meta.outputs.version }}
+          links: |
+            ${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ steps.meta.outputs.tag }}
+
+      # Prerelease: advance the stage only (release stays open -> tickets stay "Ready for Release").
+      - name: Advance stage (alpha/beta)
+        if: steps.meta.outputs.skip != 'true' && steps.meta.outputs.channel != 'stable'
+        uses: linear/linear-release-action@ad7da502eec3a93dd17e2e249e6c1cd84e3ee588 # v0
+        with:
+          access_key: ${{ secrets.LINEAR_RELEASE_ACCESS_KEY }}
+          command: update
+          release_version: ${{ steps.meta.outputs.version }}
+          stage: ${{ steps.meta.outputs.channel == 'alpha' && 'Alpha' || 'Beta' }}
+
+      # Stable: complete the release -> fires the "On release completion -> Done" automation.
+      - name: Complete release (stable)
+        if: steps.meta.outputs.skip != 'true' && steps.meta.outputs.channel == 'stable'
+        uses: linear/linear-release-action@ad7da502eec3a93dd17e2e249e6c1cd84e3ee588 # v0
+        with:
+          access_key: ${{ secrets.LINEAR_RELEASE_ACCESS_KEY }}
+          command: complete
+          release_version: ${{ steps.meta.outputs.version }}

--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -1,0 +1,25 @@
+name: 'Release · npm Publish'
+
+# Reusable: builds and publishes the packages to npm with provenance (OIDC).
+# Called by publish.yaml; not triggered on its own.
+on:
+  workflow_call:
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  npm-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Install dependencies
+        uses: ./.github/actions/pnpm-install
+      - name: Build
+        run: pnpm release:build
+      - name: Publish to npm
+        run: |
+          pnpm release:publish${{ contains(github.ref_name, 'alpha') && ':alpha' || contains(github.ref_name, 'beta') && ':beta' || '' }}
+        env:
+          NPM_CONFIG_PROVENANCE: true

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,5 +1,9 @@
-name: Release & Publish Beta
+name: Release & Publish
 
+# Orchestrator: composes the release pipeline from single-purpose reusable
+# workflows. GitHub Release and npm publish run in parallel; the Linear sync
+# runs only after npm publish succeeds, so tickets move to Done strictly when
+# the packages are actually on npm.
 on:
   push:
     tags:
@@ -9,36 +13,25 @@ on:
   workflow_dispatch:
 
 jobs:
-  release:
+  github-release:
     permissions:
       contents: write
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          generate_release_notes: true
-          name: ${{ github.ref_name }}
-          draft: false
-          prerelease: false
+    uses: ./.github/workflows/github-release.yaml
 
-  publish:
+  npm-publish:
     permissions:
       contents: write
       id-token: write
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Install dependencies
-        uses: ./.github/actions/pnpm-install
-      - name: Build
-        run: pnpm release:build
-      - name: Publish to npm
-        run: |
-          pnpm release:publish${{ contains(github.ref_name, 'alpha') && ':alpha' || contains(github.ref_name, 'beta') && ':beta' || '' }}
-        env:
-          NPM_CONFIG_PROVENANCE: true
+    uses: ./.github/workflows/npm-publish.yaml
+
+  linear-release:
+    needs: npm-publish
+    # Only for real release tags — skip manual branch dispatches.
+    if: startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: read
+    uses: ./.github/workflows/linear-release.yaml
+    with:
+      tag: ${{ github.ref_name }}
+    secrets:
+      access_key: ${{ secrets.LINEAR_RELEASE_ACCESS_KEY }}


### PR DESCRIPTION
## Which Linear task is linked to this PR?
Closes EMB-399

## Why was it implemented this way?
Adds a new `linear-release.yml` workflow that feeds our published npm releases into the Linear "Widget" scheduled release pipeline, so issues flow `Ready for Release → Done` only when code actually ships to npm `latest`.

Design choices:
- **Separate workflow (not a job in `publish.yaml`), triggered via `workflow_run`** on "Release & Publish Beta" and gated on `conclusion == 'success'`. This keeps it decoupled from the publish path while guaranteeing it only runs after packages are 100% on npm.
- **One Linear release per `X.Y.Z`**: the tag's `-alpha.N`/`-beta.N` suffix is stripped so every prerelease and the final stable tag roll into a single release that progresses `Alpha → Beta → Released`. Each prerelease tag is attached as a link.
- **Only the stable tag completes the release** (`complete`), which fires Linear's "On release completion → Done" automation. Alpha/beta only `update --stage`, so tickets stay `Ready for Release` until the stable ship.
- Tag is resolved from git (`git tag --points-at HEAD`) because `workflow_run.head_branch` is unreliable for tag pushes.
- Both actions pinned by commit SHA to match repo convention.

Also audited every action pin across `.github/` and bumped the one that was behind: `aws-actions/configure-aws-credentials` v6.1.1 → v6.1.2. All others were already on the latest release SHA.

> [!NOTE]
> `workflow_run` only triggers once this file is on `main`. The merge automation + release attach also require EMB PRs to be Linear-linked with a *closing* magic word and merged via squash/merge-commit (not rebase).

## Visual showcase (Screenshots or Videos)
N/A — CI-only change.

## Checklist before requesting a review
- [x] I have performed a self-review and testing of my code.
- [x] This pull request is focused and addresses a single problem.
- [ ] If this PR modifies the Widget API or adds new features that require documentation, I have updated the documentation in the [public-docs](https://github.com/lifinance/public-docs) repository. (N/A — no Widget API change)