### PR TITLE
feat: drop React 18 support and migrate to React 19 idioms

### DIFF
--- a/.changeset/drop-react-18-require-react-19.md
+++ b/.changeset/drop-react-18-require-react-19.md
@@ -1,0 +1,13 @@
+---
+'@lifi/widget': minor
+'@lifi/wallet-management': minor
+'@lifi/widget-light': minor
+'@lifi/widget-provider': minor
+'@lifi/widget-provider-ethereum': minor
+'@lifi/widget-provider-solana': minor
+'@lifi/widget-provider-bitcoin': minor
+'@lifi/widget-provider-sui': minor
+'@lifi/widget-provider-tron': minor
+---
+
+Drop React 18 support and require React 19+. The `react`/`react-dom` peer dependency range is narrowed from `>=18` to `>=19`, and the components are modernized to React 19 idioms (refs passed as props instead of `forwardRef`, `use()` for context). The `widget-provider-*` packages now use React-19-only APIs and declare a `react: >=19` peer dependency. Integrators must be on React 19 or newer.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Repository Overview
 
-LI.FI Widget monorepo — a cross-chain DeFi swap/bridge widget supporting Ethereum, Solana, Bitcoin, and Sui ecosystems. Managed with pnpm workspaces, Changesets (independent versioning), and TypeScript composite builds.
+LI.FI Widget monorepo — a cross-chain DeFi swap/bridge widget supporting Ethereum, Solana, Bitcoin, Sui, and Tron ecosystems. Managed with pnpm workspaces, Changesets (independent versioning), and TypeScript composite builds.
 
 ## Commands
 
@@ -28,7 +28,7 @@ pnpm --filter @lifi/widget check:types
 
 # Testing (vitest)
 pnpm --filter @lifi/widget test        # Run widget tests
-pnpm --filter @lifi/widget-light test  # Run widget-light tests
+pnpm --filter @lifi/widget-light test  # widget-light tests (no test files yet)
 
 # Unused code detection
 pnpm knip:check
@@ -51,9 +51,9 @@ pnpm knip:check
 ### Package Dependency Graph
 
 ```
-@lifi/widget-provider          ← base contexts (Ethereum/Solana/Bitcoin/Sui)
+@lifi/widget-provider          ← base contexts (Ethereum/Solana/Bitcoin/Sui/Tron)
   ↑
-@lifi/widget-provider-{ethereum,solana,bitcoin,sui}  ← chain-specific implementations
+@lifi/widget-provider-{ethereum,solana,bitcoin,sui,tron}  ← chain-specific implementations
   ↑
 @lifi/wallet-management        ← wallet UI + connection logic
   ↑
@@ -89,9 +89,9 @@ pnpm knip:check
 
 - **State**: Zustand stores in `packages/widget/src/stores/` (form, routes, chains, settings)
 - **Routing**: TanStack Router with page components in `src/pages/`
-- **Theming**: MUI v7 + Emotion; custom themes in `src/themes/`
+- **Theming**: MUI v9 + Emotion; custom themes in `src/themes/`
 - **Events**: mitt event bus (`widgetEvents` singleton in `src/hooks/useWidgetEvents.ts`)
-- **i18n**: i18next with 20 language translations in `src/i18n/`
+- **i18n**: i18next with language translations in `src/i18n/` (17 locales)
 
 ### Provider layering (widget)
 
@@ -132,11 +132,9 @@ pnpm changeset    # interactive: pick packages + bump type, write a summary
 - Private/ignored (never need a changeset): `@lifi/widget-embedded`, `@lifi/widget-playground`, `@lifi/widget-playground-next`, `@lifi/widget-playground-vite`, examples, e2e.
 - `changeset-bot` comments a reminder on any PR that edits a publishable package without a changeset (a nudge, not a hard block — the maintainer-reviewed Version PR is the real gate).
 
-### PRE-MODE — currently in `beta` (DO NOT EXIT)
+### Release line — `4.x` stable (pre-mode exited)
 
-The repo is in Changesets **pre mode** (`.changeset/pre.json`, `tag: beta`). While in pre mode, `changeset version` produces `4.0.0-beta.N` versions and `changeset publish` publishes under the `beta` dist-tag. `latest` on npm stays on the v3 line (`@lifi/widget@3.x`).
-
-**NEVER run `changeset pre exit`** unless you are deliberately cutting the stable `4.0.0` release. Exiting pre mode is the single action that moves the npm `latest` tag to 4.x — do it only on purpose.
+Changesets pre mode has been **exited** and stable **`@lifi/widget@4.0.0`** is published — npm `latest` is on the `4.x` line (the old `3.x` line is superseded). There is no `.changeset/pre.json`, so **standard semver applies**: `changeset version` bumps real `4.x` versions (`fix:` → patch, `feat:` → minor, breaking → major → `5.0.0`) and `changeset publish` publishes to the `latest` dist-tag. The historical `4.0.0-alpha.*` / `4.0.0-beta.*` prereleases remain parked under the `alpha` / `beta` dist-tags.
 
 ### How a release happens (automated)
 
@@ -156,9 +154,9 @@ removed after a successful publish (one-shot — re-add it to cut another previe
 - Install the **exact** version it prints (e.g. `npm i @lifi/widget@0.0.0-preview-<sha>`);
   `@preview` moves with the newest preview across PRs. `0.0.0` can never become `latest`/`beta`.
   The `<sha>` is the PR head's short commit hash, so the version traces to the exact source.
-- This repo is in **pre mode**, where `--snapshot` is disallowed — the job therefore runs
-  `changeset pre exit` in the **throwaway CI checkout only** (never committed or pushed)
-  before snapshotting. `.changeset/pre.json` on the branch is untouched.
+- The repo is no longer in pre mode, so the preview job snapshots the changed packages
+  directly; the former `changeset pre exit` workaround (needed only while in pre mode) no
+  longer applies.
 - Guardrails: applying a label requires Triage+ on the repo, so external people / fork-PR
   authors can't trigger it; the same-repo guard means the published code was pushed by
   someone with Write access (forks excluded); and the job is isolated (no deploy/Linear

--- a/packages/wallet-management/package.json
+++ b/packages/wallet-management/package.json
@@ -63,7 +63,7 @@
   },
   "peerDependencies": {
     "@tanstack/react-query": ">=5.90.0",
-    "react": ">=18",
-    "react-dom": ">=18"
+    "react": ">=19",
+    "react-dom": ">=19"
   }
 }

--- a/packages/wallet-management/src/providers/WalletManagementProvider/WalletManagementContext.ts
+++ b/packages/wallet-management/src/providers/WalletManagementProvider/WalletManagementContext.ts
@@ -1,4 +1,4 @@
-import { type Context, createContext, useContext } from 'react'
+import { type Context, createContext, use } from 'react'
 import type { WalletManagementConfig } from './types.js'
 
 export const initialContext: WalletManagementConfig = {}
@@ -7,4 +7,4 @@ export const WalletManagementContext: Context<WalletManagementConfig> =
   createContext<WalletManagementConfig>(initialContext)
 
 export const useWalletManagementConfig = (): WalletManagementConfig =>
-  useContext(WalletManagementContext)
+  use(WalletManagementContext)

--- a/packages/wallet-management/src/providers/WalletManagementProvider/WalletManagementProvider.tsx
+++ b/packages/wallet-management/src/providers/WalletManagementProvider/WalletManagementProvider.tsx
@@ -9,8 +9,8 @@ export const WalletManagementProvider: React.FC<
   React.PropsWithChildren<WalletManagementProviderProps>
 > = ({ children, config = initialContext }) => {
   return (
-    <WalletManagementContext.Provider value={config}>
+    <WalletManagementContext value={config}>
       <WalletMenuProvider>{children}</WalletMenuProvider>
-    </WalletManagementContext.Provider>
+    </WalletManagementContext>
   )
 }

--- a/packages/wallet-management/src/providers/WalletMenuProvider/WalletMenuContext.ts
+++ b/packages/wallet-management/src/providers/WalletMenuProvider/WalletMenuContext.ts
@@ -1,5 +1,5 @@
 import type { Context } from 'react'
-import { createContext, useContext } from 'react'
+import { createContext, use } from 'react'
 import type {
   WalletMenuContext as _WalletMenuContext,
   WalletMenuOpenArgs,
@@ -13,5 +13,4 @@ export const WalletMenuContext: Context<_WalletMenuContext> =
     closeWalletMenu: () => {},
   })
 
-export const useWalletMenu = (): _WalletMenuContext =>
-  useContext(WalletMenuContext)
+export const useWalletMenu = (): _WalletMenuContext => use(WalletMenuContext)

--- a/packages/wallet-management/src/providers/WalletMenuProvider/WalletMenuProvider.tsx
+++ b/packages/wallet-management/src/providers/WalletMenuProvider/WalletMenuProvider.tsx
@@ -52,7 +52,7 @@ export const WalletMenuProvider: React.FC<PropsWithChildren> = ({
   )
 
   return (
-    <WalletMenuContext.Provider value={context}>
+    <WalletMenuContext value={context}>
       {children}
       <I18nProvider locale={locale}>
         <WalletMenuModal open={open} onClose={closeWalletMenu}>
@@ -62,6 +62,6 @@ export const WalletMenuProvider: React.FC<PropsWithChildren> = ({
           />
         </WalletMenuModal>
       </I18nProvider>
-    </WalletMenuContext.Provider>
+    </WalletMenuContext>
   )
 }

--- a/packages/widget-embedded/src/providers/WidgetConfigProvider.tsx
+++ b/packages/widget-embedded/src/providers/WidgetConfigProvider.tsx
@@ -5,8 +5,8 @@ import {
   createContext,
   type FC,
   type PropsWithChildren,
+  use,
   useCallback,
-  useContext,
   useEffect,
   useMemo,
   useState,
@@ -21,7 +21,7 @@ export const EMBEDDED_DEFAULT_CONFIG: Partial<WidgetConfig> = {
 const WidgetConfigContext = createContext<Partial<WidgetConfig> | null>(null)
 
 export const useEmbeddedWidgetConfig = (): Partial<WidgetConfig> | null =>
-  useContext(WidgetConfigContext)
+  use(WidgetConfigContext)
 
 export const WidgetConfigProvider: FC<PropsWithChildren> = ({ children }) => {
   const [lightConfig, setLightConfig] = useState<WidgetLightConfig | null>(
@@ -72,9 +72,5 @@ export const WidgetConfigProvider: FC<PropsWithChildren> = ({ children }) => {
 
   const value = isInsideIframe ? config : EMBEDDED_DEFAULT_CONFIG
 
-  return (
-    <WidgetConfigContext.Provider value={value}>
-      {children}
-    </WidgetConfigContext.Provider>
-  )
+  return <WidgetConfigContext value={value}>{children}</WidgetConfigContext>
 }

--- a/packages/widget-embedded/src/providers/iframe/BitcoinIframeProviderValues.tsx
+++ b/packages/widget-embedded/src/providers/iframe/BitcoinIframeProviderValues.tsx
@@ -134,11 +134,7 @@ export const BitcoinIframeProviderValues: FC<PropsWithChildren> = ({
     [account, sdkProvider, isConnected]
   )
 
-  return (
-    <BitcoinContext.Provider value={contextValue}>
-      {children}
-    </BitcoinContext.Provider>
-  )
+  return <BitcoinContext value={contextValue}>{children}</BitcoinContext>
 }
 
 /**

--- a/packages/widget-embedded/src/providers/iframe/SolanaIframeProviderValues.tsx
+++ b/packages/widget-embedded/src/providers/iframe/SolanaIframeProviderValues.tsx
@@ -137,11 +137,7 @@ export const SolanaIframeProviderValues: FC<PropsWithChildren> = ({
     [account, sdkProvider, isConnected]
   )
 
-  return (
-    <SolanaContext.Provider value={contextValue}>
-      {children}
-    </SolanaContext.Provider>
-  )
+  return <SolanaContext value={contextValue}>{children}</SolanaContext>
 }
 
 /**

--- a/packages/widget-embedded/src/providers/iframe/SuiIframeProviderValues.tsx
+++ b/packages/widget-embedded/src/providers/iframe/SuiIframeProviderValues.tsx
@@ -139,7 +139,5 @@ export const SuiIframeProviderValues: FC<PropsWithChildren> = ({
     [account, sdkProvider, isConnected]
   )
 
-  return (
-    <SuiContext.Provider value={contextValue}>{children}</SuiContext.Provider>
-  )
+  return <SuiContext value={contextValue}>{children}</SuiContext>
 }

--- a/packages/widget-embedded/src/providers/iframe/TronIframeProviderValues.tsx
+++ b/packages/widget-embedded/src/providers/iframe/TronIframeProviderValues.tsx
@@ -137,7 +137,5 @@ export const TronIframeProviderValues: FC<PropsWithChildren> = ({
     [account, sdkProvider, isConnected]
   )
 
-  return (
-    <TronContext.Provider value={contextValue}>{children}</TronContext.Provider>
-  )
+  return <TronContext value={contextValue}>{children}</TronContext>
 }

--- a/packages/widget-light/package.json
+++ b/packages/widget-light/package.json
@@ -65,7 +65,7 @@
     "@mysten/dapp-kit-react": "^2.0.0",
     "@wagmi/core": "^3.5.0",
     "@wallet-standard/base": "^1.1.0",
-    "react": ">=18",
+    "react": ">=19",
     "viem": ">=2.52.0",
     "wagmi": "^3.6.16"
   },

--- a/packages/widget-provider-bitcoin/package.json
+++ b/packages/widget-provider-bitcoin/package.json
@@ -45,7 +45,8 @@
     "@lifi/widget-provider": "workspace:*"
   },
   "peerDependencies": {
-    "@bigmi/react": "^0.8.0"
+    "@bigmi/react": "^0.8.0",
+    "react": ">=19"
   },
   "devDependencies": {
     "cpy-cli": "^7.0.0",

--- a/packages/widget-provider-bitcoin/src/providers/BitcoinProvider.tsx
+++ b/packages/widget-provider-bitcoin/src/providers/BitcoinProvider.tsx
@@ -1,6 +1,6 @@
 import { BigmiContext } from '@bigmi/react'
 import type { WidgetProviderProps } from '@lifi/widget-provider'
-import { type JSX, type PropsWithChildren, useContext } from 'react'
+import { type JSX, type PropsWithChildren, use } from 'react'
 import type { BitcoinProviderConfig } from '../types.js'
 import { BitcoinBaseProvider } from './BitcoinBaseProvider.js'
 import { BitcoinProviderValues } from './BitcoinProviderValues.js'
@@ -10,7 +10,7 @@ interface BitcoinWidgetProviderProps extends WidgetProviderProps {
 }
 
 function useInBitcoinContext(): boolean {
-  const context = useContext(BigmiContext)
+  const context = use(BigmiContext)
 
   return Boolean(context)
 }

--- a/packages/widget-provider-bitcoin/src/providers/BitcoinProviderValues.tsx
+++ b/packages/widget-provider-bitcoin/src/providers/BitcoinProviderValues.tsx
@@ -104,9 +104,5 @@ export const BitcoinProviderValues: FC<
     ]
   )
 
-  return (
-    <BitcoinContext.Provider value={contextValue}>
-      {children}
-    </BitcoinContext.Provider>
-  )
+  return <BitcoinContext value={contextValue}>{children}</BitcoinContext>
 }

--- a/packages/widget-provider-ethereum/package.json
+++ b/packages/widget-provider-ethereum/package.json
@@ -45,6 +45,7 @@
   },
   "peerDependencies": {
     "@wagmi/core": "^3.5.0",
+    "react": ">=19",
     "wagmi": "^3.6.16"
   },
   "devDependencies": {

--- a/packages/widget-provider-ethereum/src/providers/EthereumProvider.tsx
+++ b/packages/widget-provider-ethereum/src/providers/EthereumProvider.tsx
@@ -1,5 +1,5 @@
 import type { WidgetProviderProps } from '@lifi/widget-provider'
-import { type JSX, type PropsWithChildren, useContext } from 'react'
+import { type JSX, type PropsWithChildren, use } from 'react'
 import { WagmiContext } from 'wagmi'
 import type { EthereumProviderConfig } from '../types.js'
 import { EthereumBaseProvider } from './EthereumBaseProvider.js'
@@ -10,7 +10,7 @@ interface EthereumWidgetProviderProps extends WidgetProviderProps {
 }
 
 function useInEthereumContext(): boolean {
-  const context = useContext(WagmiContext)
+  const context = use(WagmiContext)
   return Boolean(context)
 }
 

--- a/packages/widget-provider-ethereum/src/providers/EthereumProviderValues.tsx
+++ b/packages/widget-provider-ethereum/src/providers/EthereumProviderValues.tsx
@@ -281,9 +281,5 @@ export const EthereumProviderValues: FC<
     ]
   )
 
-  return (
-    <EthereumContext.Provider value={contextValue}>
-      {children}
-    </EthereumContext.Provider>
-  )
+  return <EthereumContext value={contextValue}>{children}</EthereumContext>
 }

--- a/packages/widget-provider-solana/package.json
+++ b/packages/widget-provider-solana/package.json
@@ -46,7 +46,8 @@
     "zustand": "^5.0.14"
   },
   "peerDependencies": {
-    "bs58": ">=4.0.1"
+    "bs58": ">=4.0.1",
+    "react": ">=19"
   },
   "devDependencies": {
     "cpy-cli": "^7.0.0",

--- a/packages/widget-provider-solana/src/providers/SolanaProviderValues.tsx
+++ b/packages/widget-provider-solana/src/providers/SolanaProviderValues.tsx
@@ -137,9 +137,5 @@ export const SolanaProviderValues: FC<
     ]
   )
 
-  return (
-    <SolanaContext.Provider value={contextValue}>
-      {children}
-    </SolanaContext.Provider>
-  )
+  return <SolanaContext value={contextValue}>{children}</SolanaContext>
 }

--- a/packages/widget-provider-sui/package.json
+++ b/packages/widget-provider-sui/package.json
@@ -43,7 +43,8 @@
     "@mysten/sui": "^2.17.0"
   },
   "peerDependencies": {
-    "@mysten/dapp-kit-react": "^2.0.0"
+    "@mysten/dapp-kit-react": "^2.0.0",
+    "react": ">=19"
   },
   "devDependencies": {
     "cpy-cli": "^7.0.0",

--- a/packages/widget-provider-sui/src/providers/SuiProvider.tsx
+++ b/packages/widget-provider-sui/src/providers/SuiProvider.tsx
@@ -1,6 +1,6 @@
 import type { WidgetProviderProps } from '@lifi/widget-provider'
 import { DAppKitContext } from '@mysten/dapp-kit-react'
-import { type JSX, type PropsWithChildren, useContext } from 'react'
+import { type JSX, type PropsWithChildren, use } from 'react'
 import type { SuiProviderConfig } from '../types.js'
 import { SuiBaseProvider } from './SuiBaseProvider.js'
 import { SuiProviderValues } from './SuiProviderValues.js'
@@ -10,7 +10,7 @@ interface SuiWidgetProviderProps extends WidgetProviderProps {
 }
 
 function useInSuiContext(): boolean {
-  const context = useContext(DAppKitContext)
+  const context = use(DAppKitContext)
   return Boolean(context)
 }
 

--- a/packages/widget-provider-sui/src/providers/SuiProviderValues.tsx
+++ b/packages/widget-provider-sui/src/providers/SuiProviderValues.tsx
@@ -105,7 +105,5 @@ export const SuiProviderValues: FC<
     ]
   )
 
-  return (
-    <SuiContext.Provider value={contextValue}>{children}</SuiContext.Provider>
-  )
+  return <SuiContext value={contextValue}>{children}</SuiContext>
 }

--- a/packages/widget-provider-tron/package.json
+++ b/packages/widget-provider-tron/package.json
@@ -44,7 +44,8 @@
     "@tronweb3/tronwallet-adapters": "^1.2.26"
   },
   "peerDependencies": {
-    "@tronweb3/tronwallet-adapter-react-hooks": "^1.1.11"
+    "@tronweb3/tronwallet-adapter-react-hooks": "^1.1.11",
+    "react": ">=19"
   },
   "devDependencies": {
     "cpy-cli": "^7.0.0",

--- a/packages/widget-provider-tron/src/providers/TronProvider.tsx
+++ b/packages/widget-provider-tron/src/providers/TronProvider.tsx
@@ -1,6 +1,6 @@
 import type { WidgetProviderProps } from '@lifi/widget-provider'
 import { WalletContext } from '@tronweb3/tronwallet-adapter-react-hooks'
-import { type JSX, type PropsWithChildren, useContext } from 'react'
+import { type JSX, type PropsWithChildren, use } from 'react'
 import type { TronProviderConfig } from '../types.js'
 import { TronBaseProvider } from './TronBaseProvider.js'
 import { TronProviderValues } from './TronProviderValues.js'
@@ -14,7 +14,7 @@ interface TronWidgetProviderProps extends WidgetProviderProps {
 // while a real provider sets plain data properties. Checking the property descriptor
 // distinguishes between the two — a non-getter means a real provider is present.
 function useInTronContext(): boolean {
-  const context = useContext(WalletContext)
+  const context = use(WalletContext)
   const descriptor = Object.getOwnPropertyDescriptor(context, 'wallets')
   return Boolean(descriptor && !descriptor.get)
 }

--- a/packages/widget-provider-tron/src/providers/TronProviderValues.tsx
+++ b/packages/widget-provider-tron/src/providers/TronProviderValues.tsx
@@ -150,7 +150,5 @@ export const TronProviderValues: FC<
     ]
   )
 
-  return (
-    <TronContext.Provider value={contextValue}>{children}</TronContext.Provider>
-  )
+  return <TronContext value={contextValue}>{children}</TronContext>
 }

--- a/packages/widget-provider/package.json
+++ b/packages/widget-provider/package.json
@@ -39,6 +39,9 @@
   "dependencies": {
     "@lifi/sdk": "^4.0.0"
   },
+  "peerDependencies": {
+    "react": ">=19"
+  },
   "devDependencies": {
     "cpy-cli": "^7.0.0",
     "madge": "^8.0.0",

--- a/packages/widget-provider/src/contexts/BitcoinContext.ts
+++ b/packages/widget-provider/src/contexts/BitcoinContext.ts
@@ -1,4 +1,4 @@
-import { createContext, useContext } from 'react'
+import { createContext, use } from 'react'
 import type { WidgetProviderContext } from '../types.js'
 import { defaultContextValue } from './defaultContextValue.js'
 
@@ -6,6 +6,6 @@ export const BitcoinContext: React.Context<WidgetProviderContext> =
   createContext<WidgetProviderContext>(defaultContextValue)
 
 export const useBitcoinContext = (): WidgetProviderContext => {
-  const context = useContext(BitcoinContext)
+  const context = use(BitcoinContext)
   return context || defaultContextValue
 }

--- a/packages/widget-provider/src/contexts/EthereumContext.ts
+++ b/packages/widget-provider/src/contexts/EthereumContext.ts
@@ -1,4 +1,4 @@
-import { createContext, useContext } from 'react'
+import { createContext, use } from 'react'
 import type { EthereumProviderContext } from '../types.js'
 import { defaultContextValue } from './defaultContextValue.js'
 
@@ -12,6 +12,6 @@ export const EthereumContext: React.Context<EthereumProviderContext> =
   createContext<EthereumProviderContext>(ethereumDefaultContextValue)
 
 export const useEthereumContext = (): EthereumProviderContext => {
-  const context = useContext(EthereumContext)
+  const context = use(EthereumContext)
   return context || ethereumDefaultContextValue
 }

--- a/packages/widget-provider/src/contexts/SolanaContext.ts
+++ b/packages/widget-provider/src/contexts/SolanaContext.ts
@@ -1,4 +1,4 @@
-import { createContext, useContext } from 'react'
+import { createContext, use } from 'react'
 import type { WidgetProviderContext } from '../types.js'
 import { defaultContextValue } from './defaultContextValue.js'
 
@@ -6,6 +6,6 @@ export const SolanaContext: React.Context<WidgetProviderContext> =
   createContext<WidgetProviderContext>(defaultContextValue)
 
 export const useSolanaContext = (): WidgetProviderContext => {
-  const context = useContext(SolanaContext)
+  const context = use(SolanaContext)
   return context || defaultContextValue
 }

--- a/packages/widget-provider/src/contexts/SuiContext.ts
+++ b/packages/widget-provider/src/contexts/SuiContext.ts
@@ -1,4 +1,4 @@
-import { createContext, useContext } from 'react'
+import { createContext, use } from 'react'
 import type { WidgetProviderContext } from '../types.js'
 import { defaultContextValue } from './defaultContextValue.js'
 
@@ -6,6 +6,6 @@ export const SuiContext: React.Context<WidgetProviderContext> =
   createContext<WidgetProviderContext>(defaultContextValue)
 
 export const useSuiContext = (): WidgetProviderContext => {
-  const context = useContext(SuiContext)
+  const context = use(SuiContext)
   return context || defaultContextValue
 }

--- a/packages/widget-provider/src/contexts/TronContext.ts
+++ b/packages/widget-provider/src/contexts/TronContext.ts
@@ -1,4 +1,4 @@
-import { createContext, useContext } from 'react'
+import { createContext, use } from 'react'
 import type { WidgetProviderContext } from '../types.js'
 import { defaultContextValue } from './defaultContextValue.js'
 
@@ -6,6 +6,6 @@ export const TronContext: React.Context<WidgetProviderContext> =
   createContext<WidgetProviderContext>(defaultContextValue)
 
 export const useTronContext = (): WidgetProviderContext => {
-  const context = useContext(TronContext)
+  const context = use(TronContext)
   return context || defaultContextValue
 }

--- a/packages/widget/package.json
+++ b/packages/widget/package.json
@@ -75,7 +75,7 @@
   },
   "peerDependencies": {
     "@tanstack/react-query": ">=5.90.0",
-    "react": ">=18",
-    "react-dom": ">=18"
+    "react": ">=19",
+    "react-dom": ">=19"
   }
 }

--- a/packages/widget/src/App.tsx
+++ b/packages/widget/src/App.tsx
@@ -1,15 +1,15 @@
 'use client'
-import type { ForwardRefExoticComponent, RefAttributes } from 'react'
-import { forwardRef, useMemo } from 'react'
+import type { JSX, Ref } from 'react'
+import { useMemo } from 'react'
 import { AppDefault } from './AppDefault.js'
 import type { WidgetDrawer } from './AppDrawer.js'
 import { AppDrawer } from './AppDrawer.js'
 import { AppProvider } from './AppProvider.js'
 import type { WidgetConfig, WidgetProps } from './types/widget.js'
 
-export const App: ForwardRefExoticComponent<
-  WidgetProps & RefAttributes<WidgetDrawer>
-> = forwardRef<WidgetDrawer, WidgetProps>((props, ref) => {
+export const App = (
+  props: WidgetProps & { ref?: Ref<WidgetDrawer> }
+): JSX.Element => {
   const config: WidgetConfig = useMemo(() => {
     const config = { ...props, ...props.config }
     if (config.variant === 'drawer') {
@@ -28,7 +28,7 @@ export const App: ForwardRefExoticComponent<
     return (
       <AppProvider config={config} formRef={props.formRef}>
         <AppDrawer
-          ref={ref}
+          ref={props.ref}
           elementRef={props.elementRef}
           config={config}
           open={props.open}
@@ -45,4 +45,4 @@ export const App: ForwardRefExoticComponent<
       <AppDefault />
     </AppProvider>
   )
-})
+}

--- a/packages/widget/src/AppDrawer.tsx
+++ b/packages/widget/src/AppDrawer.tsx
@@ -1,11 +1,6 @@
 import { Drawer } from '@mui/material'
-import type {
-  ForwardRefExoticComponent,
-  PropsWithChildren,
-  RefAttributes,
-} from 'react'
+import type { JSX, PropsWithChildren, Ref } from 'react'
 import {
-  forwardRef,
   useCallback,
   useImperativeHandle,
   useMemo,
@@ -23,82 +18,86 @@ export interface WidgetDrawer {
   closeDrawer(): void
 }
 
-export const AppDrawer: ForwardRefExoticComponent<
-  PropsWithChildren<WidgetDrawerProps> & RefAttributes<WidgetDrawer>
-> = forwardRef<WidgetDrawer, PropsWithChildren<WidgetDrawerProps>>(
-  ({ elementRef, open, onClose, children }, ref) => {
-    const openRef = useRef(Boolean(open))
-    const [drawerOpen, setDrawerOpen] = useState(Boolean(open))
+export const AppDrawer = ({
+  elementRef,
+  open,
+  onClose,
+  children,
+  ref,
+}: PropsWithChildren<WidgetDrawerProps> & {
+  ref?: Ref<WidgetDrawer>
+}): JSX.Element => {
+  const openRef = useRef(Boolean(open))
+  const [drawerOpen, setDrawerOpen] = useState(Boolean(open))
 
-    const toggleDrawer = useCallback(() => {
-      setDrawerOpen((open) => {
-        openRef.current = !open
-        return openRef.current
-      })
-      if (!openRef.current) {
-        onClose?.()
-      }
-    }, [onClose])
-
-    const openDrawer = useCallback(() => {
-      setDrawerOpen(true)
-      openRef.current = true
-    }, [])
-
-    const closeDrawer = useCallback(() => {
-      setDrawerOpen(false)
-      openRef.current = false
+  const toggleDrawer = useCallback(() => {
+    setDrawerOpen((open) => {
+      openRef.current = !open
+      return openRef.current
+    })
+    if (!openRef.current) {
       onClose?.()
-    }, [onClose])
+    }
+  }, [onClose])
 
-    useImperativeHandle(
-      ref,
-      () => ({
-        isOpen: () => openRef.current,
-        toggleDrawer,
-        openDrawer,
-        closeDrawer,
-      }),
-      [closeDrawer, openDrawer, toggleDrawer]
-    )
+  const openDrawer = useCallback(() => {
+    setDrawerOpen(true)
+    openRef.current = true
+  }, [])
 
-    const drawerContext: WidgetDrawerContext = useMemo(
-      () => ({
-        closeDrawer,
-      }),
-      [closeDrawer]
-    )
+  const closeDrawer = useCallback(() => {
+    setDrawerOpen(false)
+    openRef.current = false
+    onClose?.()
+  }, [onClose])
 
-    return (
-      <DrawerContext.Provider value={drawerContext}>
-        <Drawer
-          ref={elementRef}
-          anchor="right"
-          open={drawerOpen}
-          onClose={closeDrawer}
-          slotProps={{
-            paper: {
-              sx: (theme) => ({
-                background: theme.vars.palette.background.default,
-                width: theme?.container?.width ?? '100%',
-                minWidth:
-                  theme?.container?.minWidth ?? theme.breakpoints.values.xs,
-                maxWidth:
-                  theme?.container?.maxWidth ?? theme.breakpoints.values.sm,
-              }),
+  useImperativeHandle(
+    ref,
+    () => ({
+      isOpen: () => openRef.current,
+      toggleDrawer,
+      openDrawer,
+      closeDrawer,
+    }),
+    [closeDrawer, openDrawer, toggleDrawer]
+  )
+
+  const drawerContext: WidgetDrawerContext = useMemo(
+    () => ({
+      closeDrawer,
+    }),
+    [closeDrawer]
+  )
+
+  return (
+    <DrawerContext value={drawerContext}>
+      <Drawer
+        ref={elementRef}
+        anchor="right"
+        open={drawerOpen}
+        onClose={closeDrawer}
+        slotProps={{
+          paper: {
+            sx: (theme) => ({
+              background: theme.vars.palette.background.default,
+              width: theme?.container?.width ?? '100%',
+              minWidth:
+                theme?.container?.minWidth ?? theme.breakpoints.values.xs,
+              maxWidth:
+                theme?.container?.maxWidth ?? theme.breakpoints.values.sm,
+            }),
+          },
+          backdrop: {
+            sx: {
+              backgroundColor: 'rgb(0 0 0 / 48%)',
+              backdropFilter: 'blur(3px)',
             },
-            backdrop: {
-              sx: {
-                backgroundColor: 'rgb(0 0 0 / 48%)',
-                backdropFilter: 'blur(3px)',
-              },
-            },
-          }}
-          keepMounted
-        >
-          {children}
-        </Drawer>
-      </DrawerContext.Provider>
-    )
-  }
-)
+          },
+        }}
+        keepMounted
+      >
+        {children}
+      </Drawer>
+    </DrawerContext>
+  )
+}

--- a/packages/widget/src/AppDrawerContext.ts
+++ b/packages/widget/src/AppDrawerContext.ts
@@ -1,4 +1,4 @@
-import { type Context, createContext, useContext } from 'react'
+import { type Context, createContext, use } from 'react'
 
 export interface WidgetDrawerContext {
   closeDrawer?(): void
@@ -7,4 +7,4 @@ export interface WidgetDrawerContext {
 export const DrawerContext: Context<WidgetDrawerContext> =
   createContext<WidgetDrawerContext>({})
 
-export const useDrawer = (): WidgetDrawerContext => useContext(DrawerContext)
+export const useDrawer = (): WidgetDrawerContext => use(DrawerContext)

--- a/packages/widget/src/components/BottomSheet/BottomSheet.tsx
+++ b/packages/widget/src/components/BottomSheet/BottomSheet.tsx
@@ -1,7 +1,6 @@
 import { Drawer } from '@mui/material'
-import type { ForwardRefExoticComponent, RefAttributes } from 'react'
+import type { JSX, Ref } from 'react'
 import {
-  forwardRef,
   startTransition,
   useCallback,
   useImperativeHandle,
@@ -12,56 +11,61 @@ import { useGetScrollableContainer } from '../../hooks/useScrollableContainer.js
 import { modalProps, slotProps } from '../Dialog/Dialog.js'
 import type { BottomSheetBase, BottomSheetProps } from './types.js'
 
-export const BottomSheet: ForwardRefExoticComponent<
-  Omit<BottomSheetProps, 'ref'> & RefAttributes<BottomSheetBase>
-> = forwardRef<BottomSheetBase, BottomSheetProps>(
-  ({ elementRef, children, open, onClose, keepMounted = false }, ref) => {
-    const getContainer = useGetScrollableContainer()
-    const openRef = useRef(open)
-    const [drawerOpen, setDrawerOpen] = useState(open)
-    const [isInert, setIsInert] = useState(!open)
+export const BottomSheet = ({
+  elementRef,
+  children,
+  open,
+  onClose,
+  keepMounted = false,
+  ref,
+}: Omit<BottomSheetProps, 'ref'> & {
+  ref?: Ref<BottomSheetBase>
+}): JSX.Element => {
+  const getContainer = useGetScrollableContainer()
+  const openRef = useRef(open)
+  const [drawerOpen, setDrawerOpen] = useState(open)
+  const [isInert, setIsInert] = useState(!open)
 
-    const close = useCallback(() => {
-      // Set inert first to prevent focus issues
-      setIsInert(true)
-      // Push the state update to the next event loop tick
-      // to ensure the inert is applied to before the drawer is closed
-      startTransition(() => {
-        setDrawerOpen(false)
-        openRef.current = false
-        onClose?.()
-      })
-    }, [onClose])
+  const close = useCallback(() => {
+    // Set inert first to prevent focus issues
+    setIsInert(true)
+    // Push the state update to the next event loop tick
+    // to ensure the inert is applied to before the drawer is closed
+    startTransition(() => {
+      setDrawerOpen(false)
+      openRef.current = false
+      onClose?.()
+    })
+  }, [onClose])
 
-    useImperativeHandle(
-      ref,
-      () => ({
-        isOpen: () => openRef.current,
-        open: () => {
-          setIsInert(false)
-          setDrawerOpen(true)
-          openRef.current = true
-        },
-        close,
-      }),
-      [close]
-    )
+  useImperativeHandle(
+    ref,
+    () => ({
+      isOpen: () => openRef.current,
+      open: () => {
+        setIsInert(false)
+        setDrawerOpen(true)
+        openRef.current = true
+      },
+      close,
+    }),
+    [close]
+  )
 
-    return (
-      <Drawer
-        container={getContainer}
-        ref={elementRef}
-        anchor="bottom"
-        open={drawerOpen}
-        onClose={close}
-        ModalProps={modalProps}
-        slotProps={slotProps}
-        disableAutoFocus
-        keepMounted={keepMounted}
-        inert={isInert}
-      >
-        {children}
-      </Drawer>
-    )
-  }
-)
+  return (
+    <Drawer
+      container={getContainer}
+      ref={elementRef}
+      anchor="bottom"
+      open={drawerOpen}
+      onClose={close}
+      ModalProps={modalProps}
+      slotProps={slotProps}
+      disableAutoFocus
+      keepMounted={keepMounted}
+      inert={isInert}
+    >
+      {children}
+    </Drawer>
+  )
+}

--- a/packages/widget/src/components/Header/Header.tsx
+++ b/packages/widget/src/components/Header/Header.tsx
@@ -1,6 +1,6 @@
 import { useLocation } from '@tanstack/react-router'
 import type { FC, PropsWithChildren } from 'react'
-import { useLayoutEffect, useRef } from 'react'
+import { useCallback } from 'react'
 import { useDefaultElementId } from '../../hooks/useDefaultElementId.js'
 import { useSetHeaderHeight } from '../../stores/header/useHeaderStore.js'
 import { createElementId, ElementId } from '../../utils/elements.js'
@@ -12,31 +12,33 @@ import { WalletHeader } from './WalletHeader.js'
 const HeaderContainer: FC<PropsWithChildren> = ({ children }) => {
   const { pathname } = useLocation()
   const elementId = useDefaultElementId()
-  const headerRef = useRef<HTMLDivElement>(null)
   const { setHeaderHeight } = useSetHeaderHeight()
 
-  useLayoutEffect(() => {
-    const handleHeaderResize = () => {
-      const height = headerRef.current?.getBoundingClientRect().height
-
-      if (height) {
-        setHeaderHeight(height)
+  // React 19 ref cleanup callback: set up the ResizeObserver when the node
+  // mounts and tear it down when it unmounts.
+  const headerRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      if (!node) {
+        return
       }
-    }
 
-    let resizeObserver: ResizeObserver
+      const handleHeaderResize = () => {
+        const height = node.getBoundingClientRect().height
 
-    if (headerRef.current) {
-      resizeObserver = new ResizeObserver(handleHeaderResize)
-      resizeObserver.observe(headerRef.current)
-    }
+        if (height) {
+          setHeaderHeight(height)
+        }
+      }
 
-    return () => {
-      if (resizeObserver) {
+      const resizeObserver = new ResizeObserver(handleHeaderResize)
+      resizeObserver.observe(node)
+
+      return () => {
         resizeObserver.disconnect()
       }
-    }
-  }, [setHeaderHeight])
+    },
+    [setHeaderHeight]
+  )
 
   return (
     <Container

--- a/packages/widget/src/components/TokenList/TokenDetailsSheet.tsx
+++ b/packages/widget/src/components/TokenList/TokenDetailsSheet.tsx
@@ -1,13 +1,15 @@
-import type React from 'react'
-import { forwardRef, useImperativeHandle, useRef, useState } from 'react'
+import type { JSX, Ref } from 'react'
+import { useImperativeHandle, useRef, useState } from 'react'
 import { BottomSheet } from '../BottomSheet/BottomSheet.js'
 import type { BottomSheetBase } from '../BottomSheet/types.js'
 import { TokenDetailsSheetContent } from './TokenDetailsSheetContent.js'
 import type { TokenDetailsSheetBase } from './types.js'
 
-export const TokenDetailsSheet: React.ForwardRefExoticComponent<
-  React.RefAttributes<TokenDetailsSheetBase>
-> = forwardRef<TokenDetailsSheetBase>((_, ref) => {
+export const TokenDetailsSheet = ({
+  ref,
+}: {
+  ref?: Ref<TokenDetailsSheetBase>
+}): JSX.Element => {
   const bottomSheetRef = useRef<BottomSheetBase>(null)
   const [tokenAddress, setTokenAddress] = useState<string | undefined>(
     undefined
@@ -42,4 +44,4 @@ export const TokenDetailsSheet: React.ForwardRefExoticComponent<
       />
     </BottomSheet>
   )
-})
+}

--- a/packages/widget/src/components/TokenList/TokenDetailsSheet.tsx
+++ b/packages/widget/src/components/TokenList/TokenDetailsSheet.tsx
@@ -37,7 +37,7 @@ export const TokenDetailsSheet = ({
   return (
     <BottomSheet ref={bottomSheetRef} keepMounted>
       <TokenDetailsSheetContent
-        ref={ref}
+        onClose={() => bottomSheetRef.current?.close()}
         tokenAddress={tokenAddress}
         withoutContractAddress={withoutContractAddress}
         chainId={chainId}

--- a/packages/widget/src/components/TokenList/TokenDetailsSheetContent.tsx
+++ b/packages/widget/src/components/TokenList/TokenDetailsSheetContent.tsx
@@ -3,7 +3,7 @@ import ContentCopyRounded from '@mui/icons-material/ContentCopyRounded'
 import OpenInNewRounded from '@mui/icons-material/OpenInNewRounded'
 import { Box, IconButton, Link, Skeleton, Typography } from '@mui/material'
 import type React from 'react'
-import { forwardRef, type PropsWithChildren, useMemo } from 'react'
+import { type JSX, type PropsWithChildren, type Ref, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useAvailableChains } from '../../hooks/useAvailableChains.js'
 import { useExplorer } from '../../hooks/useExplorer.js'
@@ -27,198 +27,201 @@ interface TokenDetailsSheetContentProps {
 
 const noDataLabel = '-'
 
-export const TokenDetailsSheetContent: React.ForwardRefExoticComponent<
-  TokenDetailsSheetContentProps & React.RefAttributes<TokenDetailsSheetBase>
-> = forwardRef<TokenDetailsSheetBase, TokenDetailsSheetContentProps>(
-  ({ tokenAddress, chainId, withoutContractAddress }, ref) => {
-    const { t } = useTranslation()
-    const { getAddressLink } = useExplorer()
-    const { getChainById } = useAvailableChains()
+export const TokenDetailsSheetContent = ({
+  tokenAddress,
+  chainId,
+  withoutContractAddress,
+  ref,
+}: TokenDetailsSheetContentProps & {
+  ref?: Ref<TokenDetailsSheetBase>
+}): JSX.Element => {
+  const { t } = useTranslation()
+  const { getAddressLink } = useExplorer()
+  const { getChainById } = useAvailableChains()
 
-    const { token, isLoading } = useToken(chainId, tokenAddress, true)
-    const chain = useMemo(() => getChainById(chainId), [chainId, getChainById])
+  const { token, isLoading } = useToken(chainId, tokenAddress, true)
+  const chain = useMemo(() => getChainById(chainId), [chainId, getChainById])
 
-    const copyContractAddress = async (e: React.MouseEvent) => {
-      e.stopPropagation()
-      try {
-        // Clipboard API may throw if access is denied (e.g., in insecure contexts or older browsers)
-        await navigator.clipboard.writeText(tokenAddress || '')
-      } catch {
-        // Silently fail to avoid crashing the UI if clipboard write fails
-      }
+  const copyContractAddress = async (e: React.MouseEvent) => {
+    e.stopPropagation()
+    try {
+      // Clipboard API may throw if access is denied (e.g., in insecure contexts or older browsers)
+      await navigator.clipboard.writeText(tokenAddress || '')
+    } catch {
+      // Silently fail to avoid crashing the UI if clipboard write fails
     }
+  }
 
-    return (
-      <TokenDetailsSheetContainer>
-        <TokenDetailsSheetHeader>
+  return (
+    <TokenDetailsSheetContainer>
+      <TokenDetailsSheetHeader>
+        <Box
+          sx={{
+            display: 'flex',
+            flexDirection: 'row',
+            alignItems: 'center',
+            gap: 3,
+          }}
+        >
+          <TokenAvatar
+            token={token}
+            chain={chain}
+            tokenAvatarSize={72}
+            chainAvatarSize={28}
+            isLoading={isLoading}
+          />
+          <MetricContainer>
+            {isLoading ? (
+              <>
+                <Skeleton variant="rounded" width={80} height={24} />
+                <Skeleton variant="rounded" width={80} height={16} />
+              </>
+            ) : (
+              <>
+                <Typography
+                  sx={{
+                    fontWeight: 700,
+                    fontSize: '24px',
+                    lineHeight: '24px',
+                    color: 'text.primary',
+                  }}
+                >
+                  {token?.symbol || noDataLabel}
+                </Typography>
+                <Label>{token?.name || noDataLabel}</Label>
+              </>
+            )}
+          </MetricContainer>
+        </Box>
+        <IconButton
+          onClick={(e) => {
+            e.stopPropagation()
+            if (ref && typeof ref !== 'function') {
+              ref.current?.close()
+            }
+          }}
+          sx={{ mt: '-8px', mr: '-8px' }}
+        >
+          <Close />
+        </IconButton>
+      </TokenDetailsSheetHeader>
+      <MetricWithSkeleton
+        isLoading={isLoading}
+        label={t('tokenMetric.currentPrice')}
+        width={200}
+        height={40}
+      >
+        <Typography
+          sx={{
+            fontWeight: 700,
+            fontSize: '32px',
+            lineHeight: '40px',
+            color: 'text.primary',
+          }}
+        >
+          {token?.priceUSD
+            ? t('format.currency', {
+                value: token.priceUSD,
+              })
+            : noDataLabel}
+        </Typography>
+      </MetricWithSkeleton>
+      {!withoutContractAddress && (
+        <MetricWithSkeleton
+          isLoading={isLoading}
+          label={t('tokenMetric.contractAddress')}
+          width={200}
+          height={24}
+        >
           <Box
             sx={{
               display: 'flex',
               flexDirection: 'row',
               alignItems: 'center',
-              gap: 3,
+              gap: 1,
             }}
           >
-            <TokenAvatar
-              token={token}
-              chain={chain}
-              tokenAvatarSize={72}
-              chainAvatarSize={28}
-              isLoading={isLoading}
-            />
-            <MetricContainer>
-              {isLoading ? (
-                <>
-                  <Skeleton variant="rounded" width={80} height={24} />
-                  <Skeleton variant="rounded" width={80} height={16} />
-                </>
-              ) : (
-                <>
-                  <Typography
-                    sx={{
-                      fontWeight: 700,
-                      fontSize: '24px',
-                      lineHeight: '24px',
-                      color: 'text.primary',
-                    }}
-                  >
-                    {token?.symbol || noDataLabel}
-                  </Typography>
-                  <Label>{token?.name || noDataLabel}</Label>
-                </>
-              )}
-            </MetricContainer>
-          </Box>
-          <IconButton
-            onClick={(e) => {
-              e.stopPropagation()
-              if (ref && typeof ref !== 'function') {
-                ref.current?.close()
-              }
-            }}
-            sx={{ mt: '-8px', mr: '-8px' }}
-          >
-            <Close />
-          </IconButton>
-        </TokenDetailsSheetHeader>
-        <MetricWithSkeleton
-          isLoading={isLoading}
-          label={t('tokenMetric.currentPrice')}
-          width={200}
-          height={40}
-        >
-          <Typography
-            sx={{
-              fontWeight: 700,
-              fontSize: '32px',
-              lineHeight: '40px',
-              color: 'text.primary',
-            }}
-          >
-            {token?.priceUSD
-              ? t('format.currency', {
-                  value: token.priceUSD,
-                })
-              : noDataLabel}
-          </Typography>
-        </MetricWithSkeleton>
-        {!withoutContractAddress && (
-          <MetricWithSkeleton
-            isLoading={isLoading}
-            label={t('tokenMetric.contractAddress')}
-            width={200}
-            height={24}
-          >
-            <Box
+            <Typography
               sx={{
-                display: 'flex',
-                flexDirection: 'row',
-                alignItems: 'center',
-                gap: 1,
+                fontWeight: 700,
+                fontSize: '18px',
+                lineHeight: '24px',
+                color: 'text.primary',
               }}
             >
-              <Typography
-                sx={{
-                  fontWeight: 700,
-                  fontSize: '18px',
-                  lineHeight: '24px',
-                  color: 'text.primary',
-                }}
+              {shortenAddress(tokenAddress)}
+            </Typography>
+            {tokenAddress && (
+              <CardIconButton size="small" onClick={copyContractAddress}>
+                <ContentCopyRounded fontSize="inherit" />
+              </CardIconButton>
+            )}
+            {tokenAddress && (
+              <CardIconButton
+                size="small"
+                LinkComponent={Link}
+                href={getAddressLink(tokenAddress, chainId)}
+                target="_blank"
+                rel="nofollow noreferrer"
+                onClick={(e) => e.stopPropagation()}
               >
-                {shortenAddress(tokenAddress)}
-              </Typography>
-              {tokenAddress && (
-                <CardIconButton size="small" onClick={copyContractAddress}>
-                  <ContentCopyRounded fontSize="inherit" />
-                </CardIconButton>
-              )}
-              {tokenAddress && (
-                <CardIconButton
-                  size="small"
-                  LinkComponent={Link}
-                  href={getAddressLink(tokenAddress, chainId)}
-                  target="_blank"
-                  rel="nofollow noreferrer"
-                  onClick={(e) => e.stopPropagation()}
-                >
-                  <OpenInNewRounded fontSize="inherit" />
-                </CardIconButton>
-              )}
-            </Box>
-          </MetricWithSkeleton>
-        )}
-        <MetricWithSkeleton
-          isLoading={isLoading}
-          label={t('tokenMetric.marketCap')}
-          width={200}
-          height={24}
-        >
-          <Typography
-            sx={{
-              fontWeight: 700,
-              fontSize: '18px',
-              lineHeight: '24px',
-              color: 'text.primary',
-            }}
-          >
-            {token?.marketCapUSD
-              ? t('format.currency', {
-                  value: token.marketCapUSD,
-                  notation: 'compact',
-                  compactDisplay: 'short',
-                  maximumFractionDigits: 2,
-                })
-              : noDataLabel}
-          </Typography>
+                <OpenInNewRounded fontSize="inherit" />
+              </CardIconButton>
+            )}
+          </Box>
         </MetricWithSkeleton>
-        <MetricWithSkeleton
-          isLoading={isLoading}
-          label={t('tokenMetric.volume24h')}
-          width={200}
-          height={24}
+      )}
+      <MetricWithSkeleton
+        isLoading={isLoading}
+        label={t('tokenMetric.marketCap')}
+        width={200}
+        height={24}
+      >
+        <Typography
+          sx={{
+            fontWeight: 700,
+            fontSize: '18px',
+            lineHeight: '24px',
+            color: 'text.primary',
+          }}
         >
-          <Typography
-            sx={{
-              fontWeight: 700,
-              fontSize: '18px',
-              lineHeight: '24px',
-              color: 'text.primary',
-            }}
-          >
-            {token?.volumeUSD24H
-              ? t('format.currency', {
-                  value: token.volumeUSD24H,
-                  notation: 'compact',
-                  compactDisplay: 'short',
-                  maximumFractionDigits: 2,
-                })
-              : noDataLabel}
-          </Typography>
-        </MetricWithSkeleton>
-      </TokenDetailsSheetContainer>
-    )
-  }
-)
+          {token?.marketCapUSD
+            ? t('format.currency', {
+                value: token.marketCapUSD,
+                notation: 'compact',
+                compactDisplay: 'short',
+                maximumFractionDigits: 2,
+              })
+            : noDataLabel}
+        </Typography>
+      </MetricWithSkeleton>
+      <MetricWithSkeleton
+        isLoading={isLoading}
+        label={t('tokenMetric.volume24h')}
+        width={200}
+        height={24}
+      >
+        <Typography
+          sx={{
+            fontWeight: 700,
+            fontSize: '18px',
+            lineHeight: '24px',
+            color: 'text.primary',
+          }}
+        >
+          {token?.volumeUSD24H
+            ? t('format.currency', {
+                value: token.volumeUSD24H,
+                notation: 'compact',
+                compactDisplay: 'short',
+                maximumFractionDigits: 2,
+              })
+            : noDataLabel}
+        </Typography>
+      </MetricWithSkeleton>
+    </TokenDetailsSheetContainer>
+  )
+}
 
 interface MetricWithSkeletonProps {
   label: string

--- a/packages/widget/src/components/TokenList/TokenDetailsSheetContent.tsx
+++ b/packages/widget/src/components/TokenList/TokenDetailsSheetContent.tsx
@@ -3,7 +3,7 @@ import ContentCopyRounded from '@mui/icons-material/ContentCopyRounded'
 import OpenInNewRounded from '@mui/icons-material/OpenInNewRounded'
 import { Box, IconButton, Link, Skeleton, Typography } from '@mui/material'
 import type React from 'react'
-import { type JSX, type PropsWithChildren, type Ref, useMemo } from 'react'
+import { type JSX, type PropsWithChildren, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useAvailableChains } from '../../hooks/useAvailableChains.js'
 import { useExplorer } from '../../hooks/useExplorer.js'
@@ -17,12 +17,12 @@ import {
   TokenDetailsSheetContainer,
   TokenDetailsSheetHeader,
 } from './TokenDetailsSheetContent.style.js'
-import type { TokenDetailsSheetBase } from './types.js'
 
 interface TokenDetailsSheetContentProps {
   tokenAddress: string | undefined
   chainId: number | undefined
   withoutContractAddress: boolean
+  onClose: () => void
 }
 
 const noDataLabel = '-'
@@ -31,10 +31,8 @@ export const TokenDetailsSheetContent = ({
   tokenAddress,
   chainId,
   withoutContractAddress,
-  ref,
-}: TokenDetailsSheetContentProps & {
-  ref?: Ref<TokenDetailsSheetBase>
-}): JSX.Element => {
+  onClose,
+}: TokenDetailsSheetContentProps): JSX.Element => {
   const { t } = useTranslation()
   const { getAddressLink } = useExplorer()
   const { getChainById } = useAvailableChains()
@@ -96,9 +94,7 @@ export const TokenDetailsSheetContent = ({
         <IconButton
           onClick={(e) => {
             e.stopPropagation()
-            if (ref && typeof ref !== 'function') {
-              ref.current?.close()
-            }
+            onClose()
           }}
           sx={{ mt: '-8px', mr: '-8px' }}
         >

--- a/packages/widget/src/pages/SendToWallet/BookmarkAddressSheet.tsx
+++ b/packages/widget/src/pages/SendToWallet/BookmarkAddressSheet.tsx
@@ -2,13 +2,8 @@ import ErrorIcon from '@mui/icons-material/Error'
 import TurnedIn from '@mui/icons-material/TurnedIn'
 import WarningRounded from '@mui/icons-material/WarningRounded'
 import { Button, Typography } from '@mui/material'
-import type { ChangeEvent, RefObject } from 'react'
-import {
-  type ForwardRefExoticComponent,
-  forwardRef,
-  type RefAttributes,
-  useState,
-} from 'react'
+import type { ChangeEvent, JSX, Ref, RefObject } from 'react'
+import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { BottomSheet } from '../../components/BottomSheet/BottomSheet.js'
 import type { BottomSheetBase } from '../../components/BottomSheet/types.js'
@@ -35,213 +30,209 @@ interface BookmarkAddressProps {
   validatedWallet?: Bookmark
 }
 
-export const BookmarkAddressSheet: ForwardRefExoticComponent<
-  BookmarkAddressProps & RefAttributes<BottomSheetBase>
-> = forwardRef<BottomSheetBase, BookmarkAddressProps>(
-  ({ validatedWallet, onAddBookmark }, ref) => {
-    const { t } = useTranslation()
-    const [name, setName] = useState('')
-    const [address, setAddress] = useState('')
-    const [error, setError] = useState<BookmarkError>()
-    const { validateAddress, isValidating } = useAddressValidation()
-    const { getBookmark } = useBookmarkActions()
+export const BookmarkAddressSheet = ({
+  validatedWallet,
+  onAddBookmark,
+  ref,
+}: BookmarkAddressProps & {
+  ref?: Ref<BottomSheetBase>
+}): JSX.Element => {
+  const { t } = useTranslation()
+  const [name, setName] = useState('')
+  const [address, setAddress] = useState('')
+  const [error, setError] = useState<BookmarkError>()
+  const { validateAddress, isValidating } = useAddressValidation()
+  const { getBookmark } = useBookmarkActions()
 
-    const nameValue = name.trim() || validatedWallet?.name || ''
-    const addressValue = address || validatedWallet?.address || ''
+  const nameValue = name.trim() || validatedWallet?.name || ''
+  const addressValue = address || validatedWallet?.address || ''
 
-    const handleCancel = () => {
+  const handleCancel = () => {
+    setError(undefined)
+    ;(ref as RefObject<BottomSheetBase>).current?.close()
+  }
+
+  const validateWithAddressFromInput = async () => {
+    const validationResult = await validateAddress({ value: address })
+    if (!validationResult.isValid) {
+      setError({ type: 'address', message: validationResult.error })
+      return
+    }
+
+    return {
+      name: nameValue,
+      address: validationResult.address,
+      chainType: validationResult.chainType,
+    }
+  }
+
+  const validateWithValidatedWallet = (validatedWallet: Bookmark) => {
+    if (error) {
       setError(undefined)
-      ;(ref as RefObject<BottomSheetBase>).current?.close()
+    }
+    return {
+      name: nameValue,
+      address: validatedWallet.address,
+      chainType: validatedWallet.chainType,
+    }
+  }
+
+  const handleBookmark = async () => {
+    if (isValidating) {
+      return
+    }
+    if (!nameValue) {
+      setError({
+        type: 'name',
+        message: t('error.title.bookmarkNameRequired'),
+      })
+      return
+    }
+    if (!addressValue) {
+      setError({
+        type: 'address',
+        message: t('error.title.walletAddressRequired'),
+      })
+      return
     }
 
-    const validateWithAddressFromInput = async () => {
-      const validationResult = await validateAddress({ value: address })
-      if (!validationResult.isValid) {
-        setError({ type: 'address', message: validationResult.error })
-        return
-      }
+    //  If the validatedWallet is supplied as a prop then we should assume
+    //  the address has already been validated
+    const validatedBookmark = validatedWallet
+      ? validateWithValidatedWallet(validatedWallet)
+      : await validateWithAddressFromInput()
 
-      return {
-        name: nameValue,
-        address: validationResult.address,
-        chainType: validationResult.chainType,
-      }
-    }
-
-    const validateWithValidatedWallet = (validatedWallet: Bookmark) => {
-      if (error) {
-        setError(undefined)
-      }
-      return {
-        name: nameValue,
-        address: validatedWallet.address,
-        chainType: validatedWallet.chainType,
-      }
-    }
-
-    const handleBookmark = async () => {
-      if (isValidating) {
-        return
-      }
-      if (!nameValue) {
-        setError({
-          type: 'name',
-          message: t('error.title.bookmarkNameRequired'),
-        })
-        return
-      }
-      if (!addressValue) {
+    if (validatedBookmark) {
+      const existingBookmark = getBookmark(validatedBookmark.address)
+      if (existingBookmark) {
         setError({
           type: 'address',
-          message: t('error.title.walletAddressRequired'),
+          message: t('error.title.bookmarkAlreadyExists', {
+            name: existingBookmark.name,
+          }),
         })
         return
       }
+      ;(ref as RefObject<BottomSheetBase>).current?.close()
 
-      //  If the validatedWallet is supplied as a prop then we should assume
-      //  the address has already been validated
-      const validatedBookmark = validatedWallet
-        ? validateWithValidatedWallet(validatedWallet)
-        : await validateWithAddressFromInput()
-
-      if (validatedBookmark) {
-        const existingBookmark = getBookmark(validatedBookmark.address)
-        if (existingBookmark) {
-          setError({
-            type: 'address',
-            message: t('error.title.bookmarkAlreadyExists', {
-              name: existingBookmark.name,
-            }),
-          })
-          return
-        }
-        ;(ref as RefObject<BottomSheetBase>).current?.close()
-
-        onAddBookmark({
-          name: validatedBookmark.name,
-          address: validatedBookmark.address,
-          chainType: validatedBookmark.chainType,
-        })
-      }
+      onAddBookmark({
+        name: validatedBookmark.name,
+        address: validatedBookmark.address,
+        chainType: validatedBookmark.chainType,
+      })
     }
+  }
 
-    const handleAddressInputChange = (e: ChangeEvent) => {
-      if (error) {
-        setError(undefined)
-      }
-      setAddress((e.target as HTMLInputElement).value.trim())
+  const handleAddressInputChange = (e: ChangeEvent) => {
+    if (error) {
+      setError(undefined)
     }
+    setAddress((e.target as HTMLInputElement).value.trim())
+  }
 
-    const handleNameInputChange = (e: ChangeEvent) => {
-      if (error) {
-        setError(undefined)
-      }
-      setName((e.target as HTMLInputElement).value)
+  const handleNameInputChange = (e: ChangeEvent) => {
+    if (error) {
+      setError(undefined)
     }
+    setName((e.target as HTMLInputElement).value)
+  }
 
-    const resetValues = () => {
-      setName('')
-      setAddress('')
-    }
+  const resetValues = () => {
+    setName('')
+    setAddress('')
+  }
 
-    return (
-      <BottomSheet ref={ref} onClose={resetValues}>
-        <SendToWalletSheetContainer>
-          <IconContainer>
-            <TurnedIn sx={{ fontSize: 40 }} />
-          </IconContainer>
-          <SheetTitle>{t('sendToWallet.bookmarkWallet')}</SheetTitle>
-          {validatedWallet ? (
-            <SheetAddressContainer>
-              {validatedWallet?.name ? (
-                <Typography
-                  sx={{
-                    fontWeight: 600,
-                    mb: 0.5,
-                  }}
-                >
-                  {validatedWallet?.name}
-                </Typography>
-              ) : null}
-              <Typography>{validatedWallet?.address}</Typography>
-            </SheetAddressContainer>
-          ) : null}
-          <BookmarkInputFields>
+  return (
+    <BottomSheet ref={ref} onClose={resetValues}>
+      <SendToWalletSheetContainer>
+        <IconContainer>
+          <TurnedIn sx={{ fontSize: 40 }} />
+        </IconContainer>
+        <SheetTitle>{t('sendToWallet.bookmarkWallet')}</SheetTitle>
+        {validatedWallet ? (
+          <SheetAddressContainer>
+            {validatedWallet?.name ? (
+              <Typography
+                sx={{
+                  fontWeight: 600,
+                  mb: 0.5,
+                }}
+              >
+                {validatedWallet?.name}
+              </Typography>
+            ) : null}
+            <Typography>{validatedWallet?.address}</Typography>
+          </SheetAddressContainer>
+        ) : null}
+        <BookmarkInputFields>
+          <SendToWalletCard type={error?.type === 'name' ? 'error' : 'default'}>
+            <Input
+              size="small"
+              autoComplete="off"
+              autoCorrect="off"
+              autoCapitalize="off"
+              spellCheck="false"
+              onChange={handleNameInputChange}
+              value={name}
+              placeholder={validatedWallet?.name || t('sendToWallet.enterName')}
+              aria-label={validatedWallet?.name || t('sendToWallet.enterName')}
+              inputProps={{ maxLength: 128 }}
+            />
+          </SendToWalletCard>
+          {!validatedWallet && (
             <SendToWalletCard
-              type={error?.type === 'name' ? 'error' : 'default'}
+              type={error?.type === 'address' ? 'error' : 'default'}
             >
-              <Input
+              <AddressInput
                 size="small"
                 autoComplete="off"
                 autoCorrect="off"
                 autoCapitalize="off"
                 spellCheck="false"
-                onChange={handleNameInputChange}
-                value={name}
-                placeholder={
-                  validatedWallet?.name || t('sendToWallet.enterName')
-                }
-                aria-label={
-                  validatedWallet?.name || t('sendToWallet.enterName')
-                }
+                onChange={handleAddressInputChange}
+                value={address}
+                placeholder={t('sendToWallet.enterAddress', {
+                  context: 'long',
+                })}
+                aria-label={t('sendToWallet.enterAddress', {
+                  context: 'long',
+                })}
+                maxRows={2}
                 inputProps={{ maxLength: 128 }}
+                multiline
               />
             </SendToWalletCard>
-            {!validatedWallet && (
-              <SendToWalletCard
-                type={error?.type === 'address' ? 'error' : 'default'}
-              >
-                <AddressInput
-                  size="small"
-                  autoComplete="off"
-                  autoCorrect="off"
-                  autoCapitalize="off"
-                  spellCheck="false"
-                  onChange={handleAddressInputChange}
-                  value={address}
-                  placeholder={t('sendToWallet.enterAddress', {
-                    context: 'long',
-                  })}
-                  aria-label={t('sendToWallet.enterAddress', {
-                    context: 'long',
-                  })}
-                  maxRows={2}
-                  inputProps={{ maxLength: 128 }}
-                  multiline
-                />
-              </SendToWalletCard>
-            )}
-            {error ? (
-              <ValidationAlert icon={<ErrorIcon />}>
-                {error.message}
-              </ValidationAlert>
-            ) : null}
-          </BookmarkInputFields>
-          <AlertMessage
-            title={
-              <Typography variant="body2" sx={{ color: 'text.primary' }}>
-                {t('warning.message.fundsLossPrevention')}
-              </Typography>
-            }
-            icon={<WarningRounded />}
-          />
-          <SendToWalletButtonRow>
-            <Button variant="text" onClick={handleCancel} fullWidth>
-              {t('button.cancel')}
-            </Button>
-            <Button
-              variant="contained"
-              onClick={handleBookmark}
-              loading={isValidating}
-              loadingPosition="center"
-              fullWidth
-              focusRipple
-            >
-              {t('button.bookmark')}
-            </Button>
-          </SendToWalletButtonRow>
-        </SendToWalletSheetContainer>
-      </BottomSheet>
-    )
-  }
-)
+          )}
+          {error ? (
+            <ValidationAlert icon={<ErrorIcon />}>
+              {error.message}
+            </ValidationAlert>
+          ) : null}
+        </BookmarkInputFields>
+        <AlertMessage
+          title={
+            <Typography variant="body2" sx={{ color: 'text.primary' }}>
+              {t('warning.message.fundsLossPrevention')}
+            </Typography>
+          }
+          icon={<WarningRounded />}
+        />
+        <SendToWalletButtonRow>
+          <Button variant="text" onClick={handleCancel} fullWidth>
+            {t('button.cancel')}
+          </Button>
+          <Button
+            variant="contained"
+            onClick={handleBookmark}
+            loading={isValidating}
+            loadingPosition="center"
+            fullWidth
+            focusRipple
+          >
+            {t('button.bookmark')}
+          </Button>
+        </SendToWalletButtonRow>
+      </SendToWalletSheetContainer>
+    </BottomSheet>
+  )
+}

--- a/packages/widget/src/pages/SendToWallet/ConfirmAddressSheet.tsx
+++ b/packages/widget/src/pages/SendToWallet/ConfirmAddressSheet.tsx
@@ -1,8 +1,8 @@
 import Wallet from '@mui/icons-material/Wallet'
 import WarningRounded from '@mui/icons-material/WarningRounded'
 import { Button, Typography } from '@mui/material'
-import type { ForwardRefExoticComponent, RefAttributes, RefObject } from 'react'
-import { forwardRef, useRef } from 'react'
+import type { JSX, Ref, RefObject } from 'react'
+import { useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { BottomSheet } from '../../components/BottomSheet/BottomSheet.js'
 import type { BottomSheetBase } from '../../components/BottomSheet/types.js'
@@ -28,9 +28,12 @@ interface ConfirmAddressSheetContentProps extends ConfirmAddressSheetProps {
   onClose: () => void
 }
 
-export const ConfirmAddressSheet: ForwardRefExoticComponent<
-  ConfirmAddressSheetProps & RefAttributes<BottomSheetBase>
-> = forwardRef<BottomSheetBase, ConfirmAddressSheetProps>((props, ref) => {
+export const ConfirmAddressSheet = ({
+  ref,
+  ...props
+}: ConfirmAddressSheetProps & {
+  ref?: Ref<BottomSheetBase>
+}): JSX.Element => {
   const handleClose = () => {
     ;(ref as RefObject<BottomSheetBase>).current?.close()
   }
@@ -40,7 +43,7 @@ export const ConfirmAddressSheet: ForwardRefExoticComponent<
       <ConfirmAddressSheetContent {...props} onClose={handleClose} />
     </BottomSheet>
   )
-})
+}
 
 const ConfirmAddressSheetContent: React.FC<ConfirmAddressSheetContentProps> = ({
   validatedBookmark,

--- a/packages/widget/src/pages/SettingsPage/SettingsCard/SettingCardExpandable.tsx
+++ b/packages/widget/src/pages/SettingsPage/SettingsCard/SettingCardExpandable.tsx
@@ -1,13 +1,6 @@
 import { Collapse } from '@mui/material'
-import type { PropsWithChildren, ReactNode } from 'react'
-import {
-  type ForwardRefExoticComponent,
-  forwardRef,
-  type RefAttributes,
-  useId,
-  useImperativeHandle,
-  useRef,
-} from 'react'
+import type { JSX, PropsWithChildren, ReactNode, Ref } from 'react'
+import { useId, useImperativeHandle, useRef } from 'react'
 import { Card } from '../../../components/Card/Card.js'
 import {
   CardRowButton,
@@ -30,61 +23,61 @@ export interface SettingCardExpandableRef {
   toggleExpanded: (forceExpanded?: boolean) => void
 }
 
-export const SettingCardExpandable: ForwardRefExoticComponent<
-  PropsWithChildren<SettingCardExpandableProps> &
-    RefAttributes<SettingCardExpandableRef>
-> = forwardRef<
-  SettingCardExpandableRef,
-  PropsWithChildren<SettingCardExpandableProps>
->(
-  (
-    { icon, title, value, children, disabled, keepValueVisible, onEntered },
-    ref
-  ) => {
-    const { expanded, toggleExpanded } = useSettingsCardExpandable()
-    const buttonId = useId()
-    const collapseId = useId()
-    const buttonRef = useRef<HTMLButtonElement>(null)
+export const SettingCardExpandable = ({
+  icon,
+  title,
+  value,
+  children,
+  disabled,
+  keepValueVisible,
+  onEntered,
+  ref,
+}: PropsWithChildren<SettingCardExpandableProps> & {
+  ref?: Ref<SettingCardExpandableRef>
+}): JSX.Element => {
+  const { expanded, toggleExpanded } = useSettingsCardExpandable()
+  const buttonId = useId()
+  const collapseId = useId()
+  const buttonRef = useRef<HTMLButtonElement>(null)
 
-    useImperativeHandle(
-      ref,
-      () => ({
-        element: buttonRef.current,
-        isExpanded: expanded,
-        toggleExpanded,
-      }),
-      [expanded, toggleExpanded]
-    )
+  useImperativeHandle(
+    ref,
+    () => ({
+      element: buttonRef.current,
+      isExpanded: expanded,
+      toggleExpanded,
+    }),
+    [expanded, toggleExpanded]
+  )
 
-    return (
-      <Card sx={{ p: 1 }}>
-        <CardRowButton
-          ref={buttonRef}
-          id={buttonId}
-          aria-expanded={expanded}
-          aria-controls={collapseId}
-          onClick={disabled ? undefined : () => toggleExpanded()}
-          disableRipple
-          sx={{ p: 1, cursor: disabled ? 'default' : 'pointer' }}
-        >
-          <CardTitleContainer>
-            {icon}
-            <CardValue>{title}</CardValue>
-          </CardTitleContainer>
-          {(!expanded || keepValueVisible) && value}
-        </CardRowButton>
-        <Collapse
-          id={collapseId}
-          role="region"
-          aria-labelledby={buttonId}
-          in={expanded}
-          mountOnEnter
-          unmountOnExit
-          onEntered={onEntered}
-        >
-          {children}
-        </Collapse>
-      </Card>
-    )
-  }
-)
+  return (
+    <Card sx={{ p: 1 }}>
+      <CardRowButton
+        ref={buttonRef}
+        id={buttonId}
+        aria-expanded={expanded}
+        aria-controls={collapseId}
+        onClick={disabled ? undefined : () => toggleExpanded()}
+        disableRipple
+        sx={{ p: 1, cursor: disabled ? 'default' : 'pointer' }}
+      >
+        <CardTitleContainer>
+          {icon}
+          <CardValue>{title}</CardValue>
+        </CardTitleContainer>
+        {(!expanded || keepValueVisible) && value}
+      </CardRowButton>
+      <Collapse
+        id={collapseId}
+        role="region"
+        aria-labelledby={buttonId}
+        in={expanded}
+        mountOnEnter
+        unmountOnExit
+        onEntered={onEntered}
+      >
+        {children}
+      </Collapse>
+    </Card>
+  )
+}

--- a/packages/widget/src/pages/SettingsPage/SettingsCard/SettingsAccordian.tsx
+++ b/packages/widget/src/pages/SettingsPage/SettingsCard/SettingsAccordian.tsx
@@ -1,5 +1,5 @@
 import type { PropsWithChildren } from 'react'
-import { createContext, useContext, useEffect, useId, useState } from 'react'
+import { createContext, use, useEffect, useId, useState } from 'react'
 
 const SettingsAccordionContext = createContext({
   setOpenCard: (_id: string) => {},
@@ -12,9 +12,9 @@ export const SettingsCardAccordion: React.FC<PropsWithChildren> = ({
   const [openCard, setOpenCard] = useState('')
 
   return (
-    <SettingsAccordionContext.Provider value={{ openCard, setOpenCard }}>
+    <SettingsAccordionContext value={{ openCard, setOpenCard }}>
       {children}
-    </SettingsAccordionContext.Provider>
+    </SettingsAccordionContext>
   )
 }
 
@@ -24,7 +24,7 @@ export const useSettingsCardExpandable = (): {
 } => {
   const settingCardExpandableId = useId()
   const [expanded, setExpanded] = useState(false)
-  const { openCard, setOpenCard } = useContext(SettingsAccordionContext)
+  const { openCard, setOpenCard } = use(SettingsAccordionContext)
 
   const toggleExpanded = (forceExpanded?: boolean) => {
     const newExpanded = forceExpanded ?? !expanded

--- a/packages/widget/src/pages/TransactionPage/ConfirmToAddressSheet.tsx
+++ b/packages/widget/src/pages/TransactionPage/ConfirmToAddressSheet.tsx
@@ -1,8 +1,8 @@
 import Wallet from '@mui/icons-material/Wallet'
 import WarningRounded from '@mui/icons-material/WarningRounded'
 import { Button, Typography } from '@mui/material'
-import type { ForwardRefExoticComponent, RefAttributes, RefObject } from 'react'
-import { forwardRef, useRef } from 'react'
+import type { JSX, Ref, RefObject } from 'react'
+import { useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { BottomSheet } from '../../components/BottomSheet/BottomSheet.js'
 import type { BottomSheetBase } from '../../components/BottomSheet/types.js'
@@ -28,9 +28,12 @@ interface ConfirmToAddressSheetContentProps extends ConfirmToAddressSheetProps {
   onClose: () => void
 }
 
-export const ConfirmToAddressSheet: ForwardRefExoticComponent<
-  ConfirmToAddressSheetProps & RefAttributes<BottomSheetBase>
-> = forwardRef<BottomSheetBase, ConfirmToAddressSheetProps>((props, ref) => {
+export const ConfirmToAddressSheet = ({
+  ref,
+  ...props
+}: ConfirmToAddressSheetProps & {
+  ref?: Ref<BottomSheetBase>
+}): JSX.Element => {
   const handleClose = () => {
     ;(ref as RefObject<BottomSheetBase>).current?.close()
   }
@@ -40,7 +43,7 @@ export const ConfirmToAddressSheet: ForwardRefExoticComponent<
       <ConfirmToAddressSheetContent {...props} onClose={handleClose} />
     </BottomSheet>
   )
-})
+}
 
 const ConfirmToAddressSheetContent: React.FC<
   ConfirmToAddressSheetContentProps

--- a/packages/widget/src/pages/TransactionPage/ExchangeRateBottomSheet.tsx
+++ b/packages/widget/src/pages/TransactionPage/ExchangeRateBottomSheet.tsx
@@ -1,6 +1,6 @@
 import type { ExchangeRateUpdateParams } from '@lifi/sdk'
 import { Box, Button, Typography } from '@mui/material'
-import type { JSX, Ref, RefObject } from 'react'
+import type { JSX, Ref } from 'react'
 import { useCallback, useImperativeHandle, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { BottomSheet } from '../../components/BottomSheet/BottomSheet.js'
@@ -33,23 +33,27 @@ export const ExchangeRateBottomSheet = ({
   const bottomSheetRef = useRef<BottomSheetBase>(null)
   const resolverRef = useRef<(value: boolean) => void>(null)
 
-  const handleContinue = () => {
-    ;(ref as RefObject<ExchangeRateBottomSheetBase>).current?.close(true)
+  const close = useCallback((value = false, bottomSheetClose = true) => {
+    resolverRef.current?.(value)
+    if (bottomSheetClose) {
+      bottomSheetRef.current?.close()
+    }
+  }, [])
+
+  const handleContinue = useCallback(() => {
+    close(true)
     onContinue?.()
-  }
+  }, [close, onContinue])
 
   const handleCancel = useCallback(() => {
-    ;(ref as RefObject<ExchangeRateBottomSheetBase>).current?.close(false)
+    close(false)
     onCancel?.()
-  }, [onCancel, ref])
+  }, [close, onCancel])
 
   const handleClose = useCallback(() => {
-    ;(ref as RefObject<ExchangeRateBottomSheetBase>).current?.close(
-      false,
-      false
-    )
+    close(false, false)
     onCancel?.()
-  }, [onCancel, ref])
+  }, [close, onCancel])
 
   useImperativeHandle(
     ref,
@@ -60,14 +64,9 @@ export const ExchangeRateBottomSheet = ({
         resolverRef.current = resolver
         bottomSheetRef.current?.open()
       },
-      close: (value = false, bottomSheetClose = true) => {
-        resolverRef.current?.(value)
-        if (bottomSheetClose) {
-          bottomSheetRef.current?.close()
-        }
-      },
+      close,
     }),
-    []
+    [close]
   )
 
   return (

--- a/packages/widget/src/pages/TransactionPage/ExchangeRateBottomSheet.tsx
+++ b/packages/widget/src/pages/TransactionPage/ExchangeRateBottomSheet.tsx
@@ -1,13 +1,7 @@
 import type { ExchangeRateUpdateParams } from '@lifi/sdk'
 import { Box, Button, Typography } from '@mui/material'
-import type { ForwardRefExoticComponent, RefAttributes, RefObject } from 'react'
-import {
-  forwardRef,
-  useCallback,
-  useImperativeHandle,
-  useRef,
-  useState,
-} from 'react'
+import type { JSX, Ref, RefObject } from 'react'
+import { useCallback, useImperativeHandle, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { BottomSheet } from '../../components/BottomSheet/BottomSheet.js'
 import type { BottomSheetBase } from '../../components/BottomSheet/types.js'
@@ -28,62 +22,64 @@ interface ExchangeRateBottomSheetProps {
   onCancel?(): void
 }
 
-export const ExchangeRateBottomSheet: ForwardRefExoticComponent<
-  ExchangeRateBottomSheetProps & RefAttributes<ExchangeRateBottomSheetBase>
-> = forwardRef<ExchangeRateBottomSheetBase, ExchangeRateBottomSheetProps>(
-  ({ onContinue, onCancel }, ref) => {
-    const [data, setData] = useState<ExchangeRateUpdateParams>()
-    const bottomSheetRef = useRef<BottomSheetBase>(null)
-    const resolverRef = useRef<(value: boolean) => void>(null)
+export const ExchangeRateBottomSheet = ({
+  onContinue,
+  onCancel,
+  ref,
+}: ExchangeRateBottomSheetProps & {
+  ref?: Ref<ExchangeRateBottomSheetBase>
+}): JSX.Element => {
+  const [data, setData] = useState<ExchangeRateUpdateParams>()
+  const bottomSheetRef = useRef<BottomSheetBase>(null)
+  const resolverRef = useRef<(value: boolean) => void>(null)
 
-    const handleContinue = () => {
-      ;(ref as RefObject<ExchangeRateBottomSheetBase>).current?.close(true)
-      onContinue?.()
-    }
-
-    const handleCancel = useCallback(() => {
-      ;(ref as RefObject<ExchangeRateBottomSheetBase>).current?.close(false)
-      onCancel?.()
-    }, [onCancel, ref])
-
-    const handleClose = useCallback(() => {
-      ;(ref as RefObject<ExchangeRateBottomSheetBase>).current?.close(
-        false,
-        false
-      )
-      onCancel?.()
-    }, [onCancel, ref])
-
-    useImperativeHandle(
-      ref,
-      () => ({
-        isOpen: () => bottomSheetRef.current?.isOpen(),
-        open: (resolver, data) => {
-          setData(data)
-          resolverRef.current = resolver
-          bottomSheetRef.current?.open()
-        },
-        close: (value = false, bottomSheetClose = true) => {
-          resolverRef.current?.(value)
-          if (bottomSheetClose) {
-            bottomSheetRef.current?.close()
-          }
-        },
-      }),
-      []
-    )
-
-    return (
-      <BottomSheet ref={bottomSheetRef} onClose={handleClose}>
-        <ExchangeRateBottomSheetContent
-          data={data}
-          onContinue={handleContinue}
-          onCancel={handleCancel}
-        />
-      </BottomSheet>
-    )
+  const handleContinue = () => {
+    ;(ref as RefObject<ExchangeRateBottomSheetBase>).current?.close(true)
+    onContinue?.()
   }
-)
+
+  const handleCancel = useCallback(() => {
+    ;(ref as RefObject<ExchangeRateBottomSheetBase>).current?.close(false)
+    onCancel?.()
+  }, [onCancel, ref])
+
+  const handleClose = useCallback(() => {
+    ;(ref as RefObject<ExchangeRateBottomSheetBase>).current?.close(
+      false,
+      false
+    )
+    onCancel?.()
+  }, [onCancel, ref])
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      isOpen: () => bottomSheetRef.current?.isOpen(),
+      open: (resolver, data) => {
+        setData(data)
+        resolverRef.current = resolver
+        bottomSheetRef.current?.open()
+      },
+      close: (value = false, bottomSheetClose = true) => {
+        resolverRef.current?.(value)
+        if (bottomSheetClose) {
+          bottomSheetRef.current?.close()
+        }
+      },
+    }),
+    []
+  )
+
+  return (
+    <BottomSheet ref={bottomSheetRef} onClose={handleClose}>
+      <ExchangeRateBottomSheetContent
+        data={data}
+        onContinue={handleContinue}
+        onCancel={handleCancel}
+      />
+    </BottomSheet>
+  )
+}
 
 const ExchangeRateBottomSheetContent: React.FC<
   ExchangeRateBottomSheetProps

--- a/packages/widget/src/pages/TransactionPage/TokenValueBottomSheet.tsx
+++ b/packages/widget/src/pages/TransactionPage/TokenValueBottomSheet.tsx
@@ -1,7 +1,7 @@
 import type { Route } from '@lifi/sdk'
 import { Button, Checkbox, FormControlLabel } from '@mui/material'
-import type { ForwardRefExoticComponent, RefAttributes, RefObject } from 'react'
-import { forwardRef, useRef, useState } from 'react'
+import type { JSX, Ref, RefObject } from 'react'
+import { useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { BottomSheet } from '../../components/BottomSheet/BottomSheet.js'
 import type { BottomSheetBase } from '../../components/BottomSheet/types.js'
@@ -27,26 +27,29 @@ interface TokenValueBottomSheetProps {
   onCancel?(): void
 }
 
-export const TokenValueBottomSheet: ForwardRefExoticComponent<
-  TokenValueBottomSheetProps & RefAttributes<BottomSheetBase>
-> = forwardRef<BottomSheetBase, TokenValueBottomSheetProps>(
-  ({ route, onContinue, onCancel }, ref) => {
-    const handleCancel = () => {
-      ;(ref as RefObject<BottomSheetBase>).current?.close()
-      onCancel?.()
-    }
-
-    return (
-      <BottomSheet ref={ref} onClose={onCancel}>
-        <TokenValueBottomSheetContent
-          route={route}
-          onContinue={onContinue}
-          onCancel={handleCancel}
-        />
-      </BottomSheet>
-    )
+export const TokenValueBottomSheet = ({
+  route,
+  onContinue,
+  onCancel,
+  ref,
+}: TokenValueBottomSheetProps & {
+  ref?: Ref<BottomSheetBase>
+}): JSX.Element => {
+  const handleCancel = () => {
+    ;(ref as RefObject<BottomSheetBase>).current?.close()
+    onCancel?.()
   }
-)
+
+  return (
+    <BottomSheet ref={ref} onClose={onCancel}>
+      <TokenValueBottomSheetContent
+        route={route}
+        onContinue={onContinue}
+        onCancel={handleCancel}
+      />
+    </BottomSheet>
+  )
+}
 
 const TokenValueBottomSheetContent: React.FC<TokenValueBottomSheetProps> = ({
   route,

--- a/packages/widget/src/providers/QueryClientProvider.tsx
+++ b/packages/widget/src/providers/QueryClientProvider.tsx
@@ -3,13 +3,13 @@ import {
   QueryClientProvider as TanstackQueryClientProvider,
 } from '@tanstack/react-query'
 import type { PropsWithChildren } from 'react'
-import { useContext } from 'react'
+import { use } from 'react'
 import { queryClient } from '../config/queryClient.js'
 
 export const QueryClientProvider: React.FC<PropsWithChildren> = ({
   children,
 }) => {
-  const existingQueryClient = useContext(TanstackQueryClientContext)
+  const existingQueryClient = use(TanstackQueryClientContext)
   return existingQueryClient ? (
     children
   ) : (

--- a/packages/widget/src/providers/SDKClientProvider.tsx
+++ b/packages/widget/src/providers/SDKClientProvider.tsx
@@ -3,7 +3,7 @@ import {
   createContext,
   type JSX,
   type PropsWithChildren,
-  useContext,
+  use,
   useMemo,
 } from 'react'
 import { version } from '../config/version.js'
@@ -11,7 +11,7 @@ import { useWidgetConfig } from './WidgetProvider/WidgetProvider.js'
 
 const SDKClientContext = createContext<SDKClient>({} as SDKClient)
 
-export const useSDKClient = (): SDKClient => useContext(SDKClientContext)
+export const useSDKClient = (): SDKClient => use(SDKClientContext)
 
 export const SDKClientProvider = ({
   children,
@@ -51,9 +51,5 @@ export const SDKClientProvider = ({
     slippage,
   ])
 
-  return (
-    <SDKClientContext.Provider value={client}>
-      {children}
-    </SDKClientContext.Provider>
-  )
+  return <SDKClientContext value={client}>{children}</SDKClientContext>
 }

--- a/packages/widget/src/providers/WidgetProvider/WidgetProvider.tsx
+++ b/packages/widget/src/providers/WidgetProvider/WidgetProvider.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useId, useMemo } from 'react'
+import { createContext, use, useId, useMemo } from 'react'
 import { useSettingsActions } from '../../stores/settings/useSettingsActions.js'
 import type { WidgetContextProps, WidgetProviderProps } from './types.js'
 
@@ -9,8 +9,7 @@ const initialContext: WidgetContextProps = {
 
 const WidgetContext = createContext<WidgetContextProps>(initialContext)
 
-export const useWidgetConfig = (): WidgetContextProps =>
-  useContext(WidgetContext)
+export const useWidgetConfig = (): WidgetContextProps => use(WidgetContext)
 
 export const WidgetProvider: React.FC<
   React.PropsWithChildren<WidgetProviderProps>
@@ -43,7 +42,5 @@ export const WidgetProvider: React.FC<
       }
     }
   }, [elementId, widgetConfig, setDefaultSettings])
-  return (
-    <WidgetContext.Provider value={value}>{children}</WidgetContext.Provider>
-  )
+  return <WidgetContext value={value}>{children}</WidgetContext>
 }

--- a/packages/widget/src/stores/bookmarks/BookmarkStore.tsx
+++ b/packages/widget/src/stores/bookmarks/BookmarkStore.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useRef } from 'react'
+import { createContext, use, useRef } from 'react'
 import { useShallow } from 'zustand/shallow'
 import { useWidgetConfig } from '../../providers/WidgetProvider/WidgetProvider.js'
 import type { PersistStoreProviderProps } from '../types.js'
@@ -19,14 +19,14 @@ export const BookmarkStoreProvider: React.FC<PersistStoreProviderProps> = ({
   }
 
   return (
-    <BookmarkStoreContext.Provider value={storeRef.current}>
+    <BookmarkStoreContext value={storeRef.current}>
       {children}
-    </BookmarkStoreContext.Provider>
+    </BookmarkStoreContext>
   )
 }
 
 export function useBookmarkStore<T>(selector: (store: BookmarkState) => T): T {
-  const useStore = useContext(BookmarkStoreContext)
+  const useStore = use(BookmarkStoreContext)
 
   if (!useStore) {
     throw new Error(

--- a/packages/widget/src/stores/chains/ChainOrderStore.tsx
+++ b/packages/widget/src/stores/chains/ChainOrderStore.tsx
@@ -1,4 +1,4 @@
-import { createContext, type JSX, useContext, useEffect, useRef } from 'react'
+import { createContext, type JSX, use, useEffect, useRef } from 'react'
 import type { StoreApi, UseBoundStore } from 'zustand'
 import { useShallow } from 'zustand/shallow'
 import { useChains } from '../../hooks/useChains.js'
@@ -141,14 +141,14 @@ export function ChainOrderStoreProvider({
   ])
 
   return (
-    <ChainOrderStoreContext.Provider value={storeRef.current}>
+    <ChainOrderStoreContext value={storeRef.current}>
       {children}
-    </ChainOrderStoreContext.Provider>
+    </ChainOrderStoreContext>
   )
 }
 
 function useChainOrderStoreContext() {
-  const useStore = useContext(ChainOrderStoreContext)
+  const useStore = use(ChainOrderStoreContext)
   if (!useStore) {
     throw new Error(
       `You forgot to wrap your component in <${ChainOrderStoreProvider.name}>.`

--- a/packages/widget/src/stores/form/FormStore.tsx
+++ b/packages/widget/src/stores/form/FormStore.tsx
@@ -125,9 +125,9 @@ export const FormStoreProvider: React.FC<FormStoreProviderProps> = ({
   useFormRef(storeRef.current, formRef)
 
   return (
-    <FormStoreContext.Provider value={storeRef.current}>
+    <FormStoreContext value={storeRef.current}>
       {children}
       <FormUpdater reactiveFormValues={reactiveFormValues} />
-    </FormStoreContext.Provider>
+    </FormStoreContext>
   )
 }

--- a/packages/widget/src/stores/form/useFormStore.ts
+++ b/packages/widget/src/stores/form/useFormStore.ts
@@ -1,10 +1,10 @@
-import { useContext } from 'react'
+import { use } from 'react'
 import { useShallow } from 'zustand/shallow'
 import { FormStoreContext } from './FormStoreContext.js'
 import type { FormValuesState } from './types.js'
 
 export function useFormStore<T>(selector: (state: FormValuesState) => T): T {
-  const useStore = useContext(FormStoreContext)
+  const useStore = use(FormStoreContext)
 
   if (!useStore) {
     throw new Error('You forgot to wrap your component in <FormStoreProvider>.')

--- a/packages/widget/src/stores/header/useHeaderStore.tsx
+++ b/packages/widget/src/stores/header/useHeaderStore.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useRef } from 'react'
+import { createContext, use, useRef } from 'react'
 import { create } from 'zustand'
 import { useShallow } from 'zustand/shallow'
 import type { PersistStoreProviderProps } from '../types.js'
@@ -14,14 +14,12 @@ export function HeaderStoreProvider({
     storeRef.current = createHeaderStore()
   }
   return (
-    <HeaderStoreContext.Provider value={storeRef.current}>
-      {children}
-    </HeaderStoreContext.Provider>
+    <HeaderStoreContext value={storeRef.current}>{children}</HeaderStoreContext>
   )
 }
 
 function useHeaderStoreContext() {
-  const useStore = useContext(HeaderStoreContext)
+  const useStore = use(HeaderStoreContext)
   if (!useStore) {
     throw new Error(
       `You forgot to wrap your component in <${HeaderStoreProvider.name}>.`

--- a/packages/widget/src/stores/pinnedTokens/PinnedTokensStore.tsx
+++ b/packages/widget/src/stores/pinnedTokens/PinnedTokensStore.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useRef } from 'react'
+import { createContext, use, useRef } from 'react'
 import { useShallow } from 'zustand/shallow'
 import type { PersistStoreProviderProps } from '../types.js'
 import { createPinnedTokensStore } from './createPinnedTokensStore.js'
@@ -17,16 +17,16 @@ export const PinnedTokensStoreProvider: React.FC<PersistStoreProviderProps> = ({
   }
 
   return (
-    <PinnedTokensStoreContext.Provider value={storeRef.current}>
+    <PinnedTokensStoreContext value={storeRef.current}>
       {children}
-    </PinnedTokensStoreContext.Provider>
+    </PinnedTokensStoreContext>
   )
 }
 
 export function usePinnedTokensStore<T>(
   selector: (store: PinnedTokensState) => T
 ): T {
-  const useStore = useContext(PinnedTokensStoreContext)
+  const useStore = use(PinnedTokensStoreContext)
 
   if (!useStore) {
     throw new Error(

--- a/packages/widget/src/stores/routes/RouteExecutionStore.tsx
+++ b/packages/widget/src/stores/routes/RouteExecutionStore.tsx
@@ -1,4 +1,4 @@
-import { createContext, type JSX, useContext, useRef } from 'react'
+import { createContext, type JSX, use, useRef } from 'react'
 import type { StoreApi, UseBoundStore } from 'zustand'
 import { useShallow } from 'zustand/shallow'
 import type { PersistStoreProviderProps } from '../types.js'
@@ -20,14 +20,14 @@ export function RouteExecutionStoreProvider({
     storeRef.current = createRouteExecutionStore(props)
   }
   return (
-    <RouteExecutionStoreContext.Provider value={storeRef.current}>
+    <RouteExecutionStoreContext value={storeRef.current}>
       {children}
-    </RouteExecutionStoreContext.Provider>
+    </RouteExecutionStoreContext>
   )
 }
 
 export function useRouteExecutionStoreContext(): any {
-  const useStore = useContext(RouteExecutionStoreContext)
+  const useStore = use(RouteExecutionStoreContext)
   if (!useStore) {
     throw new Error(
       `You forgot to wrap your component in <${RouteExecutionStoreProvider.name}>.`

--- a/packages/widget/src/stores/settings/SettingsStore.tsx
+++ b/packages/widget/src/stores/settings/SettingsStore.tsx
@@ -2,7 +2,7 @@ import {
   createContext,
   type JSX,
   type PropsWithChildren,
-  useContext,
+  use,
   useRef,
 } from 'react'
 import type { StoreApi, UseBoundStore } from 'zustand'
@@ -23,14 +23,14 @@ export const SettingsStoreProvider = ({
     storeRef.current = createSettingsStore(config)
   }
   return (
-    <SettingsStoreContext.Provider value={storeRef.current}>
+    <SettingsStoreContext value={storeRef.current}>
       {children}
-    </SettingsStoreContext.Provider>
+    </SettingsStoreContext>
   )
 }
 
 export function useSettingsStoreContext(): any {
-  const useStore = useContext(SettingsStoreContext)
+  const useStore = use(SettingsStoreContext)
   if (!useStore) {
     throw new Error(
       'You forgot to wrap your component in SettingsStoreContext.'

--- a/packages/widget/src/stores/settings/useSplitModeStore.tsx
+++ b/packages/widget/src/stores/settings/useSplitModeStore.tsx
@@ -1,4 +1,4 @@
-import { createContext, type JSX, useContext, useRef } from 'react'
+import { createContext, type JSX, use, useRef } from 'react'
 import { create } from 'zustand'
 import { useShallow } from 'zustand/shallow'
 import type {
@@ -24,14 +24,14 @@ export function SplitModeStoreProvider({
     storeRef.current = createSplitModeStore(props)
   }
   return (
-    <SplitModeStoreContext.Provider value={storeRef.current}>
+    <SplitModeStoreContext value={storeRef.current}>
       {children}
-    </SplitModeStoreContext.Provider>
+    </SplitModeStoreContext>
   )
 }
 
 function useSplitModeStoreContext() {
-  const useStore = useContext(SplitModeStoreContext)
+  const useStore = use(SplitModeStoreContext)
   if (!useStore) {
     throw new Error(
       `You forgot to wrap your component in <${SplitModeStoreProvider.name}>.`

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1533,7 +1533,7 @@ importers:
         specifier: ^1.1.0
         version: 1.1.0
       react:
-        specifier: '>=18'
+        specifier: '>=19'
         version: 19.2.7
       viem:
         specifier: '>=2.52.0'
@@ -1766,7 +1766,7 @@ importers:
         version: 6.0.2(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
       react-scan:
         specifier: ^0.5.7
-        version: 0.5.7(bufferutil@4.1.0)(esbuild@0.28.0)(eslint@10.4.1(jiti@2.7.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.61.0)(utf-8-validate@6.0.6)
+        version: 0.5.7(esbuild@0.28.0)(eslint@10.4.1(jiti@2.7.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.61.0)
       source-map-explorer:
         specifier: ^2.5.3
         version: 2.5.3
@@ -2701,12 +2701,6 @@ packages:
     engines: {bun: '>=1', deno: '>=2.7.10', node: '>=16'}
     peerDependencies:
       '@noble/ciphers': ^1.0.0
-
-  '@effect/platform-node-shared@4.0.0-beta.70':
-    resolution: {integrity: sha512-3VXuL63IDmq13We+ApRKn2JW3Rb9g5gj1YEmfb8u2b73norur1VsIJ/pRE4qjShevg19dQYi2JsLawSZ6gApug==}
-    engines: {node: '>=18.0.0'}
-    peerDependencies:
-      effect: ^4.0.0-beta.70
 
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
@@ -4229,36 +4223,6 @@ packages:
     resolution: {integrity: sha512-47XIizs9XZXvuJgoaJUIE2lFoID8ugvc0jzSHP+Ptfk8nTbnR8g788wv48N03Kx0UkAv559HWRQ3yzOgzlRNUA==}
     engines: {node: '>= 18'}
 
-  '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4':
-    resolution: {integrity: sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.4':
-    resolution: {integrity: sha512-zExlW9zUJKZH/tOtVMttwjKa4Xm/3KcNjnE3dPN92uCktwavMxpgCA3MoJK/DOnTWsQgo224OaST27/mPNAf+w==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.4':
-    resolution: {integrity: sha512-dgX0P/9wGPJeHFBG+ZmhgE6bmtMt7NP5CRBGyyktpopdk/mW4POnrpQsSLtKI1dwpc+pPLuXHDh6vvskyQE/sw==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@msgpackr-extract/msgpackr-extract-linux-arm@3.0.4':
-    resolution: {integrity: sha512-Tg3yX65f5GbtXLkrYEHE5oibZG9epyYWas7FogTTEJeDEF9JlXJzKgXaNhT3UXlTOeA+AfZpYZYZ0uPj7Cfquw==}
-    cpu: [arm]
-    os: [linux]
-
-  '@msgpackr-extract/msgpackr-extract-linux-x64@3.0.4':
-    resolution: {integrity: sha512-8TNXMEjJc3QEy7R/x1INhgiU+XakDAFUzBhaz7+Rbrs8NH5UQeHQxxmzsSBJGyV6I1jW79undiQm8tOI+D+8FQ==}
-    cpu: [x64]
-    os: [linux]
-
-  '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.4':
-    resolution: {integrity: sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ==}
-    cpu: [x64]
-    os: [win32]
-
   '@mui/core-downloads-tracker@9.0.1':
     resolution: {integrity: sha512-GzamIIhZ1bH77dq7eKaeyRgJdkypsxin4jBFq2EMs4lBWRR0LFO1CSVMsoebn/VvjcNrnrOrjy48MkrkQUK2iw==}
 
@@ -5533,10 +5497,22 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@oxlint/binding-android-arm-eabi@1.66.0':
+    resolution: {integrity: sha512-f7kq8N51T4phpzqfBpA2qaVTI/KrkCmNwaj3t/97I/WLTDI+UhlP5GL9eER+zVxBhtlx5rKXWByJU1/zDAvyaw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
   '@oxlint/binding-android-arm-eabi@1.68.0':
     resolution: {integrity: sha512-wEdsIspexXLLMCPAEOcCuFLMt6aE3AzTuA/nQKLPRnoJ+EQTturmGheDkhHuuVHx0GbutjQ3JKmEn+Gz6Ag28Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
+    os: [android]
+
+  '@oxlint/binding-android-arm64@1.66.0':
+    resolution: {integrity: sha512-xu6QO71tdDS9mjmLZ3AqhtaVHBvdmsOKkYnReNNDgh+XiwnsipeQOIxbiYOOO0iAXycJ+GK0wdMSZP/2j/AmSg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
     os: [android]
 
   '@oxlint/binding-android-arm64@1.68.0':
@@ -5545,10 +5521,22 @@ packages:
     cpu: [arm64]
     os: [android]
 
+  '@oxlint/binding-darwin-arm64@1.66.0':
+    resolution: {integrity: sha512-HZ24VimSOC7mxuEA99e0H2FS0C1yO3+iW13jPRAk+e2njsUs3QeAXsafCDyaIrV/MirdOVez+etQNQsJE43zNQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
   '@oxlint/binding-darwin-arm64@1.68.0':
     resolution: {integrity: sha512-lVTbsE3kO4bLpZELgjRZuAJc8kP98wb83yMXWH8gaPaFZ+cM2IDeZto4ByoUAYj0Mxv2rvw+A1ssZequSepVSg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
+    os: [darwin]
+
+  '@oxlint/binding-darwin-x64@1.66.0':
+    resolution: {integrity: sha512-awhj8ZvJrrRSnXj7V++rpZvTmnl99L6mi0B7gg7Cp7BN6cKpzuI481bHNLvXGA9GB1/oEgA3ponuyoAc6Md12A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
     os: [darwin]
 
   '@oxlint/binding-darwin-x64@1.68.0':
@@ -5557,14 +5545,32 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@oxlint/binding-freebsd-x64@1.66.0':
+    resolution: {integrity: sha512-KQF0oVV21/FjIqkRuL8Q1vh8ECsE5+ocdH5tcqTQ4ZnYuDVoYibQUNfqBjQaUsP6UIIda5Y75Wpm5p4RgQWiWw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
   '@oxlint/binding-freebsd-x64@1.68.0':
     resolution: {integrity: sha512-TI4ovQJliYE9V6e06cEv+qEI9uj7Ao65fmif4er4HD+aouyYyh0P31q2jh3KtqsOHHcQqv2PZ61TjJFLpBDGWQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
+  '@oxlint/binding-linux-arm-gnueabihf@1.66.0':
+    resolution: {integrity: sha512-9u1rgwZSEXWb30vbFZzQ78HVXBo0WCKNwJ3a2InRUTNMRng+PUDIoSFmA+m4HdUfBaIqftShq8J8qHc+eE/Vig==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
   '@oxlint/binding-linux-arm-gnueabihf@1.68.0':
     resolution: {integrity: sha512-LcNnEi9g71Cmry5ZpLbKT+oVv+/zYG3hYVAbBBB5X85nOQZSk8l92CnDkxJMcxUg0NCnMCOFZuaVDlMyv4tYJw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxlint/binding-linux-arm-musleabihf@1.66.0':
+    resolution: {integrity: sha512-Ynot2HR1bHxUaNWoC280MVTDfZuaWuP3XfSMRDhyuZrVjhzoaBCVFlw8h8qeZjWKVUBhPWFIxB7AQTlK8Z2WWg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
@@ -5575,12 +5581,26 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@oxlint/binding-linux-arm64-gnu@1.66.0':
+    resolution: {integrity: sha512-xCbgzciGgo+A4aQZEknsNrNiIwY7sU5SfRuMmRjPIvZAgdF34cIHiKvwOsS5XRLjlTVSFwitmq6YclTtHTfU+g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
   '@oxlint/binding-linux-arm64-gnu@1.68.0':
     resolution: {integrity: sha512-YbzTglnHLzzi9zv5or8Ztz5fykAoZE8W9iM42/bOrF4HBSB6rJTqdLQWuoP76EHQw9DuKl76K1QmFlG29sPJXQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
+
+  '@oxlint/binding-linux-arm64-musl@1.66.0':
+    resolution: {integrity: sha512-hmo+ZB/lHkR1HdDmnziNpzSLmulnUSu10VEqX2Yex7OwvoBAbjJQLvy4gIBRV3AAwWnCvAxKp5Nv1GE6LU1QMg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
 
   '@oxlint/binding-linux-arm64-musl@1.68.0':
     resolution: {integrity: sha512-qVKtCZNic+OoNnOr/hCQAu22HSQzflI7Fsq/Blzkw02SnLuv163k3kfmrVpZjSBlUHgsRKj6WgQiw30d3SX02Q==}
@@ -5589,10 +5609,24 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@oxlint/binding-linux-ppc64-gnu@1.66.0':
+    resolution: {integrity: sha512-2Invd4Uyy81mVooQC5FBtfxSNrvcX1OxbMlVQ6M2erRrNI2awFYF26YNW2yFxdVFZ4ffNOWKghtMjhnUPsXsVA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
   '@oxlint/binding-linux-ppc64-gnu@1.68.0':
     resolution: {integrity: sha512-zExyZ8ZOUuAyQ0y9jpTcyjKUz62YY9JhKPyVxzvjTpXzZ3ujdqiVwfPWDdnA1SsIOrxdtxHn7KErDHLWskFjXg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-riscv64-gnu@1.66.0':
+    resolution: {integrity: sha512-s0iXPDQVdgayE3RGa/N2DZF7tjgg0TwEtD1sGoDxqPDGrIXgo45H0yHknT0f9A0yteASsweYZtDyTuVlM4aSag==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
@@ -5603,6 +5637,13 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@oxlint/binding-linux-riscv64-musl@1.66.0':
+    resolution: {integrity: sha512-OekL4XFiu7RPK0JIZi8VeHgtIXPREf42t8Cy/rKEsC+P3gcqDgNAAGiyuUOpdbG4wwbfue1q4CHcCO7spSve6w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
   '@oxlint/binding-linux-riscv64-musl@1.68.0':
     resolution: {integrity: sha512-bnZooVeHAcvA+dH0EDLgx+7HY/DRi6e0hFszg3P+OBatuUjV6EvfIyNIzWOusmqAVh4L6r21GGTZtiKE4iqM4Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -5610,10 +5651,24 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@oxlint/binding-linux-s390x-gnu@1.66.0':
+    resolution: {integrity: sha512-Ga1D0kj1SFslm34ThA/BdkUlyAYEnTsXyRC4pF0C5agZSwtGdHYWMTQWemUfBGp4RCG4QWXgdO+HmmmKqOtlBg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
   '@oxlint/binding-linux-s390x-gnu@1.68.0':
     resolution: {integrity: sha512-dIqnZnJSmHCMOUpUcWQOiV14o3DDPVx1DSsMaSzvdhNjC1tB1iEPZbdiMSCIEYbkgbsYznHXWqFdKL8WUB3F8g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-x64-gnu@1.66.0':
+    resolution: {integrity: sha512-p5jfP1wUZe/IC3qpQO84n9DRnf9g3lKRtLBlQq23ykyrDglHcVx7sWmVTlPuU6SBw8mNnPzyOn022G3XZHnlww==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
     os: [linux]
     libc: [glibc]
 
@@ -5624,6 +5679,13 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@oxlint/binding-linux-x64-musl@1.66.0':
+    resolution: {integrity: sha512-vUB/sYlYZorDL1ZD+o9mRv7zbsykrrFRtmgS6R8musZqLtrPRQn1gc1eGpuX+sfdccz42STl/AqldY6XRb2upQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
   '@oxlint/binding-linux-x64-musl@1.68.0':
     resolution: {integrity: sha512-Dl5QEX0TCo/40Cdh1o1JdPS//+YiWqjC+Hrrya5OQmStZZr4svAFtdlqcpCrU9yq2Mo3vRVyO9B3h0dzD8s36Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -5631,11 +5693,23 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@oxlint/binding-openharmony-arm64@1.66.0':
+    resolution: {integrity: sha512-yde+6p/F59xRkGR9H1HfngWRif1QRJjynZK349l+UI0H6w9hL3G8/AVaTHFyTtLVQ56qtNbX2/5Dc77n1ovnOg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
   '@oxlint/binding-openharmony-arm64@1.68.0':
     resolution: {integrity: sha512-/qy6dOvi4S3/LeXq0l5BT5pRKPYA7oj3uKwJOAZOr5HRLL+HK6jdBynvWuXIA2wwfE01RzNYmbBdM7vwYx00sA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
+
+  '@oxlint/binding-win32-arm64-msvc@1.66.0':
+    resolution: {integrity: sha512-O9GLucgoTdmOrbBX+EjzNe7o/Ze5TFOvXcib6bzUOtBOmj6cV+zw18NgB+cGKAkDw1Pdqs8vGkfHbbsLuDtXWg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
 
   '@oxlint/binding-win32-arm64-msvc@1.68.0':
     resolution: {integrity: sha512-fHNtVqPHSYE7UFDSLVFUjxQjnSVXxseNJmRW+XuP4pXXDwePdPda43NL7/BBCFTxHjycOc44JNDaOPtFDNui9A==}
@@ -5643,10 +5717,22 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@oxlint/binding-win32-ia32-msvc@1.66.0':
+    resolution: {integrity: sha512-m3Pjwc2MfTcom4E4gOv7DyuGyt7OfGNCbmqDHd+N7EzXmP+ppHuudm2NjcA3AjV5TSeGxaguVF4SbTKHe1USYA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
   '@oxlint/binding-win32-ia32-msvc@1.68.0':
     resolution: {integrity: sha512-NnKXr4Wgo4nps3erhrE0f8shBvBPZMHg72nDsvX0JyrRvsNiP3f1JNvbCKh+A6VFvpF7ZoJxu904P3cKMhvZnA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ia32]
+    os: [win32]
+
+  '@oxlint/binding-win32-x64-msvc@1.66.0':
+    resolution: {integrity: sha512-/DbBvw8UFBhja6PqudUjV4UtfsJr0Oa7jUjWVKB0g86lj/VwnPrkngn0sFql3c9RDA0O16dh7ozsXb6GjNAzBQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
     os: [win32]
 
   '@oxlint/binding-win32-x64-msvc@1.68.0':
@@ -5928,8 +6014,8 @@ packages:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-grab/cli@0.1.44':
-    resolution: {integrity: sha512-gMDYY2rw6OWajCcDlXSIgs2LC432YJXSb3Lm5yM187uhRgBYddoEVULi36h+IolX3r7jSb3ew7vn9FfI8NSo0A==}
+  '@react-grab/cli@0.1.46':
+    resolution: {integrity: sha512-rNjGKeRY3HROku1J/a7y8RGHRGFR6ZnllSPqNLfFI5cUu6FCdjjxHvXf1TEXxW7I5REq8iKoLuzM9iYboXCRdg==}
     hasBin: true
 
   '@react-native-async-storage/async-storage@3.1.1':
@@ -8649,6 +8735,10 @@ packages:
     resolution: {integrity: sha512-nHlms9BkP8ZiY79HrwCGiA2DcNaXrAaJrCM/BEqQ7MEsSKyCk+2A76xPGylIfASZSZE0SaU3T0bNSg4rBPIJAQ==}
     hasBin: true
 
+  agent-install@0.0.6:
+    resolution: {integrity: sha512-7NRMZ/ZDz2vHevQTgJsocBFpakB1/Wx5ip19YSJuj4VOXpraWztTerViNtdSyARKZT9e2yVwUUB5JXXCE7mNrA==}
+    hasBin: true
+
   agentkeepalive@4.6.0:
     resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
     engines: {node: '>= 8.0.0'}
@@ -9855,8 +9945,8 @@ packages:
   des.js@1.1.0:
     resolution: {integrity: sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg==}
 
-  deslop-js@0.0.14:
-    resolution: {integrity: sha512-FY0rNK+mdTozXwNmcJAt5tD9hVOkXEX5ac+Mg77KJvnnsoAh3qIUW64PMnofutjeYz7g1vENMbOcrBmD1v4FlA==}
+  deslop-js@0.0.24:
+    resolution: {integrity: sha512-ygcRwJXCUedo+hN1L4Ysm7luo4VWOvKEz/kRKWMlFp5bAtTKeXo+8fk/hQaJKsJ/nfahiqkhlYTlrKIR/5nsQg==}
 
   destr@2.0.5:
     resolution: {integrity: sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==}
@@ -10035,9 +10125,6 @@ packages:
 
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
-
-  effect@4.0.0-beta.70:
-    resolution: {integrity: sha512-8AwGTRiNriirHGEYHrOS0E9fzdhIqCdZjiHP1YXmNo2UyPGS43ILsymsSHT7V0DJS+8dvlKq2RxnrDBUhDNZHg==}
 
   ejs@3.1.10:
     resolution: {integrity: sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==}
@@ -10427,10 +10514,6 @@ packages:
     resolution: {integrity: sha512-GipyPsXO1anza0AOZdy69Im7hGFCNB7Y/NGjDlZGJ3GJJLtwNSb2vrzYrTYJRrRloVx7pl+bhUaTB8yiccPvFQ==}
     engines: {node: '> 0.1.90'}
 
-  fast-check@4.8.0:
-    resolution: {integrity: sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg==}
-    engines: {node: '>=12.17.0'}
-
   fast-copy@3.0.2:
     resolution: {integrity: sha512-dl0O9Vhju8IrcLndv2eU4ldt1ftXMqqfgN4H1cpmGV7P6jeB9FwpN9a2c8DPGE1Ys88rNUJVYDHq73CGAGOPfQ==}
 
@@ -10541,9 +10624,6 @@ packages:
   finalhandler@1.3.2:
     resolution: {integrity: sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==}
     engines: {node: '>= 0.8'}
-
-  find-my-way-ts@0.1.6:
-    resolution: {integrity: sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA==}
 
   find-root@1.1.0:
     resolution: {integrity: sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==}
@@ -11098,10 +11178,6 @@ packages:
     resolution: {integrity: sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
-  ini@7.0.0:
-    resolution: {integrity: sha512-ifK0CgjALofS5bkrcTy4RaQ9Vx2Knf/eLeIO+NaswQEpH1UblrtTSCIvN71qQDMq0PeQ/SSPojvEJp9vvvfr+w==}
-    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
-
   inline-style-parser@0.1.1:
     resolution: {integrity: sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q==}
 
@@ -11539,9 +11615,6 @@ packages:
 
   knitwork@1.3.0:
     resolution: {integrity: sha512-4LqMNoONzR43B1W0ek0fhXMsDNW/zxa1NdFAVMY+k28pgZLovR4G3PB5MrpTxCy1QaZCqNoiaKPr5w5qZHfSNw==}
-
-  kubernetes-types@1.30.0:
-    resolution: {integrity: sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q==}
 
   launch-editor@2.14.1:
     resolution: {integrity: sha512-QWBrQsMpH7gPr965dsKD/3cKWiNoTjpATQf++Xq63N6sKRGMwlVXz41O1IZTMfZQgBctD/K5Zt06+/I6pP6+HA==}
@@ -12251,21 +12324,11 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  msgpackr-extract@3.0.4:
-    resolution: {integrity: sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw==}
-    hasBin: true
-
-  msgpackr@2.0.2:
-    resolution: {integrity: sha512-c5hYOXFbP79Slh6Dzd2wzk+jnV7mX1UxfMYtilnY1NmalXPqG8DGb5cYCMBrW4AsH3zekBBZd4QrKz9NhtvYLQ==}
-
   muggle-string@0.4.1:
     resolution: {integrity: sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==}
 
   multiformats@9.9.0:
     resolution: {integrity: sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==}
-
-  multipasta@0.2.7:
-    resolution: {integrity: sha512-KPA58d68KgGil15oDqXjkUBEBYc00XvbPj5/X+dyzeo/lWm9Nc25pQRlf1D+gv4OpK7NM0J1odrbu9JNNGvynA==}
 
   nanoclone@0.2.1:
     resolution: {integrity: sha512-wynEP02LmIbLpcYw8uBKpcfF6dmg2vcpKqxeH5UcoKEYdExslsdUA4ugFauuaeYdTB76ez6gJW8XAZ6CgkXYxA==}
@@ -12370,10 +12433,6 @@ packages:
   node-forge@1.4.0:
     resolution: {integrity: sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==}
     engines: {node: '>= 6.13.0'}
-
-  node-gyp-build-optional-packages@5.2.2:
-    resolution: {integrity: sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==}
-    hasBin: true
 
   node-gyp-build@4.8.4:
     resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
@@ -12648,9 +12707,19 @@ packages:
       rolldown:
         optional: true
 
-  oxlint-plugin-react-doctor@0.2.16:
-    resolution: {integrity: sha512-Ul1UxcYfjBnt+HjgNaMnkvMJjyewS6rkSZl3LiD1g/QqSll1jiynYH/ZoNpUaGHp1pDQ/xLvCcXNQvqopN0tHA==}
+  oxlint-plugin-react-doctor@0.5.6:
+    resolution: {integrity: sha512-my/aMTDi2XmodqTK2ur+UeDLVAnOohIBfwj1AQ5LC3Q2vpcKsUiFjmwVxdy3RuanLXHXJ7hXwAqfmtIaYeyTpQ==}
+    engines: {node: ^20.19.0 || >=22.13.0}
+
+  oxlint@1.66.0:
+    resolution: {integrity: sha512-N4LLxYLd94KEBqXDMDM5f+2PUpItTjDLreXe2Gn5KhjhCK4Qp2YUXaBi8Yu325ryOgKwt22m45fpD7nPOn69Yw==}
     engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      oxlint-tsgolint: '>=0.22.1'
+    peerDependenciesMeta:
+      oxlint-tsgolint:
+        optional: true
 
   oxlint@1.68.0:
     resolution: {integrity: sha512-dXcbq+xsmLrMy6T8d0euf3IYUfLmjHIE11pOxiUSi5LHkFZaYPv568R6sEjcavVpUxoaQe66UBuK4HEi74NxpA==}
@@ -13344,9 +13413,6 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
-  pure-rand@8.4.0:
-    resolution: {integrity: sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==}
-
   qr-code-styling@1.9.2:
     resolution: {integrity: sha512-RgJaZJ1/RrXJ6N0j7a+pdw3zMBmzZU4VN2dtAZf8ZggCfRB5stEQ3IoDNGaNhYY3nnZKYlYSLl5YkfWN5dPutg==}
     engines: {node: '>=18.18.0'}
@@ -13456,9 +13522,9 @@ packages:
   react-devtools-core@6.1.5:
     resolution: {integrity: sha512-ePrwPfxAnB+7hgnEr8vpKxL9cmnp7F322t8oqcPshbIQQhDKgFDW4tjhF2wjVbdXF9O/nyuy3sQWd9JGpiLPvA==}
 
-  react-doctor@0.2.16:
-    resolution: {integrity: sha512-o108QscqM/TlC1QmKgDORf/P53PeZ69nZbRsvy53rXkKvWdKZC1Y0u1JRPmThbTh6v+QpMispBwEnFHhlpZQ7w==}
-    engines: {node: ^20.19.0 || >=22.12.0}
+  react-doctor@0.5.6:
+    resolution: {integrity: sha512-xiy7vRG08qFW5XCYvvB6zir1kWtfuEK68h4scBJtOvt1r6bUNyi4zSsUkq5jdU1afJ2+Uq8y8H9KIQlP2sCqQA==}
+    engines: {node: ^20.19.0 || >=22.13.0}
     hasBin: true
 
   react-dom@19.2.7:
@@ -13478,8 +13544,8 @@ packages:
       '@types/react':
         optional: true
 
-  react-grab@0.1.44:
-    resolution: {integrity: sha512-bDEwBdI90ljq2lhUtPqmWis/HwYB/CvfT0m5i+P9F83Pt0Ot8o9XL8v00s9jcWzdQUlsFDzmq2FO2CHUe8JY8A==}
+  react-grab@0.1.46:
+    resolution: {integrity: sha512-i6sSSBGqW1yxZ5TZL9wX2m9qNMKOydpou5IMaXrK1iylJAJyr/npoqv4mhq3cO7480FBhmlEZbf5VF8KOCBlMQ==}
     hasBin: true
     peerDependencies:
       react: '>=17.0.0'
@@ -14642,10 +14708,6 @@ packages:
   toml@3.0.0:
     resolution: {integrity: sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==}
 
-  toml@4.1.1:
-    resolution: {integrity: sha512-EBJnVBr3dTXdA89WVFoAIPUqkBjxPMwRqsfuo1r240tKFHXv3zgca4+NJib/h6TyvGF7vOawz0jGuryJCdNHrw==}
-    engines: {node: '>=20'}
-
   toposort@2.0.2:
     resolution: {integrity: sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==}
 
@@ -14689,6 +14751,7 @@ packages:
   tsconfck@3.1.6:
     resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
     engines: {node: ^18 || >=20}
+    deprecated: unmaintained
     hasBin: true
     peerDependencies:
       typescript: ^5.0.0
@@ -15477,6 +15540,23 @@ packages:
   void-elements@3.1.0:
     resolution: {integrity: sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==}
     engines: {node: '>=0.10.0'}
+
+  vscode-jsonrpc@8.2.0:
+    resolution: {integrity: sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==}
+    engines: {node: '>=14.0.0'}
+
+  vscode-languageserver-protocol@3.17.5:
+    resolution: {integrity: sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==}
+
+  vscode-languageserver-textdocument@1.0.12:
+    resolution: {integrity: sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==}
+
+  vscode-languageserver-types@3.17.5:
+    resolution: {integrity: sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==}
+
+  vscode-languageserver@9.0.1:
+    resolution: {integrity: sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==}
+    hasBin: true
 
   vscode-uri@3.1.0:
     resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
@@ -17554,15 +17634,6 @@ snapshots:
     dependencies:
       '@noble/ciphers': 1.3.0
 
-  '@effect/platform-node-shared@4.0.0-beta.70(bufferutil@4.1.0)(effect@4.0.0-beta.70)(utf-8-validate@6.0.6)':
-    dependencies:
-      '@types/ws': 8.18.1
-      effect: 4.0.0-beta.70
-      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-
   '@emnapi/core@1.10.0':
     dependencies:
       '@emnapi/wasi-threads': 1.2.1
@@ -19107,24 +19178,6 @@ snapshots:
 
   '@msgpack/msgpack@3.1.3': {}
 
-  '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4':
-    optional: true
-
-  '@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.4':
-    optional: true
-
-  '@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.4':
-    optional: true
-
-  '@msgpackr-extract/msgpackr-extract-linux-arm@3.0.4':
-    optional: true
-
-  '@msgpackr-extract/msgpackr-extract-linux-x64@3.0.4':
-    optional: true
-
-  '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.4':
-    optional: true
-
   '@mui/core-downloads-tracker@9.0.1': {}
 
   '@mui/icons-material@9.0.1(@mui/material@9.0.1(@emotion/react@11.14.0(@types/react@19.2.16)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.16)(react@19.2.7))(@types/react@19.2.16)(react@19.2.7))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react@19.2.16)(react@19.2.7)':
@@ -20246,58 +20299,115 @@ snapshots:
   '@oxc-transform/binding-win32-x64-msvc@0.131.0':
     optional: true
 
+  '@oxlint/binding-android-arm-eabi@1.66.0':
+    optional: true
+
   '@oxlint/binding-android-arm-eabi@1.68.0':
+    optional: true
+
+  '@oxlint/binding-android-arm64@1.66.0':
     optional: true
 
   '@oxlint/binding-android-arm64@1.68.0':
     optional: true
 
+  '@oxlint/binding-darwin-arm64@1.66.0':
+    optional: true
+
   '@oxlint/binding-darwin-arm64@1.68.0':
+    optional: true
+
+  '@oxlint/binding-darwin-x64@1.66.0':
     optional: true
 
   '@oxlint/binding-darwin-x64@1.68.0':
     optional: true
 
+  '@oxlint/binding-freebsd-x64@1.66.0':
+    optional: true
+
   '@oxlint/binding-freebsd-x64@1.68.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm-gnueabihf@1.66.0':
     optional: true
 
   '@oxlint/binding-linux-arm-gnueabihf@1.68.0':
     optional: true
 
+  '@oxlint/binding-linux-arm-musleabihf@1.66.0':
+    optional: true
+
   '@oxlint/binding-linux-arm-musleabihf@1.68.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm64-gnu@1.66.0':
     optional: true
 
   '@oxlint/binding-linux-arm64-gnu@1.68.0':
     optional: true
 
+  '@oxlint/binding-linux-arm64-musl@1.66.0':
+    optional: true
+
   '@oxlint/binding-linux-arm64-musl@1.68.0':
+    optional: true
+
+  '@oxlint/binding-linux-ppc64-gnu@1.66.0':
     optional: true
 
   '@oxlint/binding-linux-ppc64-gnu@1.68.0':
     optional: true
 
+  '@oxlint/binding-linux-riscv64-gnu@1.66.0':
+    optional: true
+
   '@oxlint/binding-linux-riscv64-gnu@1.68.0':
+    optional: true
+
+  '@oxlint/binding-linux-riscv64-musl@1.66.0':
     optional: true
 
   '@oxlint/binding-linux-riscv64-musl@1.68.0':
     optional: true
 
+  '@oxlint/binding-linux-s390x-gnu@1.66.0':
+    optional: true
+
   '@oxlint/binding-linux-s390x-gnu@1.68.0':
+    optional: true
+
+  '@oxlint/binding-linux-x64-gnu@1.66.0':
     optional: true
 
   '@oxlint/binding-linux-x64-gnu@1.68.0':
     optional: true
 
+  '@oxlint/binding-linux-x64-musl@1.66.0':
+    optional: true
+
   '@oxlint/binding-linux-x64-musl@1.68.0':
+    optional: true
+
+  '@oxlint/binding-openharmony-arm64@1.66.0':
     optional: true
 
   '@oxlint/binding-openharmony-arm64@1.68.0':
     optional: true
 
+  '@oxlint/binding-win32-arm64-msvc@1.66.0':
+    optional: true
+
   '@oxlint/binding-win32-arm64-msvc@1.68.0':
     optional: true
 
+  '@oxlint/binding-win32-ia32-msvc@1.66.0':
+    optional: true
+
   '@oxlint/binding-win32-ia32-msvc@1.68.0':
+    optional: true
+
+  '@oxlint/binding-win32-x64-msvc@1.66.0':
     optional: true
 
   '@oxlint/binding-win32-x64-msvc@1.68.0':
@@ -20624,9 +20734,9 @@ snapshots:
       react-aria: 3.49.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react-dom: 19.2.7(react@19.2.7)
 
-  '@react-grab/cli@0.1.44':
+  '@react-grab/cli@0.1.46':
     dependencies:
-      agent-install: 0.0.5
+      agent-install: 0.0.6
       commander: 14.0.3
       ignore: 7.0.5
       ora: 9.4.0
@@ -26019,6 +26129,15 @@ snapshots:
       prompts: 2.4.2
       yaml: 2.9.0
 
+  agent-install@0.0.6:
+    dependencies:
+      '@iarna/toml': 2.2.5
+      commander: 14.0.3
+      jsonc-parser: 3.3.1
+      picocolors: 1.1.1
+      prompts: 2.4.2
+      yaml: 2.9.0
+
   agentkeepalive@4.6.0:
     dependencies:
       humanize-ms: 1.2.1
@@ -27300,7 +27419,7 @@ snapshots:
       inherits: 2.0.4
       minimalistic-assert: 1.0.1
 
-  deslop-js@0.0.14:
+  deslop-js@0.0.24:
     dependencies:
       '@oxc-project/types': 0.132.0
       fast-glob: 3.3.3
@@ -27491,19 +27610,6 @@ snapshots:
       wif: 2.0.6
 
   ee-first@1.1.1: {}
-
-  effect@4.0.0-beta.70:
-    dependencies:
-      '@standard-schema/spec': 1.1.0
-      fast-check: 4.8.0
-      find-my-way-ts: 0.1.6
-      ini: 7.0.0
-      kubernetes-types: 1.30.0
-      msgpackr: 2.0.2
-      multipasta: 0.2.7
-      toml: 4.1.1
-      uuid: 14.0.0
-      yaml: 2.9.0
 
   ejs@3.1.10:
     dependencies:
@@ -28072,10 +28178,6 @@ snapshots:
 
   eyes@0.1.8: {}
 
-  fast-check@4.8.0:
-    dependencies:
-      pure-rand: 8.4.0
-
   fast-copy@3.0.2: {}
 
   fast-deep-equal@3.1.3: {}
@@ -28195,8 +28297,6 @@ snapshots:
       unpipe: 1.0.0
     transitivePeerDependencies:
       - supports-color
-
-  find-my-way-ts@0.1.6: {}
 
   find-root@1.1.0: {}
 
@@ -28785,8 +28885,6 @@ snapshots:
 
   ini@6.0.0: {}
 
-  ini@7.0.0: {}
-
   inline-style-parser@0.1.1: {}
 
   invariant@2.2.4:
@@ -29201,8 +29299,6 @@ snapshots:
       zod: 4.4.3
 
   knitwork@1.3.0: {}
-
-  kubernetes-types@1.30.0: {}
 
   launch-editor@2.14.1:
     dependencies:
@@ -30209,27 +30305,9 @@ snapshots:
 
   ms@2.1.3: {}
 
-  msgpackr-extract@3.0.4:
-    dependencies:
-      node-gyp-build-optional-packages: 5.2.2
-    optionalDependencies:
-      '@msgpackr-extract/msgpackr-extract-darwin-arm64': 3.0.4
-      '@msgpackr-extract/msgpackr-extract-darwin-x64': 3.0.4
-      '@msgpackr-extract/msgpackr-extract-linux-arm': 3.0.4
-      '@msgpackr-extract/msgpackr-extract-linux-arm64': 3.0.4
-      '@msgpackr-extract/msgpackr-extract-linux-x64': 3.0.4
-      '@msgpackr-extract/msgpackr-extract-win32-x64': 3.0.4
-    optional: true
-
-  msgpackr@2.0.2:
-    optionalDependencies:
-      msgpackr-extract: 3.0.4
-
   muggle-string@0.4.1: {}
 
   multiformats@9.9.0: {}
-
-  multipasta@0.2.7: {}
 
   nanoclone@0.2.1: {}
 
@@ -30416,11 +30494,6 @@ snapshots:
       encoding: 0.1.13
 
   node-forge@1.4.0: {}
-
-  node-gyp-build-optional-packages@5.2.2:
-    dependencies:
-      detect-libc: 2.1.2
-    optional: true
 
   node-gyp-build@4.8.4: {}
 
@@ -31000,12 +31073,34 @@ snapshots:
       oxc-parser: 0.131.0
       rolldown: 1.0.3
 
-  oxlint-plugin-react-doctor@0.2.16:
+  oxlint-plugin-react-doctor@0.5.6:
     dependencies:
       '@typescript-eslint/types': 8.60.1
       eslint-scope: 9.1.2
       eslint-visitor-keys: 5.0.1
       oxc-parser: 0.132.0
+
+  oxlint@1.66.0:
+    optionalDependencies:
+      '@oxlint/binding-android-arm-eabi': 1.66.0
+      '@oxlint/binding-android-arm64': 1.66.0
+      '@oxlint/binding-darwin-arm64': 1.66.0
+      '@oxlint/binding-darwin-x64': 1.66.0
+      '@oxlint/binding-freebsd-x64': 1.66.0
+      '@oxlint/binding-linux-arm-gnueabihf': 1.66.0
+      '@oxlint/binding-linux-arm-musleabihf': 1.66.0
+      '@oxlint/binding-linux-arm64-gnu': 1.66.0
+      '@oxlint/binding-linux-arm64-musl': 1.66.0
+      '@oxlint/binding-linux-ppc64-gnu': 1.66.0
+      '@oxlint/binding-linux-riscv64-gnu': 1.66.0
+      '@oxlint/binding-linux-riscv64-musl': 1.66.0
+      '@oxlint/binding-linux-s390x-gnu': 1.66.0
+      '@oxlint/binding-linux-x64-gnu': 1.66.0
+      '@oxlint/binding-linux-x64-musl': 1.66.0
+      '@oxlint/binding-openharmony-arm64': 1.66.0
+      '@oxlint/binding-win32-arm64-msvc': 1.66.0
+      '@oxlint/binding-win32-ia32-msvc': 1.66.0
+      '@oxlint/binding-win32-x64-msvc': 1.66.0
 
   oxlint@1.68.0:
     optionalDependencies:
@@ -31028,6 +31123,7 @@ snapshots:
       '@oxlint/binding-win32-arm64-msvc': 1.68.0
       '@oxlint/binding-win32-ia32-msvc': 1.68.0
       '@oxlint/binding-win32-x64-msvc': 1.68.0
+    optional: true
 
   p-cancelable@2.1.1: {}
 
@@ -31704,8 +31800,6 @@ snapshots:
 
   punycode@2.3.1: {}
 
-  pure-rand@8.4.0: {}
-
   qr-code-styling@1.9.2:
     dependencies:
       qrcode-generator: 1.5.2
@@ -31830,31 +31924,29 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  react-doctor@0.2.16(bufferutil@4.1.0)(eslint@10.4.1(jiti@2.7.0))(utf-8-validate@6.0.6):
+  react-doctor@0.5.6(eslint@10.4.1(jiti@2.7.0)):
     dependencies:
       '@babel/code-frame': 7.29.7
-      '@effect/platform-node-shared': 4.0.0-beta.70(bufferutil@4.1.0)(effect@4.0.0-beta.70)(utf-8-validate@6.0.6)
       '@sentry/node': 10.55.0
       agent-install: 0.0.5
       conf: 15.1.0
       confbox: 0.2.4
-      deslop-js: 0.0.14
-      effect: 4.0.0-beta.70
+      deslop-js: 0.0.24
       eslint-plugin-react-hooks: 7.1.1(eslint@10.4.1(jiti@2.7.0))
       jiti: 2.7.0
       magicast: 0.5.3
-      oxlint: 1.68.0
-      oxlint-plugin-react-doctor: 0.2.16
+      oxlint: 1.66.0
+      oxlint-plugin-react-doctor: 0.5.6
       prompts: 2.4.2
       typescript: 6.0.3
+      vscode-languageserver: 9.0.1
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-uri: 3.1.0
     transitivePeerDependencies:
       - '@opentelemetry/exporter-trace-otlp-http'
-      - bufferutil
       - eslint
       - oxlint-tsgolint
       - supports-color
-      - utf-8-validate
-      - vite-plus
 
   react-dom@19.2.7(react@19.2.7):
     dependencies:
@@ -31875,9 +31967,9 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.16
 
-  react-grab@0.1.44(react@19.2.7):
+  react-grab@0.1.46(react@19.2.7):
     dependencies:
-      '@react-grab/cli': 0.1.44
+      '@react-grab/cli': 0.1.46
       bippy: 0.5.41(react@19.2.7)
     optionalDependencies:
       react: 19.2.7
@@ -32012,7 +32104,7 @@ snapshots:
     optionalDependencies:
       react-dom: 19.2.7(react@19.2.7)
 
-  react-scan@0.5.7(bufferutil@4.1.0)(esbuild@0.28.0)(eslint@10.4.1(jiti@2.7.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.61.0)(utf-8-validate@6.0.6):
+  react-scan@0.5.7(esbuild@0.28.0)(eslint@10.4.1(jiti@2.7.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.61.0):
     dependencies:
       '@babel/core': 7.29.7
       '@babel/types': 7.29.7
@@ -32024,21 +32116,18 @@ snapshots:
       preact: 10.29.2
       prompts: 2.4.2
       react: 19.2.7
-      react-doctor: 0.2.16(bufferutil@4.1.0)(eslint@10.4.1(jiti@2.7.0))(utf-8-validate@6.0.6)
+      react-doctor: 0.5.6(eslint@10.4.1(jiti@2.7.0))
       react-dom: 19.2.7(react@19.2.7)
-      react-grab: 0.1.44(react@19.2.7)
+      react-grab: 0.1.46(react@19.2.7)
     optionalDependencies:
       esbuild: 0.28.0
       unplugin: 3.0.0
     transitivePeerDependencies:
       - '@opentelemetry/exporter-trace-otlp-http'
-      - bufferutil
       - eslint
       - oxlint-tsgolint
       - rollup
       - supports-color
-      - utf-8-validate
-      - vite-plus
 
   react-stately@3.47.0(react@19.2.7):
     dependencies:
@@ -33177,8 +33266,6 @@ snapshots:
 
   toml@3.0.0: {}
 
-  toml@4.1.1: {}
-
   toposort@2.0.2: {}
 
   totalist@3.0.1: {}
@@ -33945,6 +34032,21 @@ snapshots:
   vm-browserify@1.1.2: {}
 
   void-elements@3.1.0: {}
+
+  vscode-jsonrpc@8.2.0: {}
+
+  vscode-languageserver-protocol@3.17.5:
+    dependencies:
+      vscode-jsonrpc: 8.2.0
+      vscode-languageserver-types: 3.17.5
+
+  vscode-languageserver-textdocument@1.0.12: {}
+
+  vscode-languageserver-types@3.17.5: {}
+
+  vscode-languageserver@9.0.1:
+    dependencies:
+      vscode-languageserver-protocol: 3.17.5
 
   vscode-uri@3.1.0: {}
 


### PR DESCRIPTION
## Which Linear task is linked to this PR?

[EMB-456](https://linear.app/lifi-linear/issue/EMB-456/drop-react-18-support-migrate-to-react-19)

## Why was it implemented this way?

Formalizes the move off React 18 — the repo already ran on React 19.2.7, so this makes it official and adopts React 19 idioms:

- `react`/`react-dom` peer deps narrowed `>=18` → `>=19` (`widget`, `wallet-management`, `widget-light`).
- `forwardRef` removed from 11 components (ref passed as a prop; `useImperativeHandle` kept).
- `<Context.Provider>` → `<Context>` and `useContext` → `use()` across packages.
- Header `ResizeObserver` → React 19 ref-cleanup callback.
- The 6 `widget-provider-*` packages use React-19-only APIs (`use()`), so they now declare a `react >=19` peer dependency.

**Bumped `minor`** (changeset): v4 is already released, so the React-version floor is treated as a support-matrix change, not a breaking API change.

The Rust/oxc **React Compiler** was evaluated and **deferred** — it's a no-op in the rolldown bundler path at current versions (experimental); the Babel path was intentionally not used.

Also refreshes a few stale facts in `CLAUDE.md` (separate `docs:` commit).

## Visual showcase (Screenshots or Videos)

_No visual change._ Verified: `check:types` + Biome across all packages, 40 widget tests, full build, and browser smoke of the default + drawer-`ref` paths.

## Checklist before requesting a review
- [x] I have performed a self-review and testing of my code.
- [x] This pull request is focused and addresses a single problem.
- [ ] If this PR modifies the Widget API or adds new features that require documentation, I have updated the documentation in the [public-docs](https://github.com/lifinance/public-docs) repository. _(N/A — no Widget API change.)_
