### PR TITLE
fix(playground): scope floating drawer styles to right anchor only

### DIFF
--- a/packages/widget-playground/src/providers/PlaygroundThemeProvider/floatingDrawer.ts
+++ b/packages/widget-playground/src/providers/PlaygroundThemeProvider/floatingDrawer.ts
@@ -3,14 +3,17 @@ import type { WidgetTheme } from '@lifi/widget'
 const floatingDrawerStyleOverrides: WidgetTheme['components'] = {
   MuiDrawer: {
     styleOverrides: {
-      paper: ({ theme }) => ({
-        top: theme.spacing(1.5),
-        right: theme.spacing(1.5),
-        height: `calc(100% - ${theme.spacing(3)})`,
-        borderRadius: theme.spacing(4),
-        border: `1px solid ${theme.vars.palette.divider}`,
-        filter: 'drop-shadow(0px 8px 32px rgba(0, 0, 0, 0.08))',
-      }),
+      paper: ({ theme, ownerState }) =>
+        ownerState.anchor === 'right'
+          ? {
+              top: theme.spacing(1.5),
+              right: theme.spacing(1.5),
+              height: `calc(100% - ${theme.spacing(3)})`,
+              borderRadius: theme.spacing(4),
+              border: `1px solid ${theme.vars.palette.divider}`,
+              filter: 'drop-shadow(0px 8px 32px rgba(0, 0, 0, 0.08))',
+            }
+          : {},
     },
   },
 }


### PR DESCRIPTION
## Which Linear task is linked to this PR?  

[EMB-416](https://linear.app/lifi-linear/issue/EMB-416/scope-floating-drawer-styles-to-right-anchor-only)

## Why was it implemented this way?  

The floating drawer `MuiDrawer` style overrides (border-radius, inset spacing, border, shadow) were applying to **all** `<Drawer>` components — including the bottom sheet. This scopes them to only the side drawer by checking `ownerState.anchor === 'right'` in the `paper` style callback, which is MUI's built-in mechanism for conditional styling based on component props.

The scoping is done at the playground level (`floatingDrawer.ts`) rather than in the widget's `createTheme` because consumers should be free to style any drawer anchor however they want — the widget shouldn't make that decision for them.

No changeset needed — `widget-playground` is a private package and is not published to npm.

## Visual showcase (Screenshots or Videos)  

https://github.com/user-attachments/assets/8fc35187-9864-4fa6-af71-a8021079b02f

## Checklist before requesting a review  
- [x] I have performed a self-review and testing of my code.  
- [x] This pull request is focused and addresses a single problem.  