### PR TITLE
ci: keep example pins during changeset version PR

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,7 +166,7 @@ removed after a successful publish (one-shot — re-add it to cut another previe
 
 ### Root scripts
 
-- `pnpm changeset:version` — `changeset version` + `pnpm install --lockfile-only` + `pnpm check:write`.
+- `pnpm changeset:version` — `changeset version` + `scripts/restore-example-versions.sh` + `pnpm install --lockfile-only` + `pnpm check:write`. **The version PR intentionally does not bump example pins.** `changeset version` rewrites every in-workspace example's `@lifi/*` range to the just-bumped, not-yet-published version (and neither `ignore` nor `privatePackages.version:false` prevents this), which then breaks `pnpm install`. `scripts/restore-example-versions.sh` reverts those edits so examples stay pinned to the *published* widget (so their bundlers — notably Next.js — consume the built package rather than the widget's TS source). Bump example pins manually when you want them to track a newer release.
 - `pnpm changeset:prepublish` — `pnpm build`, then `build:prerelease` across publishable packages. **This is where the publish transform runs:** `changeset publish` does flat per-package `npm publish` and does NOT run each package's `build:prerelease` lifecycle, so the transform (`scripts/prerelease.js` → `scripts/formatPackageJson.js`, rewriting entry points to `dist/esm/` and copying `README.md`) must run here.
 - `pnpm changeset:publish` — `pnpm changeset:prepublish && changeset publish` (used by CI).
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "dev:staging": "pnpm --filter widget-playground-vite dev:staging",
     "dev:local": "pnpm --filter widget-playground-vite dev:local",
     "dev:next": "pnpm --filter widget-playground-next dev",
-    "changeset:version": "changeset version && pnpm install --lockfile-only && pnpm check:write",
+    "changeset:version": "changeset version && bash scripts/restore-example-versions.sh && pnpm install --lockfile-only && pnpm check:write",
     "changeset:prepublish": "pnpm build && pnpm -r --filter './packages/**' --filter '!*-playground-*' --filter '!*-embedded' build:prerelease",
     "changeset:publish": "pnpm changeset:prepublish && pnpm --config.verify-deps-before-run=false changeset publish",
     "check": "biome check",

--- a/scripts/restore-example-versions.sh
+++ b/scripts/restore-example-versions.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Restore example package versions after `changeset version`.
+#
+# `changeset version` rewrites the @lifi/* dependency ranges of every in-workspace
+# example to the just-bumped, NOT-YET-PUBLISHED version (e.g. 4.0.0-beta.N+1) and
+# patch-bumps the examples' own private versions. The subsequent
+# `pnpm install --lockfile-only` then fails (ERR_PNPM_NO_MATCHING_VERSION) because
+# that version isn't on npm yet — it's published only after the version PR merges.
+#
+# Examples must stay pinned to the PUBLISHED @lifi/widget so their bundlers
+# (notably Next.js / webpack / Turbopack) consume the built package instead of the
+# widget's TypeScript source. Changesets has no config that exempts a dependent
+# from the range rewrite — `ignore` and `privatePackages.version: false` both still
+# rewrite it — so we discard the auto-edits here, right after versioning.
+#
+# Runs only inside the automated "version packages" PR (via `changeset:version`);
+# it never touches example edits made in normal feature PRs.
+set -euo pipefail
+ROOT="$(git rev-parse --show-toplevel)"
+
+# Revert the auto-edited example manifests back to their committed pins...
+git -C "$ROOT" checkout HEAD -- examples
+# ...and drop the per-example CHANGELOG.md files Changesets generated for them.
+git -C "$ROOT" clean -fq -- 'examples/*/CHANGELOG.md'
+
+echo "restore-example-versions: reverted Changesets' example version bumps."


### PR DESCRIPTION
## Which Linear task is linked to this PR?

N/A — fixes the failing Changesets **"version packages"** job (release tooling). Failing run: https://github.com/lifinance/widget/actions/runs/26825745210/job/79093111996

## Why was it implemented this way?

The `Changesets` job's *"Create version pull request"* step (`pnpm changeset:version`) was failing with `ERR_PNPM_NO_MATCHING_VERSION`.

**Root cause:** `changeset version` rewrites the `@lifi/*` dependency ranges of every in-workspace **example** to the just-bumped, *not-yet-published* version (e.g. `4.0.0-beta.21`). The subsequent `pnpm install --lockfile-only` then can't resolve it from npm (it's published only after the version PR merges).

**Alternatives ruled out (verified empirically in a worktree):**
- Changesets `ignore` — still rewrites the example dependency ranges.
- `privatePackages: { version: false }` — same, still rewrites them.
- Converting examples to `workspace:*` — survives `changeset version`, but makes examples consume the widget's **TS source**: the Next.js examples' bundlers (Next 16 Turbopack / Next 15 webpack) can't resolve the widget's `.js`-suffixed source specifiers, and `zustand`/`vue` fail type-checking the source (`es2023`/`@types/node` gaps). Too invasive + fragile.
- Removing examples from the workspace — explicitly not wanted.

**Chosen approach:** revert the auto-generated example edits right after `changeset version`, via a small `scripts/restore-example-versions.sh`, wired into the `changeset:version` script. Examples stay pinned to the **published** widget — which also keeps the Next.js examples building (they consume the prebuilt package, not source). The version PR simply doesn't touch examples.

**Diff is minimal:** the helper script + one line in `package.json` + a note in `CLAUDE.md`. No example files change.

**Verification:**
- Ran the real `pnpm changeset:version` end-to-end → exits `0`; `@lifi/widget` → `beta.21`, examples stay pinned at `beta.20`, `pnpm install --lockfile-only` succeeds.
- Re-ran the e2e example render suite (build → serve → Playwright) on **all 17 active examples → 17/17 build + render green**, including `nextjs`, `nextjs15`, `zustand-widget-config`, `vue`.

> [!NOTE]
> **Known follow-up (pre-existing, not introduced by this PR):** the examples call `widgetEvents.all.clear()` — the old `mitt` API. `main` has migrated `widgetEvents` to `eventemitter3` (no `.all`). It's valid against the pinned `beta.20`, but will break at runtime whenever the example pins are bumped to a post-migration release. Should be tracked + fixed separately before bumping example pins.

## Visual showcase (Screenshots or Videos)

N/A — release tooling. Render was verified via the e2e Playwright suite: all 17 examples mount the widget (Exchange heading, Settings view, selectable From/To tokens).

## Checklist before requesting a review
- [x] I have performed a self-review and testing of my code.
- [x] This pull request is focused and addresses a single problem.
- [x] If this PR modifies the Widget API or adds new features that require documentation, I have updated the documentation — N/A (no API change; release tooling only).

