### PR TITLE
fix(widget): hide pre-flight warnings on bridge status screen during execution

### DIFF
--- a/.changeset/emb-448-funds-warning-status-screen.md
+++ b/.changeset/emb-448-funds-warning-status-screen.md
@@ -1,0 +1,5 @@
+---
+'@lifi/widget': patch
+---
+
+Fix a false "Not enough funds" warning that appeared on the transaction status screen while waiting for the destination chain. Pre-flight warning messages are no longer rendered during the in-progress (pending) execution state, restoring the behavior from before the v4 execution page redesign.

--- a/packages/widget/src/pages/TransactionPage/TransactionExecutionContent.tsx
+++ b/packages/widget/src/pages/TransactionPage/TransactionExecutionContent.tsx
@@ -76,13 +76,15 @@ export const TransactionExecutionContent: React.FC<
             iconSlot={iconSlot}
             footerSlot={footerSlot}
           />
-          <WarningMessages route={route} allowInteraction />
           {status === RouteExecutionStatus.Failed ? (
-            <TransactionFailedButtons
-              route={route}
-              restartRoute={restartRoute}
-              deleteRoute={deleteRoute}
-            />
+            <>
+              <WarningMessages route={route} allowInteraction />
+              <TransactionFailedButtons
+                route={route}
+                restartRoute={restartRoute}
+                deleteRoute={deleteRoute}
+              />
+            </>
           ) : isDone ? (
             <TransactionDoneButtons route={route} status={status} />
           ) : null}


### PR DESCRIPTION
## Which Linear task is linked to this PR?

[EMB-448 — "Not enough funds" warning appears on bridge status screen after balance refetch](https://linear.app/lifi-linear/issue/EMB-448/triage-not-enough-funds-warning-appears-on-bridge-status-screen-after)

## Why was it implemented this way?

**The bug:** On the bridge status screen ("Waiting for destination chain"), the banner *"You don't have enough funds to complete the transaction."* appears ~1–2 min after the source transaction is already confirmed. By then the bridged funds have left the wallet, so the periodic (30 s) balance re-fetch makes the pre-flight sufficiency check fail.

**Root cause — a regression from #666.** The sufficiency hooks (`useFromTokenSufficiency`, `useGasSufficiency`) are *pre-flight* checks and were always correct for their original purpose. The problem is *where* they're consumed:

- **Before #666**, `WarningMessages` was rendered only when `status === Idle || Failed`, and **never during `Pending`** (the executing/"waiting for destination" state used a separate `StatusBottomSheet` with no warnings).
- **#666 ("new widget v4 execution page design")** split the page into `TransactionReview` (Idle) and `TransactionExecutionContent` (every non-idle state: `Pending | Done | Failed`) and moved `WarningMessages` into the latter, rendered **unconditionally**. So the pre-flight checks began rendering during `Pending` for the first time → the false warning.

**The fix (minimal, one file):** gate the execution-screen `WarningMessages` to `status === Failed`, restoring exact pre-#666 parity:

| State | Behavior after fix |
|-------|--------------------|
| Idle (review) | warnings shown (via `TransactionReview`, unchanged) |
| Pending (waiting for destination) | **no warnings** ✅ |
| Done | no warnings |
| Failed (retry) | warnings shown |

**Alternative considered:** gating the individual funds/gas messages inside `useMessageQueue` by route-active state. Rejected in favor of the smaller, behavior-faithful change — it touches one presentational file, leaves the sufficiency hooks and the message queue untouched, and exactly reproduces how the widget behaved before the redesign.

## Visual showcase (Screenshots or Videos)

N/A — the change removes an erroneous warning during the in-progress execution state. Reproduction per the issue: start a long (10+ min) bridge (e.g. ETH on Ethereum → ETH on Base) and stay on the status screen; previously the warning appeared after ~1–2 min, now it does not.

## Checklist before requesting a review
- [x] I have performed a self-review and testing of my code.
- [x] This pull request is focused and addresses a single problem.
- [ ] If this PR modifies the Widget API or adds new features that require documentation, I have updated the documentation in the [public-docs](https://github.com/lifinance/public-docs) repository.
