### PR TITLE
fix(playground): drop non-existent isSkeletonSideBySide reference in WidgetNextView

### DIFF
--- a/packages/widget-playground-next/src/app/WidgetNextView.tsx
+++ b/packages/widget-playground-next/src/app/WidgetNextView.tsx
@@ -11,7 +11,7 @@ import { ClientOnly } from './ClientOnly.js'
 export function WidgetNextView() {
   const { config } = useConfig()
   const drawerRef = useRef<WidgetDrawer>(null)
-  const { isSkeletonShown, isSkeletonSideBySide } = useSkeletonToolValues()
+  const { isSkeletonShown } = useSkeletonToolValues()
 
   const toggleDrawer = useCallback(() => {
     drawerRef?.current?.toggleDrawer()
@@ -19,7 +19,7 @@ export function WidgetNextView() {
 
   return (
     <WidgetViewContainer toggleDrawer={toggleDrawer}>
-      {!isSkeletonShown || isSkeletonSideBySide ? (
+      {!isSkeletonShown ? (
         <ClientOnly fallback={<WidgetSkeleton config={config} />}>
           <LiFiWidget
             config={config}


### PR DESCRIPTION
## Which Linear task is linked to this PR?

_None — pre-existing type-error cleanup (surfaced while reviewing the playground-next build)._

## Why was it implemented this way?

`WidgetNextView` destructured `isSkeletonSideBySide` from `useSkeletonToolValues()`, but that hook returns only `{ isSkeletonShown: boolean }` — there is **no** side-by-side concept anywhere in the edit-tools store. So the property was always `undefined`, which means `!isSkeletonShown || isSkeletonSideBySide` already evaluated to plain `!isSkeletonShown` at runtime. Removing the reference is therefore **behavior-preserving** and brings the file in line with the canonical vite `WidgetView` (a straight widget/skeleton toggle).

Why it went unnoticed: `pnpm check:types` runs per-package `check:types`, and `widget-playground-next` has no such script — so the error only appeared during `next build`'s type-check, where it was masked by `typescript.ignoreBuildErrors: true`.

Alternative considered: implementing an actual side-by-side skeleton mode in the store. Rejected — there's no evidence the feature is wanted (it doesn't exist in the store or the vite playground), so that would be inventing a feature, not fixing a bug.

Scoped deliberately: this only removes the dead reference. `ignoreBuildErrors` stays (it still guards other latent playground type issues) and `next.config.mjs` is untouched.

## Visual showcase (Screenshots or Videos)

No UI change (the removed branch was dead — the value was always `undefined`). Verified the type error is gone via `tsc --noEmit` on `widget-playground-next`: present before (`WidgetNextView.tsx(14,28): Property 'isSkeletonSideBySide' does not exist on type '{ isSkeletonShown: boolean; }'`), zero occurrences after.

## Checklist before requesting a review
- [x] I have performed a self-review and testing of my code.
- [x] This pull request is focused and addresses a single problem.
- [ ] If this PR modifies the Widget API or adds new features that require documentation, I have updated the documentation in the [public-docs](https://github.com/lifinance/public-docs) repository. — _N/A; private playground only, no API change._
