### PR TITLE
fix(playground): bump storage version to clear stale config

### DIFF
--- a/packages/widget-playground/src/store/editTools/createEditToolsStore.ts
+++ b/packages/widget-playground/src/store/editTools/createEditToolsStore.ts
@@ -105,7 +105,8 @@ export const createEditToolsStore = (
       }),
       {
         name: 'li.fi-playground-tools',
-        version: 2,
+        version: 3,
+        migrate: () => ({}),
         partialize: (state) => ({
           drawer: {
             open: state.drawer.open,

--- a/packages/widget-playground/src/store/widgetConfig/createWidgetConfigStore.ts
+++ b/packages/widget-playground/src/store/widgetConfig/createWidgetConfigStore.ts
@@ -267,7 +267,8 @@ export const createWidgetConfigStore = (
       }),
       {
         name: 'li.fi-playground-config',
-        version: 2,
+        version: 3,
+        migrate: () => ({}),
         partialize: (state) => ({
           config: state?.config
             ? getLocalStorageOutput(state.config)


### PR DESCRIPTION
## Which Linear task is linked to this PR?  

[EMB-417](https://linear.app/lifi-linear/issue/EMB-417/bump-playground-storage-version-to-clear-stale-config)

## Why was it implemented this way?  

Several breaking config changes landed on main without bumping the `li.fi-playground-config` storage version — `subvariant` → `mode`, `theme.palette` → `theme.colorSchemes`, added `modeOptions` and `theme.container`. Users with stale localStorage from before these changes see a wrong theme and broken configuration on first load.

Both persisted stores are bumped from v2 → v3 with a clean-slate migration (`migrate: () => ({})`) so existing users get fresh defaults. A field-by-field migration isn't worth the complexity since this is an internal playground, not a published package.

No changeset needed — `widget-playground` is a private package and is not published to npm.

## Visual showcase (Screenshots or Videos)  

_N/A — fixes initial load state; no new UI._

## Checklist before requesting a review  
- [x] I have performed a self-review and testing of my code.  
- [x] This pull request is focused and addresses a single problem.  
- [ ] If this PR modifies the Widget API or adds new features that require documentation, I have updated the documentation in the [public-docs](https://github.com/lifinance/public-docs) repository.