### PR TITLE
feat(tron): re-enable WalletConnect adapter

### DIFF
--- a/.changeset/tron-walletconnect-address-guard.md
+++ b/.changeset/tron-walletconnect-address-guard.md
@@ -1,0 +1,9 @@
+---
+'@lifi/widget-provider-ethereum': patch
+'@lifi/widget-provider-tron': patch
+---
+
+Harden Tron WalletConnect against the EVM connector sharing the same project id.
+
+- Force `customStoragePrefix: 'evm'` on the EVM WalletConnect connector. The Tron wrapper drops the prefix it is given, so both cores wrote identical `wc@2:…//session` keys and last-writer-wins clobbered the other ecosystem's session (a connected wallet vanished, refresh re-opened the QR). Isolating the EVM side fixes the collision regardless of the wrapper.
+- Reject non-Tron addresses at the Tron provider boundary. The wrapper returns `accounts[0]` across all session namespaces, so scanning with an EVM wallet surfaced an `eip155` `0x…` address as the Tron account and let it flow into the route request as the Tron sender. Connected Tron accounts whose address isn't a valid base58 `T…` are now ignored, and the offending adapter is disconnected.

--- a/.changeset/tron-walletconnect.md
+++ b/.changeset/tron-walletconnect.md
@@ -5,3 +5,5 @@
 Re-enable WalletConnect for Tron. `createTronAdapters` accepts a `WalletConnectAdapterConfig`, and `TronProviderConfig.walletConnect` controls whether the adapter is registered: `true` uses the shipped defaults (mirroring the EVM provider), a config object is merged over them, `false`/undefined disables it.
 
 The resolver always forces `options.customStoragePrefix` to `'tron'` to isolate the Tron WalletConnect storage from the EVM connector's (same project id, same origin). Without it the EVM `eip155` namespaces bleed into the Tron session proposal and wallets connect as EVM, producing "No accounts found in session".
+
+`createTronAdapters` now takes an optional `WalletConnectAdapterConfig` argument. The change is backwards-compatible — existing callers keep the previous behaviour (WalletConnect adapter not registered).

--- a/.changeset/tron-walletconnect.md
+++ b/.changeset/tron-walletconnect.md
@@ -1,0 +1,7 @@
+---
+'@lifi/widget-provider-tron': minor
+---
+
+Re-enable WalletConnect for Tron. `createTronAdapters` accepts a `WalletConnectAdapterConfig`, and `TronProviderConfig.walletConnect` controls whether the adapter is registered: `true` uses the shipped defaults (mirroring the EVM provider), a config object is merged over them, `false`/undefined disables it.
+
+The resolver always forces `options.customStoragePrefix` to `'tron'` to isolate the Tron WalletConnect storage from the EVM connector's (same project id, same origin). Without it the EVM `eip155` namespaces bleed into the Tron session proposal and wallets connect as EVM, producing "No accounts found in session".

--- a/packages/widget-playground/src/defaultWidgetConfig.ts
+++ b/packages/widget-playground/src/defaultWidgetConfig.ts
@@ -50,7 +50,7 @@ export const widgetBaseConfig: WidgetConfig = {
     TronProvider({
       walletConnect: import.meta.env?.VITE_TVM_WALLET_CONNECT
         ? {
-            network: 'mainnet',
+            network: 'Mainnet',
             options: {
               projectId: import.meta.env.VITE_TVM_WALLET_CONNECT,
             },

--- a/packages/widget-provider-ethereum/src/connectors/walletConnect.ts
+++ b/packages/widget-provider-ethereum/src/connectors/walletConnect.ts
@@ -15,6 +15,8 @@ export const createWalletConnectConnector = /*#__PURE__*/ (
         },
       },
       ...params,
+      // Isolate EVM's WC storage from Tron's (shared project id).
+      customStoragePrefix: 'evm',
     }),
     'walletConnect',
     'WalletConnect'

--- a/packages/widget-provider-tron/package.json
+++ b/packages/widget-provider-tron/package.json
@@ -12,6 +12,7 @@
     "build:prerelease": "node ../../scripts/prerelease.js && cpy '../../README.md' .",
     "build:postrelease": "node ../../scripts/postrelease.js && rm -rf README.md",
     "clean": "rm -rf dist",
+    "test": "vitest run",
     "check:types": "tsc --noEmit",
     "check:circular-deps": "madge --circular $(find ./src -name '*.ts' -o -name '*.tsx')",
     "check:circular-deps-graph": "madge --circular $(find ./src -name '*.ts' -o -name '*.tsx') --image graph.svg"
@@ -50,6 +51,7 @@
     "cpy-cli": "^7.0.0",
     "madge": "^8.0.0",
     "react": "^19.2.7",
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.8"
   }
 }

--- a/packages/widget-provider-tron/src/config/adapters.ts
+++ b/packages/widget-provider-tron/src/config/adapters.ts
@@ -14,9 +14,13 @@ import {
   TomoWalletAdapter,
   TronLinkAdapter,
   TrustAdapter,
+  WalletConnectAdapter,
+  type WalletConnectAdapterConfig,
 } from '@tronweb3/tronwallet-adapters'
 
-export const createTronAdapters = (): Adapter[] => [
+export const createTronAdapters = (
+  walletConnect?: WalletConnectAdapterConfig
+): Adapter[] => [
   new BinanceWalletAdapter(),
   new BitKeepAdapter(),
   new BybitWalletAdapter(),
@@ -31,4 +35,5 @@ export const createTronAdapters = (): Adapter[] => [
   new TomoWalletAdapter(),
   new TronLinkAdapter(),
   new TrustAdapter(),
+  ...(walletConnect ? [new WalletConnectAdapter(walletConnect)] : []),
 ]

--- a/packages/widget-provider-tron/src/config/walletConnect.test.ts
+++ b/packages/widget-provider-tron/src/config/walletConnect.test.ts
@@ -1,0 +1,52 @@
+import type { WalletConnectAdapterConfig } from '@tronweb3/tronwallet-adapters'
+import { describe, expect, it } from 'vitest'
+import { resolveTronWalletConnectConfig } from './walletConnect.js'
+
+const resolve = (config: Partial<WalletConnectAdapterConfig>) =>
+  resolveTronWalletConnectConfig(config as WalletConnectAdapterConfig)!
+
+describe('resolveTronWalletConnectConfig', () => {
+  it('returns undefined when disabled', () => {
+    expect(resolveTronWalletConnectConfig(undefined)).toBeUndefined()
+    expect(resolveTronWalletConnectConfig(false)).toBeUndefined()
+  })
+
+  it('defaults to Mainnet, the shared project id, and the tron storage prefix', () => {
+    expect(resolveTronWalletConnectConfig(true)).toEqual({
+      network: 'Mainnet',
+      options: {
+        projectId: '5432e3507d41270bee46b7b85bbc2ef8',
+        customStoragePrefix: 'tron',
+      },
+    })
+  })
+
+  it.each([
+    ['mainnet', 'Mainnet'],
+    ['MAINNET', 'Mainnet'],
+    ['shasta', 'Shasta'],
+    ['NILE', 'Nile'],
+  ])('snaps %s to canonical casing %s', (input, expected) => {
+    expect(resolve({ network: input }).network).toBe(expected)
+  })
+
+  it('passes chainId-style networks through untouched', () => {
+    expect(resolve({ network: 'tron:0x2b6653dc' }).network).toBe(
+      'tron:0x2b6653dc'
+    )
+    expect(resolve({ network: '0x2b6653dc' }).network).toBe('0x2b6653dc')
+  })
+
+  it('forces the tron storage prefix even when overridden', () => {
+    expect(
+      resolve({ options: { customStoragePrefix: 'evm' } }).options
+        .customStoragePrefix
+    ).toBe('tron')
+  })
+
+  it('lets a caller override the default project id', () => {
+    expect(
+      resolve({ options: { projectId: 'my-project-id' } }).options.projectId
+    ).toBe('my-project-id')
+  })
+})

--- a/packages/widget-provider-tron/src/config/walletConnect.ts
+++ b/packages/widget-provider-tron/src/config/walletConnect.ts
@@ -10,17 +10,17 @@ export const resolveTronWalletConnectConfig = (
     return undefined
   }
   const config = walletConnect === true ? undefined : walletConnect
+  const network = config?.network ?? 'Mainnet'
   return {
     ...config,
-    // Must be capitalized; lowercase yields an invalid `tron:<name>` id upstream.
-    network: config?.network ?? 'Mainnet',
+    // Lowercase yields an invalid `tron:<name>` CAIP id upstream.
+    network: `${network.charAt(0).toUpperCase()}${network.slice(1)}`,
     options: {
       projectId: defaultProjectId,
-      // Isolate Tron WC storage from the EVM connector's (shared project id +
-      // origin); otherwise its eip155 namespaces leak into the Tron proposal
-      // and wallets connect as EVM ("No accounts found in session").
-      customStoragePrefix: 'tron',
       ...config?.options,
+      // Forced last: a distinct prefix keeps the EVM connector's eip155
+      // namespaces (shared project id) out of the Tron session proposal.
+      customStoragePrefix: 'tron',
     },
   }
 }

--- a/packages/widget-provider-tron/src/config/walletConnect.ts
+++ b/packages/widget-provider-tron/src/config/walletConnect.ts
@@ -1,0 +1,26 @@
+import type { WalletConnectAdapterConfig } from '@tronweb3/tronwallet-adapters'
+
+// Same project id as the EVM provider — lets `walletConnect: true` work with no setup.
+const defaultProjectId = '5432e3507d41270bee46b7b85bbc2ef8'
+
+export const resolveTronWalletConnectConfig = (
+  walletConnect: WalletConnectAdapterConfig | boolean | undefined
+): WalletConnectAdapterConfig | undefined => {
+  if (!walletConnect) {
+    return undefined
+  }
+  const config = walletConnect === true ? undefined : walletConnect
+  return {
+    ...config,
+    // Must be capitalized; lowercase yields an invalid `tron:<name>` id upstream.
+    network: config?.network ?? 'Mainnet',
+    options: {
+      projectId: defaultProjectId,
+      // Isolate Tron WC storage from the EVM connector's (shared project id +
+      // origin); otherwise its eip155 namespaces leak into the Tron proposal
+      // and wallets connect as EVM ("No accounts found in session").
+      customStoragePrefix: 'tron',
+      ...config?.options,
+    },
+  }
+}

--- a/packages/widget-provider-tron/src/config/walletConnect.ts
+++ b/packages/widget-provider-tron/src/config/walletConnect.ts
@@ -1,7 +1,16 @@
+import { ChainNetwork } from '@tronweb3/tronwallet-abstract-adapter'
 import type { WalletConnectAdapterConfig } from '@tronweb3/tronwallet-adapters'
 
-// Same project id as the EVM provider — lets `walletConnect: true` work with no setup.
+// Shared with the EVM provider so `walletConnect: true` works with no setup.
 const defaultProjectId = '5432e3507d41270bee46b7b85bbc2ef8'
+
+// Upstream matches network names case-sensitively; snap to canonical casing, pass chainIds through.
+const normalizeNetwork = (
+  network: WalletConnectAdapterConfig['network']
+): WalletConnectAdapterConfig['network'] =>
+  Object.values(ChainNetwork).find(
+    (name) => name.toLowerCase() === network.toLowerCase()
+  ) ?? network
 
 export const resolveTronWalletConnectConfig = (
   walletConnect: WalletConnectAdapterConfig | boolean | undefined
@@ -10,16 +19,13 @@ export const resolveTronWalletConnectConfig = (
     return undefined
   }
   const config = walletConnect === true ? undefined : walletConnect
-  const network = config?.network ?? 'Mainnet'
   return {
     ...config,
-    // Lowercase yields an invalid `tron:<name>` CAIP id upstream.
-    network: `${network.charAt(0).toUpperCase()}${network.slice(1)}`,
+    network: normalizeNetwork(config?.network ?? ChainNetwork.Mainnet),
     options: {
       projectId: defaultProjectId,
       ...config?.options,
-      // Forced last: a distinct prefix keeps the EVM connector's eip155
-      // namespaces (shared project id) out of the Tron session proposal.
+      // Forced last: isolates Tron's WC session from the EVM connector's (shared project id).
       customStoragePrefix: 'tron',
     },
   }

--- a/packages/widget-provider-tron/src/providers/TronBaseProvider.tsx
+++ b/packages/widget-provider-tron/src/providers/TronBaseProvider.tsx
@@ -2,6 +2,7 @@ import type { Adapter } from '@tronweb3/tronwallet-abstract-adapter'
 import { WalletProvider } from '@tronweb3/tronwallet-adapter-react-hooks'
 import { type FC, type PropsWithChildren, useRef } from 'react'
 import { createTronAdapters } from '../config/adapters.js'
+import { resolveTronWalletConnectConfig } from '../config/walletConnect.js'
 import type { TronProviderConfig } from '../types.js'
 
 interface TronBaseProviderProps {
@@ -9,17 +10,15 @@ interface TronBaseProviderProps {
 }
 
 export const TronBaseProvider: FC<PropsWithChildren<TronBaseProviderProps>> = ({
-  config: _config,
+  config,
   children,
 }) => {
   const adapters = useRef<Adapter[]>(null)
 
   if (!adapters.current) {
-    // TODO: Re-enable WalletConnect once @tronweb3/tronwallet-adapters fixes
-    // the "No accounts found in session" error. The upstream adapter (v1.2.24)
-    // uses requiredNamespaces which WalletConnect v2 demotes to optional,
-    // causing sessions to complete with zero Tron accounts.
-    adapters.current = createTronAdapters()
+    adapters.current = createTronAdapters(
+      resolveTronWalletConnectConfig(config?.walletConnect)
+    )
   }
 
   return <WalletProvider adapters={adapters.current}>{children}</WalletProvider>

--- a/packages/widget-provider-tron/src/providers/TronProviderValues.tsx
+++ b/packages/widget-provider-tron/src/providers/TronProviderValues.tsx
@@ -10,6 +10,7 @@ import {
   type FC,
   type PropsWithChildren,
   useCallback,
+  useEffect,
   useMemo,
   useRef,
 } from 'react'
@@ -44,33 +45,6 @@ export const TronProviderValues: FC<
     [currentWallet]
   )
 
-  const account = useMemo(
-    () =>
-      address
-        ? {
-            address: address,
-            chainId: ChainId.TRN,
-            chainType: ChainType.TVM,
-            connector,
-            isConnected,
-            isConnecting: connecting,
-            isReconnecting: false,
-            isDisconnected: false,
-            status: 'connected' as const,
-          }
-        : {
-            chainType: ChainType.TVM,
-            isConnected: false,
-            isConnecting: connecting,
-            isReconnecting: false,
-            isDisconnected: true,
-            status: connecting
-              ? ('connecting' as const)
-              : ('disconnected' as const),
-          },
-    [address, connector, isConnected, connecting]
-  )
-
   const walletRef = useRef(currentWallet)
   walletRef.current = currentWallet
 
@@ -92,6 +66,43 @@ export const TronProviderValues: FC<
       }) as SDKProvider)
     )
   }, [config?.sdkProvider])
+
+  // The WC wrapper can surface a foreign-namespace address (e.g. eip155 `0x…`).
+  const tronAddress =
+    address && sdkProvider.isAddress(address) ? address : undefined
+
+  useEffect(() => {
+    if (isConnected && address && !tronAddress) {
+      disconnect()
+    }
+  }, [isConnected, address, tronAddress, disconnect])
+
+  const account = useMemo(
+    () =>
+      tronAddress
+        ? {
+            address: tronAddress,
+            chainId: ChainId.TRN,
+            chainType: ChainType.TVM,
+            connector,
+            isConnected,
+            isConnecting: connecting,
+            isReconnecting: false,
+            isDisconnected: false,
+            status: 'connected' as const,
+          }
+        : {
+            chainType: ChainType.TVM,
+            isConnected: false,
+            isConnecting: connecting,
+            isReconnecting: false,
+            isDisconnected: true,
+            status: connecting
+              ? ('connecting' as const)
+              : ('disconnected' as const),
+          },
+    [tronAddress, connector, isConnected, connecting]
+  )
 
   const installedWallets = useMemo(
     () =>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1974,6 +1974,9 @@ importers:
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
 
 packages:
 
@@ -9855,8 +9858,8 @@ packages:
   des.js@1.1.0:
     resolution: {integrity: sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg==}
 
-  deslop-js@0.0.21:
-    resolution: {integrity: sha512-1fYusMl4tDaQ/xdHFtLfDe8kFrEeU0Vu0Pfiy2k/Gd4HSqYlQj1Z7iRqldNneRyuCzNMhwNBvhaL07Urbh5VOA==}
+  deslop-js@0.0.14:
+    resolution: {integrity: sha512-FY0rNK+mdTozXwNmcJAt5tD9hVOkXEX5ac+Mg77KJvnnsoAh3qIUW64PMnofutjeYz7g1vENMbOcrBmD1v4FlA==}
 
   destr@2.0.5:
     resolution: {integrity: sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==}
@@ -12648,8 +12651,8 @@ packages:
       rolldown:
         optional: true
 
-  oxlint-plugin-react-doctor@0.5.1:
-    resolution: {integrity: sha512-gGx0NCPA7s8z8UYCulfhX4CiXwBI4QdQve7zaVXglakWzzdgcXMZv6pedmbKUtefegzlfzkKDcYO4lOg8vqnJw==}
+  oxlint-plugin-react-doctor@0.2.16:
+    resolution: {integrity: sha512-Ul1UxcYfjBnt+HjgNaMnkvMJjyewS6rkSZl3LiD1g/QqSll1jiynYH/ZoNpUaGHp1pDQ/xLvCcXNQvqopN0tHA==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
   oxlint@1.68.0:
@@ -13456,8 +13459,8 @@ packages:
   react-devtools-core@6.1.5:
     resolution: {integrity: sha512-ePrwPfxAnB+7hgnEr8vpKxL9cmnp7F322t8oqcPshbIQQhDKgFDW4tjhF2wjVbdXF9O/nyuy3sQWd9JGpiLPvA==}
 
-  react-doctor@0.5.1:
-    resolution: {integrity: sha512-2LSJ/iYtUugr9xj01XTyU2tRtfjmGjiwyDotrnxL0raP+q4Uhp10VaiY7BqfDhBpj4HtCsC+//G1xVupTTBDoA==}
+  react-doctor@0.2.16:
+    resolution: {integrity: sha512-o108QscqM/TlC1QmKgDORf/P53PeZ69nZbRsvy53rXkKvWdKZC1Y0u1JRPmThbTh6v+QpMispBwEnFHhlpZQ7w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -15477,23 +15480,6 @@ packages:
   void-elements@3.1.0:
     resolution: {integrity: sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==}
     engines: {node: '>=0.10.0'}
-
-  vscode-jsonrpc@8.2.0:
-    resolution: {integrity: sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==}
-    engines: {node: '>=14.0.0'}
-
-  vscode-languageserver-protocol@3.17.5:
-    resolution: {integrity: sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==}
-
-  vscode-languageserver-textdocument@1.0.12:
-    resolution: {integrity: sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==}
-
-  vscode-languageserver-types@3.17.5:
-    resolution: {integrity: sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==}
-
-  vscode-languageserver@9.0.1:
-    resolution: {integrity: sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==}
-    hasBin: true
 
   vscode-uri@3.1.0:
     resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
@@ -27317,7 +27303,7 @@ snapshots:
       inherits: 2.0.4
       minimalistic-assert: 1.0.1
 
-  deslop-js@0.0.21:
+  deslop-js@0.0.14:
     dependencies:
       '@oxc-project/types': 0.132.0
       fast-glob: 3.3.3
@@ -31017,7 +31003,7 @@ snapshots:
       oxc-parser: 0.131.0
       rolldown: 1.0.3
 
-  oxlint-plugin-react-doctor@0.5.1:
+  oxlint-plugin-react-doctor@0.2.16:
     dependencies:
       '@typescript-eslint/types': 8.60.1
       eslint-scope: 9.1.2
@@ -31847,7 +31833,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  react-doctor@0.5.1(bufferutil@4.1.0)(eslint@10.4.1(jiti@2.7.0))(utf-8-validate@6.0.6):
+  react-doctor@0.2.16(bufferutil@4.1.0)(eslint@10.4.1(jiti@2.7.0))(utf-8-validate@6.0.6):
     dependencies:
       '@babel/code-frame': 7.29.7
       '@effect/platform-node-shared': 4.0.0-beta.70(bufferutil@4.1.0)(effect@4.0.0-beta.70)(utf-8-validate@6.0.6)
@@ -31855,18 +31841,15 @@ snapshots:
       agent-install: 0.0.5
       conf: 15.1.0
       confbox: 0.2.4
-      deslop-js: 0.0.21
+      deslop-js: 0.0.14
       effect: 4.0.0-beta.70
       eslint-plugin-react-hooks: 7.1.1(eslint@10.4.1(jiti@2.7.0))
       jiti: 2.7.0
       magicast: 0.5.3
       oxlint: 1.68.0
-      oxlint-plugin-react-doctor: 0.5.1
+      oxlint-plugin-react-doctor: 0.2.16
       prompts: 2.4.2
       typescript: 6.0.3
-      vscode-languageserver: 9.0.1
-      vscode-languageserver-textdocument: 1.0.12
-      vscode-uri: 3.1.0
     transitivePeerDependencies:
       - '@opentelemetry/exporter-trace-otlp-http'
       - bufferutil
@@ -32044,7 +32027,7 @@ snapshots:
       preact: 10.29.2
       prompts: 2.4.2
       react: 19.2.7
-      react-doctor: 0.5.1(bufferutil@4.1.0)(eslint@10.4.1(jiti@2.7.0))(utf-8-validate@6.0.6)
+      react-doctor: 0.2.16(bufferutil@4.1.0)(eslint@10.4.1(jiti@2.7.0))(utf-8-validate@6.0.6)
       react-dom: 19.2.7(react@19.2.7)
       react-grab: 0.1.44(react@19.2.7)
     optionalDependencies:
@@ -33965,21 +33948,6 @@ snapshots:
   vm-browserify@1.1.2: {}
 
   void-elements@3.1.0: {}
-
-  vscode-jsonrpc@8.2.0: {}
-
-  vscode-languageserver-protocol@3.17.5:
-    dependencies:
-      vscode-jsonrpc: 8.2.0
-      vscode-languageserver-types: 3.17.5
-
-  vscode-languageserver-textdocument@1.0.12: {}
-
-  vscode-languageserver-types@3.17.5: {}
-
-  vscode-languageserver@9.0.1:
-    dependencies:
-      vscode-languageserver-protocol: 3.17.5
 
   vscode-uri@3.1.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9855,8 +9855,8 @@ packages:
   des.js@1.1.0:
     resolution: {integrity: sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg==}
 
-  deslop-js@0.0.14:
-    resolution: {integrity: sha512-FY0rNK+mdTozXwNmcJAt5tD9hVOkXEX5ac+Mg77KJvnnsoAh3qIUW64PMnofutjeYz7g1vENMbOcrBmD1v4FlA==}
+  deslop-js@0.0.21:
+    resolution: {integrity: sha512-1fYusMl4tDaQ/xdHFtLfDe8kFrEeU0Vu0Pfiy2k/Gd4HSqYlQj1Z7iRqldNneRyuCzNMhwNBvhaL07Urbh5VOA==}
 
   destr@2.0.5:
     resolution: {integrity: sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==}
@@ -12648,8 +12648,8 @@ packages:
       rolldown:
         optional: true
 
-  oxlint-plugin-react-doctor@0.2.16:
-    resolution: {integrity: sha512-Ul1UxcYfjBnt+HjgNaMnkvMJjyewS6rkSZl3LiD1g/QqSll1jiynYH/ZoNpUaGHp1pDQ/xLvCcXNQvqopN0tHA==}
+  oxlint-plugin-react-doctor@0.5.1:
+    resolution: {integrity: sha512-gGx0NCPA7s8z8UYCulfhX4CiXwBI4QdQve7zaVXglakWzzdgcXMZv6pedmbKUtefegzlfzkKDcYO4lOg8vqnJw==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
   oxlint@1.68.0:
@@ -13456,8 +13456,8 @@ packages:
   react-devtools-core@6.1.5:
     resolution: {integrity: sha512-ePrwPfxAnB+7hgnEr8vpKxL9cmnp7F322t8oqcPshbIQQhDKgFDW4tjhF2wjVbdXF9O/nyuy3sQWd9JGpiLPvA==}
 
-  react-doctor@0.2.16:
-    resolution: {integrity: sha512-o108QscqM/TlC1QmKgDORf/P53PeZ69nZbRsvy53rXkKvWdKZC1Y0u1JRPmThbTh6v+QpMispBwEnFHhlpZQ7w==}
+  react-doctor@0.5.1:
+    resolution: {integrity: sha512-2LSJ/iYtUugr9xj01XTyU2tRtfjmGjiwyDotrnxL0raP+q4Uhp10VaiY7BqfDhBpj4HtCsC+//G1xVupTTBDoA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -15477,6 +15477,23 @@ packages:
   void-elements@3.1.0:
     resolution: {integrity: sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==}
     engines: {node: '>=0.10.0'}
+
+  vscode-jsonrpc@8.2.0:
+    resolution: {integrity: sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==}
+    engines: {node: '>=14.0.0'}
+
+  vscode-languageserver-protocol@3.17.5:
+    resolution: {integrity: sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==}
+
+  vscode-languageserver-textdocument@1.0.12:
+    resolution: {integrity: sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==}
+
+  vscode-languageserver-types@3.17.5:
+    resolution: {integrity: sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==}
+
+  vscode-languageserver@9.0.1:
+    resolution: {integrity: sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==}
+    hasBin: true
 
   vscode-uri@3.1.0:
     resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
@@ -27300,7 +27317,7 @@ snapshots:
       inherits: 2.0.4
       minimalistic-assert: 1.0.1
 
-  deslop-js@0.0.14:
+  deslop-js@0.0.21:
     dependencies:
       '@oxc-project/types': 0.132.0
       fast-glob: 3.3.3
@@ -31000,7 +31017,7 @@ snapshots:
       oxc-parser: 0.131.0
       rolldown: 1.0.3
 
-  oxlint-plugin-react-doctor@0.2.16:
+  oxlint-plugin-react-doctor@0.5.1:
     dependencies:
       '@typescript-eslint/types': 8.60.1
       eslint-scope: 9.1.2
@@ -31830,7 +31847,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  react-doctor@0.2.16(bufferutil@4.1.0)(eslint@10.4.1(jiti@2.7.0))(utf-8-validate@6.0.6):
+  react-doctor@0.5.1(bufferutil@4.1.0)(eslint@10.4.1(jiti@2.7.0))(utf-8-validate@6.0.6):
     dependencies:
       '@babel/code-frame': 7.29.7
       '@effect/platform-node-shared': 4.0.0-beta.70(bufferutil@4.1.0)(effect@4.0.0-beta.70)(utf-8-validate@6.0.6)
@@ -31838,15 +31855,18 @@ snapshots:
       agent-install: 0.0.5
       conf: 15.1.0
       confbox: 0.2.4
-      deslop-js: 0.0.14
+      deslop-js: 0.0.21
       effect: 4.0.0-beta.70
       eslint-plugin-react-hooks: 7.1.1(eslint@10.4.1(jiti@2.7.0))
       jiti: 2.7.0
       magicast: 0.5.3
       oxlint: 1.68.0
-      oxlint-plugin-react-doctor: 0.2.16
+      oxlint-plugin-react-doctor: 0.5.1
       prompts: 2.4.2
       typescript: 6.0.3
+      vscode-languageserver: 9.0.1
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-uri: 3.1.0
     transitivePeerDependencies:
       - '@opentelemetry/exporter-trace-otlp-http'
       - bufferutil
@@ -32024,7 +32044,7 @@ snapshots:
       preact: 10.29.2
       prompts: 2.4.2
       react: 19.2.7
-      react-doctor: 0.2.16(bufferutil@4.1.0)(eslint@10.4.1(jiti@2.7.0))(utf-8-validate@6.0.6)
+      react-doctor: 0.5.1(bufferutil@4.1.0)(eslint@10.4.1(jiti@2.7.0))(utf-8-validate@6.0.6)
       react-dom: 19.2.7(react@19.2.7)
       react-grab: 0.1.44(react@19.2.7)
     optionalDependencies:
@@ -33945,6 +33965,21 @@ snapshots:
   vm-browserify@1.1.2: {}
 
   void-elements@3.1.0: {}
+
+  vscode-jsonrpc@8.2.0: {}
+
+  vscode-languageserver-protocol@3.17.5:
+    dependencies:
+      vscode-jsonrpc: 8.2.0
+      vscode-languageserver-types: 3.17.5
+
+  vscode-languageserver-textdocument@1.0.12: {}
+
+  vscode-languageserver-types@3.17.5: {}
+
+  vscode-languageserver@9.0.1:
+    dependencies:
+      vscode-languageserver-protocol: 3.17.5
 
   vscode-uri@3.1.0: {}
 


### PR DESCRIPTION
## Which Linear task is linked to this PR?  
https://linear.app/lifi-linear/issue/EMB-435/investigate-walletconnect-modal-closing-immediately-in-widget-v4

## Why was it implemented this way?  
WalletConnect was previously stubbed out in the Tron provider (createTronAdapters() registered no WC adapter) because of a "No  accounts found in session" error: the upstream @tronweb3/tronwallet-adapters WalletConnect adapter uses the same WalletConnect Cloud project id and origin as the EVM provider, so the EVM connector's persisted eip155 namespaces bled into the Tron session proposal and wallets connected as EVM.

  This re-enables it by registering WalletConnectAdapter through a new resolveTronWalletConnectConfig helper
  (packages/widget-provider-tron/src/config/walletConnect.ts) that:
  - Defaults customStoragePrefix to 'tron' — isolates the Tron WalletConnect storage from the EVM connector's, which is the actual fix
  for the session-bleed bug. Integrators can still override it via options.
  - Mirrors the EVM provider's config contract — walletConnect: true uses the shipped defaults (incl. the shared LI.FI project id, so  it works with no integrator setup), a config object is merged over those defaults, and false/undefined disables it.
  -  Defaults network to 'Mainnet' (capitalized) — lowercase values fall through to an invalid tron:<name> CAIP id upstream.
  - Adapter registration stays conditional (...(walletConnect ? [new WalletConnectAdapter(...)] : [])), so nothing is registered when WC
  is disabled.

## Limitation
From my tests, only two wallets work over wallet connect.
- [TokenPocket connects via Tron WalletConnect ](https://github.com/tronweb3/tronwallet-adapter/issues/3#issuecomment-2251616301). 
- Tronlink

Other wallets confirmed in these issues:
https://github.com/tronweb3/tronwallet-adapter/issues/3
https://github.com/tronweb3/tronwallet-adapter/issues/37
https://github.com/tronweb3/tronwallet-adapter/issues/82#issuecomment-3177916700

I confirmed this by patching the wallet connect library to log the connection details

### Connection logs from Token pocket
<img width="986" height="477" alt="Screenshot 2026-06-11 at 8 49 02 PM" src="https://github.com/user-attachments/assets/88274198-18d3-4fb5-a66f-d0459bad794e" />


### Connection logs from metamask over wallet connect
Metamask only sends EVM connections over walletconnect.
<img width="1000" height="870" alt="Screenshot 2026-06-11 at 8 48 48 PM" src="https://github.com/user-attachments/assets/f752e328-f564-457a-b00c-b38f0752b266" />


## Visual showcase (Screenshots or Videos)  
<img width="487" height="581" alt="Screenshot 2026-06-11 at 8 48 24 PM" src="https://github.com/user-attachments/assets/ac495f86-9835-4f03-9f55-df6778a12c56" />


## Checklist before requesting a review  
- [x] I have performed a self-review and testing of my code.  
- [x] This pull request is focused and addresses a single problem.  
- [ ] If this PR modifies the Widget API or adds new features that require documentation, I have updated the documentation in the [public-docs](https://github.com/lifinance/public-docs) repository.
