### PR TITLE
fix(widget): show receiving-chain receipt row for non-EVM-hash bridges

### DIFF
--- a/.changeset/fix-receiving-chain-receipt-row-non-evm-hash.md
+++ b/.changeset/fix-receiving-chain-receipt-row-non-evm-hash.md
@@ -1,0 +1,5 @@
+---
+"@lifi/widget": patch
+---
+
+Show the "Bridge completed" receipt row for bridges whose destination transaction hash is not a `0x`-prefixed EVM hash (e.g. Lighter), building the explorer link from a chain-specific path override.

--- a/packages/widget/src/components/Step/StepAction.tsx
+++ b/packages/widget/src/components/Step/StepAction.tsx
@@ -18,17 +18,11 @@ export const StepAction: React.FC<{
     return null
   }
 
-  const transactionLink = action.txHash
-    ? getTransactionLink({
-        txHash: action.txHash,
-        chain: action.chainId,
-      })
-    : action.txLink
-      ? getTransactionLink({
-          txLink: action.txLink,
-          chain: action.chainId,
-        })
-      : undefined
+  const transactionLink = getTransactionLink({
+    txHash: action.txHash,
+    txLink: action.txLink,
+    chain: action.chainId,
+  })
 
   return (
     <Box

--- a/packages/widget/src/hooks/useExplorer.ts
+++ b/packages/widget/src/hooks/useExplorer.ts
@@ -78,7 +78,7 @@ export const useExplorer = (): {
       const validForEvm =
         config.resolvedChain?.chainType !== ChainType.EVM ||
         config.hasOverride ||
-        isHex(txHash, { strict: false })
+        isHex(txHash, { strict: true })
       if (validForEvm) {
         return `${config.url}/${config.txPath}/${txHash}`
       }

--- a/packages/widget/src/hooks/useExplorer.ts
+++ b/packages/widget/src/hooks/useExplorer.ts
@@ -10,19 +10,15 @@ const explorerPathOverrides: Partial<
   Record<ChainType | ChainId, { txPath: string; addressPath: string }>
 > = {
   [ChainId.SUI]: { txPath: 'txblock', addressPath: 'coin' },
+  [ChainId.LTR]: { txPath: 'logs', addressPath: 'accounts' },
   [ChainType.TVM]: { txPath: '#/transaction', addressPath: '#/address' },
 }
 
-type TransactionLinkProps = { chain?: Chain | number } & (
-  | {
-      txHash: string
-      txLink?: never
-    }
-  | {
-      txHash?: never
-      txLink: string
-    }
-)
+type TransactionLinkProps = {
+  chain?: Chain | number
+  txHash?: string
+  txLink?: string
+}
 
 export const useExplorer = (): {
   getTransactionLink: (props: TransactionLinkProps) => string | undefined
@@ -65,6 +61,7 @@ export const useExplorer = (): {
       txPath,
       addressPath,
       resolvedChain,
+      hasOverride: Boolean(overrides),
     }
   }
 
@@ -73,20 +70,20 @@ export const useExplorer = (): {
     txLink,
     chain,
   }: TransactionLinkProps): string | undefined => {
-    if (!txHash) {
-      return txLink
-    }
-
-    const config = getExplorerConfig(chain)
-
-    // For EVM chains, validate the transaction hash as some relayers return custom task hashes that are not visible on-chain
-    if (config.resolvedChain?.chainType === ChainType.EVM) {
-      if (!isHex(txHash, { strict: true })) {
-        return undefined
+    if (txHash) {
+      const config = getExplorerConfig(chain)
+      // For EVM chains, sanity-check the transaction hash as some relayers return custom task hashes that are not visible on-chain.
+      // Skip the check when a chain-specific path override is registered — that's an explicit signal the chain's
+      // explorer accepts a non-hex hash (e.g. Lighter, whose hash has no 0x prefix).
+      const validForEvm =
+        config.resolvedChain?.chainType !== ChainType.EVM ||
+        config.hasOverride ||
+        isHex(txHash, { strict: false })
+      if (validForEvm) {
+        return `${config.url}/${config.txPath}/${txHash}`
       }
     }
-
-    return `${config.url}/${config.txPath}/${txHash}`
+    return txLink
   }
 
   const getAddressLink = (address: string, chain?: Chain | number) => {

--- a/packages/widget/src/pages/TransactionDetailsPage/StepActionsList.tsx
+++ b/packages/widget/src/pages/TransactionDetailsPage/StepActionsList.tsx
@@ -20,17 +20,11 @@ export const StepActionsList: React.FC<StepActionsListProps> = ({
       const rows = prepareActions(step.execution?.actions ?? [])
         .map((actionsGroup) => {
           const action = actionsGroup.at(-1)
-          const href = action?.txHash
-            ? getTransactionLink({
-                txHash: action.txHash,
-                chain: action.chainId,
-              })
-            : action?.txLink
-              ? getTransactionLink({
-                  txLink: action.txLink,
-                  chain: action.chainId,
-                })
-              : undefined
+          const href = getTransactionLink({
+            txHash: action?.txHash,
+            txLink: action?.txLink,
+            chain: action?.chainId,
+          })
           return { action, href }
         })
         .filter(({ action, href }) => {


### PR DESCRIPTION
## Which Linear task is linked to this PR?

[EMB-396 — Widget UI missing "bridge completed" + dest tx link](https://linear.app/lifi-linear/issue/EMB-396/widget-ui-missing-bridge-completed-dest-tx-link)

## Why was it implemented this way?

**Bug:** The "Bridge completed" receipt row was missing for bridges whose destination transaction hash is not a `0x`-prefixed EVM hash. Reproduced with a USDC Arbitrum → Lighter route via Relay: the Across leg shows `Bridge transaction confirmed` + `Bridge completed`, but the Lighter leg only shows `Bridge transaction confirmed`.

**Root cause:** The SDK correctly adds a `RECEIVING_CHAIN` action (`status: DONE`, with both `txHash` and `txLink`). The widget then dropped the row in `StepActionsList`, whose filter requires a truthy `href`. `useExplorer.getTransactionLink` was returning `undefined` because Lighter is registered as an EVM chain (`ChainId.LTR = 3586256`) and its destination hash (`609af30b…`, 80 chars, no `0x`) fails the strict `isHex` check that exists to guard against relayer task-IDs producing dead Etherscan links.

**Fix:**
- Build the explorer link from the chain explorer + path override instead of bailing out. `getTransactionLink` now skips the EVM hash check when a chain-specific override is registered (an explicit signal the chain's explorer accepts a non-hex hash), and relaxes the remaining EVM check to non-strict. It falls back to the SDK-provided `txLink` only when no link can be built.
- Add a Lighter override using its real explorer paths: `txPath: 'logs'`, `addressPath: 'accounts'` (→ `https://lighter.exchange/explorer/logs/<hash>` and `…/accounts/<addr>`).
- Collapse the duplicated `txHash ? … : txLink ? …` call sites in `StepActionsList` and `StepAction` into a single `getTransactionLink({ txHash, txLink, chain })` call (props type relaxed to both-optional).

**Alternatives considered:** Falling back to the SDK's `txLink` alone is insufficient — the status API currently returns the wrong path (`/tx/` instead of `/logs/`) for Lighter, so relying on it would produce a broken link. Building the URL from the registered override is the source of truth.

## Visual showcase (Screenshots or Videos)

_Before:_ Lighter receipt shows only "Bridge transaction confirmed" + "Sent to wallet".
_After:_ "Bridge completed" row renders, linking to `https://lighter.exchange/explorer/logs/<hash>`.

_No runtime screenshot attached — reproducing requires a live Lighter route; change verified via type-check, lint, unit tests, and source tracing._

## Checklist before requesting a review
- [x] I have performed a self-review and testing of my code.
- [x] This pull request is focused and addresses a single problem.
- [ ] If this PR modifies the Widget API or adds new features that require documentation, I have updated the documentation in the [public-docs](https://github.com/lifinance/public-docs) repository.