### PR TITLE
ci(e2e): gate playground dev-mode smoke on PRs (EMB-446)

### DIFF
--- a/.github/workflows/e2e-playground-dev.yml
+++ b/.github/workflows/e2e-playground-dev.yml
@@ -1,0 +1,234 @@
+name: E2E Playground (dev mode)
+
+# Gates the dev-mode path that the preview suite (e2e-playground.yml) cannot catch.
+# The preview suite tests the production build; this one boots the Vite dev server
+# (`pnpm dev`, port 3000), which resolves @lifi/widget from TypeScript source — the
+# exact path EMB-413 broke. No package prebuild: dev mode transpiles source on the fly.
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+    branches: [main]
+    paths:
+      # Playground app and its logic package
+      - 'packages/widget-playground/**'
+      - 'packages/widget-playground-vite/**'
+      # Widget and wallet packages resolved from source by the dev server
+      - 'packages/widget/**'
+      - 'packages/wallet-management/**'
+      - 'packages/widget-provider/**'
+      - 'packages/widget-provider-ethereum/**'
+      - 'packages/widget-provider-solana/**'
+      - 'packages/widget-provider-bitcoin/**'
+      - 'packages/widget-provider-sui/**'
+      - 'packages/widget-provider-tron/**'
+      # Dev smoke test code and config
+      - 'e2e/tests/dev/**'
+      - 'e2e/tests/components/**'
+      - 'e2e/tests/fixtures/**'
+      - 'e2e/tests/helpers.ts'
+      - 'e2e/playwright.dev.config.ts'
+      - 'e2e/package.json'
+      - 'e2e/tsconfig.json'
+      # Workspace-level dependency changes
+      - 'pnpm-workspace.yaml'
+      - 'pnpm-lock.yaml'
+      - 'package.json'
+
+concurrency:
+  group: e2e-playground-dev-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  # ── Boot the playground in dev mode and run the smoke suite ──────────────────
+  dev-smoke:
+    name: Dev smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # Step outcomes for the report job. Job outputs are evaluated even when the job
+    # fails, so the comment reflects what actually happened to each step — a red job
+    # caused by a later step (e.g. artifact upload) can't masquerade as a test failure.
+    outputs:
+      dev_server: ${{ steps.dev-server.outcome }}
+      smoke: ${{ steps.smoke.outcome }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install dependencies
+        uses: ./.github/actions/pnpm-install
+
+      # Start the dev server first so a broken dev build fails the job fast — before the
+      # (slower) Playwright browser install. The backgrounded server survives into the later
+      # steps (same pattern as e2e-playground.yml's preview server).
+      #
+      # No build step: `pnpm dev` runs Vite in development mode and resolves the widget
+      # packages from source. The committed .env supplies public wallet-connect IDs and the
+      # production API URL, so no secrets are needed (do NOT use dev:dev / --mode dev, which
+      # requires a git-ignored VITE_API_KEY).
+      - name: Start dev server
+        id: dev-server
+        run: |
+          pnpm --filter widget-playground-vite dev &
+
+          # Coarse liveness gate only — a 200 on / is just the Vite index.html shell and does
+          # not prove the module graph resolves. The real "dev build healthy" assessment is the
+          # smoke suite rendering the widget (a resolve break fails those assertions).
+          for i in $(seq 1 60); do
+            if curl -sf http://localhost:3000 > /dev/null 2>&1; then
+              echo "Dev server ready after ${i}s"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "::error::Dev server failed to start within 60s"
+          exit 1
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-browsers-${{ runner.os }}-${{ hashFiles('e2e/package.json') }}
+
+      - name: Install Playwright browsers
+        run: pnpm --filter @lifi/widget-e2e exec playwright install chromium --with-deps
+
+      # reuseExistingServer in playwright.dev.config.ts attaches to the server started above.
+      - name: Run dev smoke tests
+        id: smoke
+        run: pnpm --filter @lifi/widget-e2e test:dev
+
+      - name: Upload JSON report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: dev-smoke-report-json
+          path: e2e/dev-smoke-report.json
+          # Absence is expected and handled: an early failure (dev server never started)
+          # produces no report. `ignore` keeps that path quiet — the report job uses the
+          # missing file to post the "dev build broken" comment, and the real root cause is
+          # already surfaced by the Start dev server step. (Not `error`: that would add a
+          # redundant red on a path that has already failed louder upstream.)
+          if-no-files-found: ignore
+          retention-days: 1
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: playwright-report-dev-smoke
+          path: e2e/playwright-report-dev-smoke/
+          if-no-files-found: ignore
+          retention-days: 7
+
+  # ── Report results as a single sticky PR comment ─────────────────────────────
+  # Every run posts/updates the same comment (one header, no conditional posting).
+  # Branches on the dev-smoke job's STEP outcomes (not the job result, which a
+  # failed artifact upload would also redden) to cover all four outcomes:
+  #   - smoke passed              → ✅ with stats
+  #   - smoke ran and failed      → ❌ with stats + failed test list
+  #   - smoke never ran           → ⚠️ setup step failed or job cancelled/timed out
+  #   - dev server never started  → ❌ dev build broken, smoke marked "not run"
+  # The JSON report only supplies stats/failed-test names — never the verdict —
+  # so a missing artifact degrades the detail, not the correctness.
+  # (Dev-build success is never reported on its own — if the server starts, the
+  # smoke suite runs and its result is what gets posted.)
+  report:
+    name: Report results
+    needs: dev-smoke
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      pull-requests: write
+      actions: read # download-artifact (same grant as e2e-playground.yml's report job)
+    steps:
+      - name: Download JSON report
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        # Tolerate a missing report: an early failure (e.g. dev server never started)
+        # produces no JSON. The summary step then falls back to a generic message.
+        continue-on-error: true
+        with:
+          name: dev-smoke-report-json
+
+      - name: Build comment body
+        env:
+          DEV_SERVER: ${{ needs.dev-smoke.outputs.dev_server }}
+          SMOKE: ${{ needs.dev-smoke.outputs.smoke }}
+        run: |
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          stats_line() {
+            jq -r '.stats | "\(.expected) passed · \(.unexpected) failed · \(.skipped) skipped · \((.duration/1000)|floor)s"' dev-smoke-report.json 2>/dev/null || echo "stats unavailable"
+          }
+          if [ "$DEV_SERVER" != "success" ]; then
+            # The dev server never became ready, so the smoke suite did not run: the dev
+            # build is broken before any test can execute. Surface that directly rather
+            # than reporting a generic test failure.
+            {
+              echo "## ❌ E2E Dev Smoke — dev build broken"
+              echo
+              echo "| Check | Result |"
+              echo "| --- | --- |"
+              echo "| Dev server start (\`pnpm dev\`) | ❌ failed |"
+              echo "| Smoke tests | — not run |"
+              echo
+              echo "The Vite dev server never became ready, so the smoke suite did not run. \`pnpm dev\` itself is broken (e.g. an unresolved import) — the dev build fails before any test can execute."
+              echo
+              echo "See the **Start dev server** step in the [run]($RUN_URL)."
+            } > comment.md
+          elif [ "$SMOKE" = "success" ]; then
+            {
+              echo "## ✅ E2E Dev Smoke — passing"
+              echo
+              echo "| Check | Result |"
+              echo "| --- | --- |"
+              echo "| Dev server start (\`pnpm dev\`) | ✅ started |"
+              echo "| Smoke tests | ✅ passed |"
+              echo
+              echo "**$(stats_line)**"
+              echo
+              echo "[View run]($RUN_URL)"
+            } > comment.md
+          elif [ "$SMOKE" != "failure" ]; then
+            # skipped/cancelled (or unset): the dev server started but the smoke step never
+            # produced a verdict — a setup step in between failed (e.g. browser install), or
+            # the job was cancelled/timed out. Only a confirmed step failure may report ❌.
+            {
+              echo "## ⚠️ E2E Dev Smoke — did not run"
+              echo
+              echo "| Check | Result |"
+              echo "| --- | --- |"
+              echo "| Dev server start (\`pnpm dev\`) | ✅ started |"
+              echo "| Smoke tests | — not run or interrupted |"
+              echo
+              echo "The smoke suite produced no verdict: a setup step failed (e.g. browser install), or the job was cancelled/timed out."
+              echo
+              echo "See the failing step in the [run]($RUN_URL)."
+            } > comment.md
+          else
+            FAILED=$(jq -r '[.suites[]? | recurse(.suites[]?) | .specs[]? | select(.ok | not) | .title] | unique | map("- `" + . + "`") | join("\n")' dev-smoke-report.json 2>/dev/null || true)
+            {
+              echo "## ❌ E2E Dev Smoke — failed"
+              echo
+              echo "| Check | Result |"
+              echo "| --- | --- |"
+              echo "| Dev server start (\`pnpm dev\`) | ✅ started |"
+              echo "| Smoke tests | ❌ failed |"
+              echo
+              echo "**$(stats_line)**"
+              echo
+              echo "$FAILED"
+              echo
+              echo "[View run]($RUN_URL) — the full HTML report is attached as the \`playwright-report-dev-smoke\` artifact."
+            } > comment.md
+          fi
+
+      - name: Post sticky comment
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
+        with:
+          header: e2e-dev-smoke-results
+          path: comment.md

--- a/e2e/.gitignore
+++ b/e2e/.gitignore
@@ -2,6 +2,8 @@ node_modules/
 test-results/
 playwright-report/
 playwright-report-examples/
+playwright-report-dev-smoke/
+dev-smoke-report.json
 .auth/
 .env.test
 *.local

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,10 +1,11 @@
 # LI.FI Widget — E2E Tests
 
-Playwright TypeScript E2E tests for the LI.FI Widget. Two independent suites share this directory:
+Playwright TypeScript E2E tests for the LI.FI Widget. Two test suites share this directory — the **Playground** suite (run in two modes) and the **Examples** suite:
 
 | Suite | Config | Targets | CI workflow |
 |---|---|---|---|
-| **Playground** | `playwright.config.ts` | Widget Playground app | `e2e-playground.yml` |
+| **Playground** (preview) | `playwright.config.ts` | Widget Playground — production build (:4173) | `e2e-playground.yml` |
+| **Playground** (dev smoke) | `playwright.dev.config.ts` | Widget Playground — vite dev server (:3000) | `e2e-playground-dev.yml` |
 | **Examples** | `playwright.examples.config.ts` | 17 active example apps | `e2e-examples.yml` |
 
 ---
@@ -38,6 +39,10 @@ pnpm e2e:dev    # smoke subset, dev mode (vite dev server at :3000)
 > No need to start a server or `cd` anywhere — each config's `webServer` builds/serves
 > the playground and tears it down when finished, reusing one already running on the port.
 > See [README.playground.md](./README.playground.md) for lower-level flags and dev/preview details.
+
+Both modes gate PRs: `e2e-playground.yml` runs the full suite against the production build,
+and `e2e-playground-dev.yml` runs the dev-mode smoke subset to guard the source-resolution
+path (the dev server resolves `@lifi/widget` from source — a break the production build can't catch).
 
 ---
 
@@ -92,6 +97,14 @@ e2e/
 | **CI** | Blob per shard (merged after) + list |
 
 On CI, blob reports from each shard are merged into a single HTML report uploaded as a workflow artifact.
+
+The dev-mode smoke run is unsharded, so it skips blobs: in CI it emits a JSON report
+(`dev-smoke-report.json`, parsed with `jq` to build the sticky PR results comment) plus
+an HTML report (`playwright-report-dev-smoke/`, uploaded as an artifact on failure). Every
+run updates a single sticky comment summarising both checks: dev server start and smoke
+tests. If the dev server fails to start, the comment reports the broken dev build with the
+smoke suite marked "not run"; otherwise it reports the smoke result (pass or fail) with
+stats — or a ⚠️ notice if the suite never produced a verdict (setup failure, cancellation).
 
 ### Selector strategy — priority order
 

--- a/e2e/playwright.dev.config.ts
+++ b/e2e/playwright.dev.config.ts
@@ -18,8 +18,21 @@ export default defineConfig({
   testDir: './tests/dev',
   fullyParallel: true,
   forbidOnly: isCI,
-  retries: isCI ? 2 : 0,
-  reporter: [['list']],
+  // A smoke suite should not be flaky: a single CI retry is enough to ride out a transient
+  // hiccup without masking a real, reproducible break.
+  retries: isCI ? 1 : 0,
+  // CI also emits a JSON report (for the failure summary comment) and an HTML report
+  // (uploaded as an artifact on failure) into a dev-smoke-specific folder.
+  reporter: isCI
+    ? [
+        ['list'],
+        ['json', { outputFile: 'dev-smoke-report.json' }],
+        [
+          'html',
+          { outputFolder: 'playwright-report-dev-smoke', open: 'never' },
+        ],
+      ]
+    : [['list'], ['html', { open: 'never' }]],
   use: {
     actionTimeout: 10_000,
     baseURL: 'http://localhost:3000',


### PR DESCRIPTION
## Which Linear task is linked to this PR?

[EMB-446 — Gate playground dev-mode smoke on PRs via a dev-server build-and-smoke job](https://linear.app/lifi-linear/issue/EMB-446/gate-playground-dev-mode-smoke-on-prs-via-a-dev-server-build-and-smoke)

## Why was it implemented this way?

The dev-mode smoke suite already existed (`e2e/tests/dev/smoke.spec.ts`, run via `playwright.dev.config.ts` / `pnpm test:dev`) but **did not run on PRs**. Only the *preview* suite gated (`e2e-playground.yml`, against the production build at `:4173`). So dev-only regressions could still ship — most recently the node-polyfill shim resolve break in **EMB-413**: the playground builds and previews fine, but `pnpm dev` is broken for anyone consuming `@lifi/widget` from source.

This adds a new PR-gating workflow that boots the playground in Vite dev mode, confirms the dev server is live, then runs the existing smoke suite against it.

**What's in the PR**
- **New `.github/workflows/e2e-playground-dev.yml`** — a `dev-smoke` job + a `report` job.
  - Boots `pnpm --filter widget-playground-vite dev` (port 3000) with a curl readiness loop, then runs `pnpm test:dev`. `reuseExistingServer` attaches the suite to the running server.
  - **No package prebuild** — dev mode resolves `@lifi/widget` from TS source. That source-resolution path is exactly what EMB-413 broke and what the preview suite (which builds `dist/` first) cannot catch.
  - The dev server starts **before** the (slower) Playwright browser install, so a fully broken dev build fails the job fast.
  - Mirrors `e2e-playground.yml` conventions: same pinned action SHAs, concurrency group, minimal permissions, `pnpm-install` composite, Playwright browser cache, and the source-package path filter.
- **`e2e/playwright.dev.config.ts`** — adds CI reporters: JSON (`dev-smoke-report.json`) + HTML (`playwright-report-dev-smoke/`, uploaded as a failure artifact).
- **`e2e/README.md`** — documents the new dev-smoke gate in the suite/CI table and reporters section.
- **`e2e/.gitignore`** — ignore the generated reports.

**Single always-updated sticky PR comment** — every run posts/updates one comment (one `marocchino` header), so it always reflects current state and a stale signal can't survive a corrective commit. It branches on the dev-smoke job's **step outcomes** (exposed as job outputs), not the job result — so a later step failure (e.g. artifact upload) can't masquerade as a test failure:
- **smoke passed** → ✅ with the stats line;
- **smoke ran and failed** → ❌ with stats + the failed-test names;
- **smoke never ran** → ⚠️ "did not run" (a setup step failed, or the job was cancelled/timed out);
- **dev server never started** → ❌ "dev build broken" (the resolve break surfaces here; smoke marked *not run*).

Stats/failed-test names are built from `dev-smoke-report.json` with `jq` — they only supply detail, never the verdict (which comes from the step outcomes), so a missing report degrades the detail, not the correctness. (daun was dropped — its always-create-or-update behaviour can't express these distinct states cleanly.)

**Other design decisions & alternatives**
- **New workflow file vs. a job in `e2e-playground.yml`** → chose a separate file for clean separation and an independent required-check name; the dev job has no dependency on the preview build pipeline.
- **Manual server start + readiness loop vs. Playwright's `webServer`** → chose the manual readiness loop to match `e2e-playground.yml` and to give an explicit "server failed to start" failure.
- **Detection** → a 200 on `/` is **not** a health signal (it's just the Vite index.html shell); the real "dev build healthy" assessment is the smoke suite rendering the widget. The readiness loop is only a coarse gate to start the tests.
- **No secrets** — plain `pnpm dev` runs in `development` mode and reads the committed `.env` (public wallet-connect IDs); `dev:dev`/`--mode dev` would need a git-ignored `VITE_API_KEY`, so it's deliberately avoided.
- **No changeset** — only workflow + the private `@lifi/widget-e2e` config change; nothing publishable.

**Follow-ups (not in this PR)**
- Marking **Dev smoke** a *required* check is a GitHub branch-protection setting (not in-repo).
- The acceptance/negative-control (revert the EMB-413 fix → check goes red) is the verification step, tracked on the ticket.

## Visual showcase (Screenshots or Videos)

CI/test-infra change — no UI. Local verification: `pnpm test:dev` → **4 passed** (sidebar, widget mount + Exchange heading, settings, live-API token route). CI-mode run confirmed `dev-smoke-report.json` + `playwright-report-dev-smoke/` are produced, and the `jq` stats/failed-title extraction was validated against real and synthetic reports.

## Checklist before requesting a review
- [x] I have performed a self-review and testing of my code.
- [x] This pull request is focused and addresses a single problem.
- [x] If this PR modifies the Widget API or adds new features that require documentation, I have updated the documentation. _(N/A — no Widget API change; e2e/README.md updated.)_

