### PR TITLE
fix: downgrade vite-plugin-node-polyfills to 0.26 (EMB-413)

### DIFF
--- a/examples/deposit-flow/package.json
+++ b/examples/deposit-flow/package.json
@@ -28,6 +28,6 @@
     "@vitejs/plugin-react": "^6.0.2",
     "typescript": "^6.0.3",
     "vite": "^8.0.16",
-    "vite-plugin-node-polyfills": "^0.28.0"
+    "vite-plugin-node-polyfills": "^0.26.0"
   }
 }

--- a/examples/nft-checkout/package.json
+++ b/examples/nft-checkout/package.json
@@ -39,7 +39,7 @@
     "source-map-explorer": "^2.5.3",
     "typescript": "^6.0.3",
     "vite": "^8.0.16",
-    "vite-plugin-node-polyfills": "0.28.0",
+    "vite-plugin-node-polyfills": "0.26.0",
     "web-vitals": "^5.3.0"
   },
   "browserslist": {

--- a/examples/nuxt/package.json
+++ b/examples/nuxt/package.json
@@ -13,7 +13,7 @@
     "@lifi/widget": "4.0.0-beta.20",
     "nuxt": "4.4.6",
     "veaury": "^2.6.3",
-    "vite-plugin-node-polyfills": "^0.28.0",
+    "vite-plugin-node-polyfills": "^0.26.0",
     "vue": "^3.5.35",
     "vue-router": "^5.1.0"
   }

--- a/examples/privy-ethers/package.json
+++ b/examples/privy-ethers/package.json
@@ -42,6 +42,6 @@
     "typescript": "~6.0.3",
     "typescript-eslint": "^8.60.0",
     "vite": "^8.0.16",
-    "vite-plugin-node-polyfills": "^0.28.0"
+    "vite-plugin-node-polyfills": "^0.26.0"
   }
 }

--- a/examples/privy/package.json
+++ b/examples/privy/package.json
@@ -39,6 +39,6 @@
     "typescript": "~6.0.3",
     "typescript-eslint": "^8.60.0",
     "vite": "^8.0.16",
-    "vite-plugin-node-polyfills": "^0.28.0"
+    "vite-plugin-node-polyfills": "^0.26.0"
   }
 }

--- a/examples/rainbowkit/package.json
+++ b/examples/rainbowkit/package.json
@@ -26,6 +26,6 @@
     "@vitejs/plugin-react": "^6.0.2",
     "typescript": "^6.0.3",
     "vite": "^8.0.16",
-    "vite-plugin-node-polyfills": "^0.28.0"
+    "vite-plugin-node-polyfills": "^0.26.0"
   }
 }

--- a/examples/svelte/package.json
+++ b/examples/svelte/package.json
@@ -22,7 +22,7 @@
     "tslib": "^2.8.1",
     "typescript": "^6.0.3",
     "vite": "^8.0.16",
-    "vite-plugin-node-polyfills": "^0.28.0"
+    "vite-plugin-node-polyfills": "^0.26.0"
   },
   "dependencies": {
     "@lifi/widget": "4.0.0-beta.20",

--- a/examples/vite-iframe/package.json
+++ b/examples/vite-iframe/package.json
@@ -39,6 +39,6 @@
     "@vitejs/plugin-react": "^6.0.2",
     "typescript": "^6.0.3",
     "vite": "^8.0.16",
-    "vite-plugin-node-polyfills": "^0.28.0"
+    "vite-plugin-node-polyfills": "^0.26.0"
   }
 }

--- a/examples/vite/package.json
+++ b/examples/vite/package.json
@@ -31,6 +31,6 @@
     "@vitejs/plugin-react": "^6.0.2",
     "typescript": "^6.0.3",
     "vite": "^8.0.16",
-    "vite-plugin-node-polyfills": "^0.28.0"
+    "vite-plugin-node-polyfills": "^0.26.0"
   }
 }

--- a/examples/vue/package.json
+++ b/examples/vue/package.json
@@ -21,7 +21,7 @@
     "@vitejs/plugin-vue-jsx": "^5.1.5",
     "typescript": "^6.0.3",
     "vite": "^8.0.16",
-    "vite-plugin-node-polyfills": "^0.28.0",
+    "vite-plugin-node-polyfills": "^0.26.0",
     "vue-tsc": "^3.3.3"
   }
 }

--- a/examples/zustand-widget-config/package.json
+++ b/examples/zustand-widget-config/package.json
@@ -24,6 +24,6 @@
     "globals": "^17.6.0",
     "typescript": "^6.0.3",
     "vite": "^8.0.16",
-    "vite-plugin-node-polyfills": "^0.28.0"
+    "vite-plugin-node-polyfills": "^0.26.0"
   }
 }

--- a/packages/widget-embedded/package.json
+++ b/packages/widget-embedded/package.json
@@ -40,7 +40,7 @@
     "@vitejs/plugin-react": "^6.0.2",
     "typescript": "^6.0.3",
     "vite": "^8.0.16",
-    "vite-plugin-node-polyfills": "^0.28.0",
+    "vite-plugin-node-polyfills": "^0.26.0",
     "web-vitals": "^5.3.0"
   },
   "private": true

--- a/packages/widget-playground-vite/package.json
+++ b/packages/widget-playground-vite/package.json
@@ -27,7 +27,7 @@
     "source-map-explorer": "^2.5.3",
     "typescript": "^6.0.3",
     "vite": "^8.0.16",
-    "vite-plugin-node-polyfills": "0.28.0",
+    "vite-plugin-node-polyfills": "0.26.0",
     "web-vitals": "^5.3.0"
   },
   "browserslist": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -217,8 +217,8 @@ importers:
         specifier: ^8.0.16
         version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)
       vite-plugin-node-polyfills:
-        specifier: ^0.28.0
-        version: 0.28.0(rollup@4.60.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
+        specifier: ^0.26.0
+        version: 0.26.0(rollup@4.60.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
 
   examples/dynamic:
     dependencies:
@@ -473,8 +473,8 @@ importers:
         specifier: ^8.0.16
         version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)
       vite-plugin-node-polyfills:
-        specifier: 0.28.0
-        version: 0.28.0(rollup@4.60.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
+        specifier: 0.26.0
+        version: 0.26.0(rollup@4.60.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
       web-vitals:
         specifier: ^5.3.0
         version: 5.3.0
@@ -491,8 +491,8 @@ importers:
         specifier: ^2.6.3
         version: 2.6.3(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       vite-plugin-node-polyfills:
-        specifier: ^0.28.0
-        version: 0.28.0(rollup@4.60.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
+        specifier: ^0.26.0
+        version: 0.26.0(rollup@4.60.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
       vue:
         specifier: ^3.5.35
         version: 3.5.35(typescript@6.0.3)
@@ -585,8 +585,8 @@ importers:
         specifier: ^8.0.16
         version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)
       vite-plugin-node-polyfills:
-        specifier: ^0.28.0
-        version: 0.28.0(rollup@4.60.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
+        specifier: ^0.26.0
+        version: 0.26.0(rollup@4.60.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
 
   examples/privy-ethers:
     dependencies:
@@ -682,8 +682,8 @@ importers:
         specifier: ^8.0.16
         version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)
       vite-plugin-node-polyfills:
-        specifier: ^0.28.0
-        version: 0.28.0(rollup@4.60.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
+        specifier: ^0.26.0
+        version: 0.26.0(rollup@4.60.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
 
   examples/rainbowkit:
     dependencies:
@@ -734,8 +734,8 @@ importers:
         specifier: ^8.0.16
         version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)
       vite-plugin-node-polyfills:
-        specifier: ^0.28.0
-        version: 0.28.0(rollup@4.60.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
+        specifier: ^0.26.0
+        version: 0.26.0(rollup@4.60.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
 
   examples/react-router-7:
     dependencies:
@@ -975,8 +975,8 @@ importers:
         specifier: ^8.0.16
         version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)
       vite-plugin-node-polyfills:
-        specifier: ^0.28.0
-        version: 0.28.0(rollup@4.60.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
+        specifier: ^0.26.0
+        version: 0.26.0(rollup@4.60.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
 
   examples/tanstack-router:
     dependencies:
@@ -1076,8 +1076,8 @@ importers:
         specifier: ^8.0.16
         version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)
       vite-plugin-node-polyfills:
-        specifier: ^0.28.0
-        version: 0.28.0(rollup@4.60.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
+        specifier: ^0.26.0
+        version: 0.26.0(rollup@4.60.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
 
   examples/vite-iframe:
     dependencies:
@@ -1161,8 +1161,8 @@ importers:
         specifier: ^8.0.16
         version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)
       vite-plugin-node-polyfills:
-        specifier: ^0.28.0
-        version: 0.28.0(rollup@4.60.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
+        specifier: ^0.26.0
+        version: 0.26.0(rollup@4.60.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
 
   examples/vite-iframe-wagmi:
     dependencies:
@@ -1235,8 +1235,8 @@ importers:
         specifier: ^8.0.16
         version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)
       vite-plugin-node-polyfills:
-        specifier: ^0.28.0
-        version: 0.28.0(rollup@4.60.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
+        specifier: ^0.26.0
+        version: 0.26.0(rollup@4.60.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
       vue-tsc:
         specifier: ^3.3.3
         version: 3.3.3(typescript@6.0.3)
@@ -1284,8 +1284,8 @@ importers:
         specifier: ^8.0.16
         version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)
       vite-plugin-node-polyfills:
-        specifier: ^0.28.0
-        version: 0.28.0(rollup@4.60.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
+        specifier: ^0.26.0
+        version: 0.26.0(rollup@4.60.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
 
   packages/wallet-management:
     dependencies:
@@ -1506,8 +1506,8 @@ importers:
         specifier: ^8.0.16
         version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)
       vite-plugin-node-polyfills:
-        specifier: ^0.28.0
-        version: 0.28.0(rollup@4.60.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
+        specifier: ^0.26.0
+        version: 0.26.0(rollup@4.60.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
       web-vitals:
         specifier: ^5.3.0
         version: 5.3.0
@@ -1774,8 +1774,8 @@ importers:
         specifier: ^8.0.16
         version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)
       vite-plugin-node-polyfills:
-        specifier: 0.28.0
-        version: 0.28.0(rollup@4.60.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
+        specifier: 0.26.0
+        version: 0.26.0(rollup@4.60.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
       web-vitals:
         specifier: ^5.3.0
         version: 5.3.0
@@ -12584,8 +12584,8 @@ packages:
       rolldown:
         optional: true
 
-  oxlint-plugin-react-doctor@0.2.15:
-    resolution: {integrity: sha512-Q4q6zcpTXU5tky2/NS1qjk5qNIiUshrCl1ycnqpiRZu0gjOyVkuoF3Z9eoHmtVHixP55hdYUn15JR7b6S0hc8A==}
+  oxlint-plugin-react-doctor@0.2.16:
+    resolution: {integrity: sha512-Ul1UxcYfjBnt+HjgNaMnkvMJjyewS6rkSZl3LiD1g/QqSll1jiynYH/ZoNpUaGHp1pDQ/xLvCcXNQvqopN0tHA==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
   oxlint@1.67.0:
@@ -13396,8 +13396,8 @@ packages:
   react-devtools-core@6.1.5:
     resolution: {integrity: sha512-ePrwPfxAnB+7hgnEr8vpKxL9cmnp7F322t8oqcPshbIQQhDKgFDW4tjhF2wjVbdXF9O/nyuy3sQWd9JGpiLPvA==}
 
-  react-doctor@0.2.15:
-    resolution: {integrity: sha512-WM2rfCnUqm13NULZj3HgfKAG+Zs6UMCyeWq+P+4NF4hIfvN4DBoFfHc+jz4l5gHEqdh2AO2lzD0pNP8PYDT9wg==}
+  react-doctor@0.2.16:
+    resolution: {integrity: sha512-o108QscqM/TlC1QmKgDORf/P53PeZ69nZbRsvy53rXkKvWdKZC1Y0u1JRPmThbTh6v+QpMispBwEnFHhlpZQ7w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -15229,8 +15229,8 @@ packages:
     peerDependencies:
       vite: '>=3'
 
-  vite-plugin-node-polyfills@0.28.0:
-    resolution: {integrity: sha512-NXct/ci2ef4fRyCfTb8fk2HmR80Rv7icLd+cRH41TnUugDzdKMFKqFPpZYCFUInZMMem9bkLv5pkq02+7Xu7+w==}
+  vite-plugin-node-polyfills@0.26.0:
+    resolution: {integrity: sha512-BAe5YzJf368XGev02hDvioidx4uVH8dqEJlG73bjQSxM26/AQnGcKFomq9n3vGq5yqpSHKN4h1XQNxx9l98mBg==}
     peerDependencies:
       vite: ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
@@ -30825,7 +30825,7 @@ snapshots:
       oxc-parser: 0.131.0
       rolldown: 1.0.3
 
-  oxlint-plugin-react-doctor@0.2.15:
+  oxlint-plugin-react-doctor@0.2.16:
     dependencies:
       '@typescript-eslint/types': 8.60.0
       eslint-scope: 9.1.2
@@ -31659,7 +31659,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  react-doctor@0.2.15(bufferutil@4.1.0)(eslint@10.4.1(jiti@2.7.0))(utf-8-validate@6.0.6):
+  react-doctor@0.2.16(bufferutil@4.1.0)(eslint@10.4.1(jiti@2.7.0))(utf-8-validate@6.0.6):
     dependencies:
       '@babel/code-frame': 7.29.7
       '@effect/platform-node-shared': 4.0.0-beta.70(bufferutil@4.1.0)(effect@4.0.0-beta.70)(utf-8-validate@6.0.6)
@@ -31673,7 +31673,7 @@ snapshots:
       jiti: 2.7.0
       magicast: 0.5.3
       oxlint: 1.67.0
-      oxlint-plugin-react-doctor: 0.2.15
+      oxlint-plugin-react-doctor: 0.2.16
       prompts: 2.4.2
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -31853,7 +31853,7 @@ snapshots:
       preact: 10.29.2
       prompts: 2.4.2
       react: 19.2.6
-      react-doctor: 0.2.15(bufferutil@4.1.0)(eslint@10.4.1(jiti@2.7.0))(utf-8-validate@6.0.6)
+      react-doctor: 0.2.16(bufferutil@4.1.0)(eslint@10.4.1(jiti@2.7.0))(utf-8-validate@6.0.6)
       react-dom: 19.2.6(react@19.2.6)
       react-grab: 0.1.44(react@19.2.6)
     optionalDependencies:
@@ -33641,7 +33641,7 @@ snapshots:
       undici: 8.2.0
       vite: 8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)
 
-  vite-plugin-node-polyfills@0.28.0(rollup@4.60.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)):
+  vite-plugin-node-polyfills@0.26.0(rollup@4.60.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)):
     dependencies:
       '@rollup/plugin-inject': 5.0.5(rollup@4.60.3)
       node-stdlib-browser: 1.3.1


### PR DESCRIPTION
## Which Linear task is linked to this PR?
https://linear.app/lifi-linear/issue/EMB-413/pnpm-dev-fails-to-resolve-node-polyfill-shims-when-running-the-widget

## Why was it implemented this way?
`vite-plugin-node-polyfills@0.28` (bumped in #757) breaks `pnpm dev`: its dev-serve transform injects bare `vite-plugin-node-polyfills/shims/{buffer,global,process}` imports into every transformed file, and Vite resolves those relative to the importer — so workspace-linked `@lifi/widget` source (e.g. `useRoutes.ts`) can't resolve them, since the plugin only lives in the app's `node_modules`. (`pnpm build` is unaffected — rolldown uses native inject.)

Reverting to `0.26` restores the previous working behavior with the smallest possible change. Verified: `pnpm dev` boots, the widget renders, and `Buffer`/`process`/`global` are present in the browser; a production build shows the singleton-critical packages (`@lifi/sdk`, `@lifi/types`, `wagmi`, `viem`, `react`, TanStack, MUI) remain single-copy. All touched packages are private (apps + examples) → no changeset.

Alternative considered: aliasing the shim specifiers in each Vite config (works, but adds workaround code). Fully removing/confining the plugin is a larger follow-up.

## Checklist before requesting a review
- [x] I have performed a self-review and testing of my code.
- [x] This pull request is focused and addresses a single problem.
- [ ] If this PR modifies the Widget API or adds new features that require documentation, I have updated the documentation in the public-docs repository.
