### PR TITLE
fix: reset viewport background when switching themes

### DIFF
--- a/packages/widget-playground/src/components/ThemeControl/ThemeControl.tsx
+++ b/packages/widget-playground/src/components/ThemeControl/ThemeControl.tsx
@@ -36,12 +36,14 @@ export const ThemeControl = ({
         setAppearance(nextThemeMode)
         setMode(nextThemeMode)
       }
-      const resolvedMode = nextThemeMode ?? themeMode
-      const playgroundColor =
-        themeItem.theme.colorSchemes?.[resolvedMode]?.palette?.playground?.main
-      if (playgroundColor) {
-        setViewportBackgroundColor(playgroundColor, resolvedMode)
-      }
+      setViewportBackgroundColor(
+        themeItem.theme.colorSchemes?.light?.palette?.playground?.main,
+        'light'
+      )
+      setViewportBackgroundColor(
+        themeItem.theme.colorSchemes?.dark?.palette?.playground?.main,
+        'dark'
+      )
     },
     [
       themeMode,

--- a/packages/widget-playground/src/defaultWidgetConfig.ts
+++ b/packages/widget-playground/src/defaultWidgetConfig.ts
@@ -317,6 +317,9 @@ export const defaultWidgetConfig: Partial<WidgetConfig> = {
           secondary: {
             main: '#F7C2FF',
           },
+          playground: {
+            main: '#F5F5F5',
+          },
         },
       },
       dark: {
@@ -326,6 +329,9 @@ export const defaultWidgetConfig: Partial<WidgetConfig> = {
           },
           secondary: {
             main: '#F7C2FF',
+          },
+          playground: {
+            main: '#000000',
           },
         },
       },

--- a/packages/widget-playground/src/defaultWidgetConfig.ts
+++ b/packages/widget-playground/src/defaultWidgetConfig.ts
@@ -6,6 +6,7 @@ import { SolanaProvider } from '@lifi/widget-provider-solana'
 import { SuiProvider } from '@lifi/widget-provider-sui'
 import { TronProvider } from '@lifi/widget-provider-tron'
 import { withFloatingDrawer } from './providers/PlaygroundThemeProvider/floatingDrawer.js'
+import { DEFAULT_VIEWPORT_BACKGROUND } from './utils/themeEdit.js'
 
 export const widgetBaseConfig: WidgetConfig = {
   // fromChain: 137,
@@ -318,7 +319,7 @@ export const defaultWidgetConfig: Partial<WidgetConfig> = {
             main: '#F7C2FF',
           },
           playground: {
-            main: '#F5F5F5',
+            main: DEFAULT_VIEWPORT_BACKGROUND.light,
           },
         },
       },
@@ -331,7 +332,7 @@ export const defaultWidgetConfig: Partial<WidgetConfig> = {
             main: '#F7C2FF',
           },
           playground: {
-            main: '#000000',
+            main: DEFAULT_VIEWPORT_BACKGROUND.dark,
           },
         },
       },


### PR DESCRIPTION
## Which Linear task is linked to this PR?  
[EMB-418](https://linear.app/lifi-linear/issue/EMB-418/fix-viewport-background-not-resetting-when-switching-themes-in)

## Why was it implemented this way?  

When switching from a theme with custom viewport colors (e.g. Jumper) back to the Default theme, the viewport background didn't update because:

1. The Default theme didn't define `playground.main` palette colors, so the theme selection handler had nothing to write to the store — the old Jumper colors stayed persisted.
2. The handler only updated the viewport color for the active color scheme mode (light or dark), leaving the inactive mode stale.

**Fix:**
- Added `playground.main` colors to the Default theme config using `DEFAULT_VIEWPORT_BACKGROUND` constant.
- Updated `ThemeControl` to set viewport colors for both light and dark modes on every theme switch.

## Visual showcase (Screenshots or Videos)  
https://github.com/user-attachments/assets/f7543c41-8242-4833-94ed-036d6632c16a

## Checklist before requesting a review  
- [x] I have performed a self-review and testing of my code.  
- [x] This pull request is focused and addresses a single problem.  
- [ ] If this PR modifies the Widget API or adds new features that require documentation, I have updated the documentation in the [public-docs](https://github.com/lifinance/public-docs) repository.