### PR TITLE
fix(widget): respect tool allow-list on first route request

### DIFF
--- a/.changeset/emb-450-enabled-tools-config-seed.md
+++ b/.changeset/emb-450-enabled-tools-config-seed.md
@@ -1,0 +1,5 @@
+---
+'@lifi/widget': patch
+---
+
+Respect the integrator's `exchanges`/`bridges` allow-list on the first route request. Previously, before the `/tools` fetch populated the enabled-tools store, the initial `/advanced/routes` request omitted the exchange/bridge filter (or sent a stale persisted list), so it could return and render routes from disabled tools. The enabled-tools state is now seeded synchronously from the config allow-list and stale persisted entries are intersected against it on rehydration.

--- a/packages/widget/src/stores/settings/createSettingsStore.test.ts
+++ b/packages/widget/src/stores/settings/createSettingsStore.test.ts
@@ -3,6 +3,8 @@ import type { WidgetConfig } from '../../types/widget.js'
 import { createSettingsStore } from './createSettingsStore.js'
 
 const STORAGE_KEY = 'li.fi-widget-settings'
+// Must match the persist version in createSettingsStore, else merge tests
+// silently become migration tests.
 const STORE_VERSION = 6
 
 const createLocalStorageMock = (): Storage => {
@@ -33,12 +35,15 @@ const seedPersistedState = (state: Record<string, unknown>) => {
 }
 
 describe('createSettingsStore tool allow-list', () => {
+  let originalLocalStorage: Storage | undefined
+
   beforeEach(() => {
+    originalLocalStorage = globalThis.localStorage
     globalThis.localStorage = createLocalStorageMock()
   })
 
   afterEach(() => {
-    globalThis.localStorage.clear()
+    globalThis.localStorage = originalLocalStorage as Storage
   })
 
   it('seeds enabled tools from the config allow-list on a fresh store', () => {
@@ -67,6 +72,34 @@ describe('createSettingsStore tool allow-list', () => {
     expect(state.enabledExchanges).toEqual(['fly'])
     expect(state._enabledExchanges).toEqual({ fly: true })
     expect(state.disabledExchanges).toEqual([])
+  })
+
+  it('keeps the allow-list when the persisted map has no overlap', () => {
+    seedPersistedState({
+      _enabledExchanges: { okx: true, kyber: true },
+    })
+
+    const store = createSettingsStore({
+      exchanges: { allow: ['fly'] },
+    } as WidgetConfig)
+
+    const state = store.getState()
+    expect(state.enabledExchanges).toEqual(['fly'])
+    expect(state._enabledExchanges).toEqual({ fly: true })
+  })
+
+  it('intersects a stale persisted bridges list with the current config', () => {
+    seedPersistedState({
+      _enabledBridges: { across: true, hop: true, stargate: true },
+    })
+
+    const store = createSettingsStore({
+      bridges: { allow: ['across'] },
+    } as WidgetConfig)
+
+    const state = store.getState()
+    expect(state.enabledBridges).toEqual(['across'])
+    expect(state._enabledBridges).toEqual({ across: true })
   })
 
   it('does not restrict tools when the config has no allow-list', () => {

--- a/packages/widget/src/stores/settings/createSettingsStore.test.ts
+++ b/packages/widget/src/stores/settings/createSettingsStore.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import type { WidgetConfig } from '../../types/widget.js'
+import { createSettingsStore } from './createSettingsStore.js'
+
+const STORAGE_KEY = 'li.fi-widget-settings'
+const STORE_VERSION = 6
+
+const createLocalStorageMock = (): Storage => {
+  let store: Record<string, string> = {}
+  return {
+    getItem: (key) => (key in store ? store[key] : null),
+    setItem: (key, value) => {
+      store[key] = value
+    },
+    removeItem: (key) => {
+      delete store[key]
+    },
+    clear: () => {
+      store = {}
+    },
+    key: (index) => Object.keys(store)[index] ?? null,
+    get length() {
+      return Object.keys(store).length
+    },
+  }
+}
+
+const seedPersistedState = (state: Record<string, unknown>) => {
+  globalThis.localStorage.setItem(
+    STORAGE_KEY,
+    JSON.stringify({ state, version: STORE_VERSION })
+  )
+}
+
+describe('createSettingsStore tool allow-list', () => {
+  beforeEach(() => {
+    globalThis.localStorage = createLocalStorageMock()
+  })
+
+  afterEach(() => {
+    globalThis.localStorage.clear()
+  })
+
+  it('seeds enabled tools from the config allow-list on a fresh store', () => {
+    const store = createSettingsStore({
+      exchanges: { allow: ['fly'] },
+      bridges: { allow: ['across'] },
+    } as WidgetConfig)
+
+    const state = store.getState()
+    expect(state.enabledExchanges).toEqual(['fly'])
+    expect(state._enabledExchanges).toEqual({ fly: true })
+    expect(state.enabledBridges).toEqual(['across'])
+    expect(state._enabledBridges).toEqual({ across: true })
+  })
+
+  it('intersects a stale persisted allow-list with the current config', () => {
+    seedPersistedState({
+      _enabledExchanges: { fly: true, okx: true, kyber: true },
+    })
+
+    const store = createSettingsStore({
+      exchanges: { allow: ['fly'] },
+    } as WidgetConfig)
+
+    const state = store.getState()
+    expect(state.enabledExchanges).toEqual(['fly'])
+    expect(state._enabledExchanges).toEqual({ fly: true })
+    expect(state.disabledExchanges).toEqual([])
+  })
+
+  it('does not restrict tools when the config has no allow-list', () => {
+    const store = createSettingsStore({} as WidgetConfig)
+
+    const state = store.getState()
+    expect(state.enabledExchanges).toEqual([])
+    expect(state.enabledBridges).toEqual([])
+  })
+})

--- a/packages/widget/src/stores/settings/createSettingsStore.ts
+++ b/packages/widget/src/stores/settings/createSettingsStore.ts
@@ -6,7 +6,8 @@ import { allLanguages } from '../../providers/I18nProvider/constants.js'
 import { loadLocale } from '../../providers/I18nProvider/i18n.js'
 import type { LanguageKey } from '../../providers/I18nProvider/types.js'
 import type { WidgetConfig } from '../../types/widget.js'
-import type { SettingsProps, SettingsState } from './types.js'
+import { getConfigItemSets, isItemAllowedForSets } from '../../utils/item.js'
+import type { SettingsProps, SettingsState, SettingsToolType } from './types.js'
 import { SettingsToolTypes } from './types.js'
 import { getStateValues } from './utils/getStateValues.js'
 
@@ -35,11 +36,43 @@ const defaultSettings: SettingsProps = {
 
 export const createSettingsStore = (
   config: WidgetConfig
-): UseBoundStore<StoreApi<SettingsState>> =>
-  create<SettingsState>()(
+): UseBoundStore<StoreApi<SettingsState>> => {
+  const configItemsByToolType = {
+    Bridges: config.bridges,
+    Exchanges: config.exchanges,
+  }
+  // Tool state from a candidate map, keeping only config-allowed tools.
+  const buildToolState = (
+    toolType: SettingsToolType,
+    enabledMap: Record<string, boolean>
+  ) => {
+    const configItemSets = getConfigItemSets(
+      configItemsByToolType[toolType],
+      (items) => new Set(items)
+    )
+    const allowed: Record<string, boolean> = Object.fromEntries(
+      Object.entries(enabledMap).filter(([key]) =>
+        isItemAllowedForSets(key, configItemSets)
+      )
+    )
+    const keys = Object.keys(allowed)
+    return {
+      [`_enabled${toolType}`]: allowed,
+      [`enabled${toolType}`]: keys.filter((key) => allowed[key]),
+      [`disabled${toolType}`]: keys.filter((key) => !allowed[key]),
+    }
+  }
+  const toEnabledMap = (keys: string[] = []): Record<string, boolean> =>
+    Object.fromEntries(keys.map((key) => [key, true] as const))
+  const initialSettings: SettingsProps = {
+    ...defaultSettings,
+    ...buildToolState('Bridges', toEnabledMap(config.bridges?.allow)),
+    ...buildToolState('Exchanges', toEnabledMap(config.exchanges?.allow)),
+  }
+  return create<SettingsState>()(
     persist(
       (set, get) => ({
-        ...defaultSettings,
+        ...initialSettings,
         setValue: (key, value) =>
           set(() => ({
             [key]: value,
@@ -163,16 +196,10 @@ export const createSettingsStore = (
         merge: (persistedState: any, currentState: SettingsState) => {
           const state = { ...currentState, ...persistedState }
           SettingsToolTypes.forEach((toolType) => {
-            if (persistedState?.[`_enabled${toolType}`]) {
-              const enabledToolKeys = Object.keys(
-                persistedState[`_enabled${toolType}`]
-              )
-              state[`enabled${toolType}`] = enabledToolKeys.filter(
-                (key) => persistedState[`_enabled${toolType}`][key]
-              )
-              state[`disabled${toolType}`] = enabledToolKeys.filter(
-                (key) => !persistedState[`_enabled${toolType}`][key]
-              )
+            const persistedEnabled = persistedState?.[`_enabled${toolType}`]
+            if (persistedEnabled) {
+              // Drop rehydrated tools the config no longer allows.
+              Object.assign(state, buildToolState(toolType, persistedEnabled))
             }
           })
           return state
@@ -217,3 +244,4 @@ export const createSettingsStore = (
       }
     )
   )
+}

--- a/packages/widget/src/stores/settings/createSettingsStore.ts
+++ b/packages/widget/src/stores/settings/createSettingsStore.ts
@@ -64,6 +64,7 @@ export const createSettingsStore = (
   }
   const toEnabledMap = (keys: string[] = []): Record<string, boolean> =>
     Object.fromEntries(keys.map((key) => [key, true] as const))
+  // Deny-only configs can't be seeded; the tool universe is unknown until /tools.
   const initialSettings: SettingsProps = {
     ...defaultSettings,
     ...buildToolState('Bridges', toEnabledMap(config.bridges?.allow)),
@@ -198,8 +199,15 @@ export const createSettingsStore = (
           SettingsToolTypes.forEach((toolType) => {
             const persistedEnabled = persistedState?.[`_enabled${toolType}`]
             if (persistedEnabled) {
-              // Drop rehydrated tools the config no longer allows.
-              Object.assign(state, buildToolState(toolType, persistedEnabled))
+              // Overlay persisted toggles on the config allow seed so an empty
+              // intersection keeps the allow-list instead of going unrestricted.
+              const allowMap = toEnabledMap(
+                configItemsByToolType[toolType]?.allow
+              )
+              Object.assign(
+                state,
+                buildToolState(toolType, { ...allowMap, ...persistedEnabled })
+              )
             }
           })
           return state


### PR DESCRIPTION
## Which Linear task is linked to this PR?
https://linear.app/lifi-linear/issue/EMB-450/stale-localstorage-allow-list-returns-disabled-exchange-routes

## Why was it implemented this way?
The integrator allow-list (`exchanges.allow` / `bridges.allow`) is enforced only through the `enabledExchanges` / `enabledBridges` store arrays, which are populated asynchronously by the `/tools` fetch. Before that resolves the array is empty (cleared or fresh storage) or stale, and `useRoutes` then either omits the `exchanges`/`bridges` filter entirely (an empty array reads as "no restriction") or sends the stale list. So the first `/advanced/routes` request escapes the allow-list and can return disabled tools (OKX, Kyber, etc.); it self-corrects once `/tools` resolves, which is why only the first request was affected.

Fix:
- Seed `enabled*` from the config allow-list synchronously at store creation (covers empty/cleared localStorage).
- Intersect any persisted state against the config in the persist `merge` (covers a stale persisted list).

This makes the store reflect the allow-list from the first render with no dependency on `/tools` timing. A `useRoutes`-only fallback was considered but rejected: it scatters the config logic into a second place and leaves the persisted store and settings UI inconsistent.

Known limitation: deny-only / no-allow configs cannot be pre-seeded synchronously (the full tool universe is unknown until `/tools`). The reporting integrator uses `allow`, so this is covered.

## Visual showcase (Screenshots or Videos)
N/A (request-payload behavior). Repro: with `exchanges: { allow: ['fly'] }`, clear localStorage and block `/tools` in DevTools, then trigger a quote. The first `POST /advanced/routes` body omits `options.exchanges` before the fix and sends `{ allow: ['fly'] }` after.

## Checklist before requesting a review
- [x] I have performed a self-review and testing of my code.
- [x] This pull request is focused and addresses a single problem.
- [ ] If this PR modifies the Widget API or adds new features that require documentation, I have updated the documentation in the public-docs repository. (N/A, no API change)
