### PR TITLE
ci: skip husky pre-commit hook on changesets version commit

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -64,6 +64,13 @@ jobs:
           commit: 'chore: version packages'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # The version-bump commit is machine-generated (versions, changelogs,
+          # lockfile) and already linted via `pnpm check:write` inside
+          # `changeset:version`. Skip the husky pre-commit hook here: it runs
+          # `check:types`, which needs build artifacts this job never produces
+          # (no `pnpm build`), so it fails with TS6305. Real correctness is
+          # gated by the Verify job and the version PR's own CI.
+          HUSKY: '0'
 
   release:
     name: Release

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -64,12 +64,6 @@ jobs:
           commit: 'chore: version packages'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # The version-bump commit is machine-generated (versions, changelogs,
-          # lockfile) and already linted via `pnpm check:write` inside
-          # `changeset:version`. Skip the husky pre-commit hook here: it runs
-          # `check:types`, which needs build artifacts this job never produces
-          # (no `pnpm build`), so it fails with TS6305. Real correctness is
-          # gated by the Verify job and the version PR's own CI.
           HUSKY: '0'
 
   release:


### PR DESCRIPTION
Set `HUSKY=0` on the changesets "Create version pull request" step.

The bot's `chore: version packages` commit runs via `commitMode: git-cli`, which fires the husky pre-commit hook → `pnpm check:types`. That job never runs `pnpm build`, so the widget's project-reference type-check fails with `TS6305` (missing `wallet-management/dist/esm/index.d.ts`) and the commit aborts.

The version commit is machine-generated and already linted via `pnpm check:write` inside `changeset:version`; correctness is gated by the Verify job and the version PR's own CI, so the hook is unnecessary here.

Fixes the failing [Changesets job](https://github.com/lifinance/widget/actions/runs/26883519584/job/79289814133).