### PR TITLE
feat: remove Porto wallet support (Ithaca sunset)

### DIFF
--- a/.changeset/remove-porto.md
+++ b/.changeset/remove-porto.md
@@ -1,0 +1,6 @@
+---
+"@lifi/widget-provider-ethereum": minor
+"@lifi/wallet-management": patch
+---
+
+Remove Porto wallet connector support following the Ithaca Porto sunset. The `porto` option on `EthereumProviderConfig` and `createDefaultWagmiConfig` is removed, along with the Porto wallet icon and tag.

--- a/knip.json
+++ b/knip.json
@@ -24,8 +24,7 @@
         "@coinbase/wallet-sdk",
         "@metamask/connect-evm",
         "@metamask/connect-multichain",
-        "@walletconnect/ethereum-provider",
-        "porto"
+        "@walletconnect/ethereum-provider"
       ]
     }
   }

--- a/packages/wallet-management/src/icons.ts
+++ b/packages/wallet-management/src/icons.ts
@@ -13,8 +13,6 @@ export const getWalletIcon = (id: string): string | undefined => {
       return 'https://lifinance.github.io/types/src/assets/icons/wallets/metamask.svg'
     case 'baseAccount':
       return 'https://lifinance.github.io/types/src/assets/icons/wallets/baseAccount.svg'
-    case 'xyz.ithaca.porto':
-      return 'https://lifinance.github.io/types/src/assets/icons/wallets/porto.svg'
     default:
       break
   }

--- a/packages/wallet-management/src/utils/walletTags.ts
+++ b/packages/wallet-management/src/utils/walletTags.ts
@@ -26,11 +26,7 @@ export const getConnectorTagType = (
       : WalletTagType.GetStarted
   }
 
-  if (
-    connectorId === 'coinbaseWalletSDK' ||
-    connectorId === 'baseAccount' ||
-    connectorId === 'xyz.ithaca.porto'
-  ) {
+  if (connectorId === 'coinbaseWalletSDK' || connectorId === 'baseAccount') {
     return WalletTagType.GetStarted
   }
 

--- a/packages/widget-playground/package.json
+++ b/packages/widget-playground/package.json
@@ -49,7 +49,6 @@
     "csstype": "^3.2.3",
     "lodash.isequal": "^4.5.0",
     "microdiff": "^1.5.0",
-    "porto": "^0.2.37",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "viem": "^2.52.2",

--- a/packages/widget-playground/src/defaultWidgetConfig.ts
+++ b/packages/widget-playground/src/defaultWidgetConfig.ts
@@ -42,7 +42,6 @@ export const widgetBaseConfig: WidgetConfig = {
       coinbase: true,
       metaMask: true,
       walletConnect: true,
-      porto: true,
     }),
     SuiProvider(),
     SolanaProvider(),

--- a/packages/widget-provider-ethereum/src/connectors/porto.ts
+++ b/packages/widget-provider-ethereum/src/connectors/porto.ts
@@ -1,8 +1,0 @@
-import { type PortoParameters, porto } from 'wagmi/connectors'
-import type { CreateConnectorFnExtended } from '../types.js'
-import { extendConnector } from '../utils/extendConnector.js'
-
-export const createPortoConnector = /*#__PURE__*/ (
-  params?: Partial<PortoParameters>
-): CreateConnectorFnExtended =>
-  extendConnector(porto(params), 'xyz.ithaca.porto', 'Porto')

--- a/packages/widget-provider-ethereum/src/providers/EthereumBaseProvider.tsx
+++ b/packages/widget-provider-ethereum/src/providers/EthereumBaseProvider.tsx
@@ -32,7 +32,6 @@ export const EthereumBaseProvider: FC<
         defaultWalletConnectConfig
       ),
       baseAccount: resolveConfig(config?.baseAccount, defaultBaseAccountConfig),
-      porto: resolveConfig(config?.porto, undefined),
       wagmiConfig: {
         ssr: true,
       },

--- a/packages/widget-provider-ethereum/src/providers/EthereumProviderValues.tsx
+++ b/packages/widget-provider-ethereum/src/providers/EthereumProviderValues.tsx
@@ -37,7 +37,6 @@ import { defaultWalletConnectConfig } from '../config/walletConnect.js'
 import { createBaseAccountConnector } from '../connectors/baseAccount.js'
 import { createCoinbaseConnector } from '../connectors/coinbase.js'
 import { createMetaMaskConnector } from '../connectors/metaMask.js'
-import { createPortoConnector } from '../connectors/porto.js'
 import { createWalletConnectConnector } from '../connectors/walletConnect.js'
 import type {
   CreateConnectorFnExtended,
@@ -145,16 +144,6 @@ export const EthereumProviderValues: FC<
           createBaseAccountConnector(
             resolveConfig(config.baseAccount, defaultBaseAccountConfig)!
           )
-        )
-      }
-      if (
-        config?.porto &&
-        !evmConnectors.some((connector) =>
-          connector.id.toLowerCase().includes('porto')
-        )
-      ) {
-        additionalConnectors.unshift(
-          createPortoConnector(resolveConfig(config.porto, undefined))
         )
       }
 

--- a/packages/widget-provider-ethereum/src/types.ts
+++ b/packages/widget-provider-ethereum/src/types.ts
@@ -6,7 +6,6 @@ import type {
   BaseAccountParameters,
   CoinbaseWalletParameters,
   MetaMaskParameters,
-  PortoParameters,
   WalletConnectParameters,
 } from 'wagmi/connectors'
 
@@ -26,7 +25,6 @@ export interface EthereumProviderConfig {
   coinbase?: CoinbaseWalletParameters | boolean
   metaMask?: MetaMaskParameters | boolean
   baseAccount?: BaseAccountParameters | boolean
-  porto?: Partial<PortoParameters> | boolean
   disableMessageSigning?: boolean
   sdkProvider?: SDKProvider | SDKProviderFactory<EthereumProviderDeps>
 }

--- a/packages/widget-provider-ethereum/src/utils/createDefaultWagmiConfig.ts
+++ b/packages/widget-provider-ethereum/src/utils/createDefaultWagmiConfig.ts
@@ -8,14 +8,12 @@ import type {
   BaseAccountParameters,
   CoinbaseWalletParameters,
   MetaMaskParameters,
-  PortoParameters,
   WalletConnectParameters,
 } from 'wagmi/connectors'
 import { safe } from 'wagmi/connectors'
 import { createBaseAccountConnector } from '../connectors/baseAccount.js'
 import { createCoinbaseConnector } from '../connectors/coinbase.js'
 import { createMetaMaskConnector } from '../connectors/metaMask.js'
-import { createPortoConnector } from '../connectors/porto.js'
 import { createWalletConnectConnector } from '../connectors/walletConnect.js'
 
 // Drop viem's bundled mainnet default (eth.merkle.io); BE RPCs arrive via useSyncWagmiConfig.
@@ -32,7 +30,6 @@ export interface DefaultWagmiConfigProps {
   coinbase?: CoinbaseWalletParameters
   metaMask?: MetaMaskParameters
   baseAccount?: BaseAccountParameters
-  porto?: Partial<PortoParameters>
   wagmiConfig?: {
     ssr?: boolean
     multiInjectedProviderDiscovery?: boolean
@@ -139,10 +136,6 @@ export function createDefaultWagmiConfig(
     (recentConnectorId?.includes?.('baseAccount') || !props.lazy)
   ) {
     connectors.unshift(createBaseAccountConnector(props.baseAccount))
-  }
-
-  if (props?.porto && (recentConnectorId?.includes?.('porto') || !props.lazy)) {
-    connectors.unshift(createPortoConnector(props.porto))
   }
 
   return {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1650,9 +1650,6 @@ importers:
       microdiff:
         specifier: ^1.5.0
         version: 1.5.0
-      porto:
-        specifier: ^0.2.37
-        version: 0.2.37(@tanstack/react-query@5.101.0(react@19.2.7))(@types/react@19.2.17)(@wagmi/core@3.5.1(@tanstack/query-core@5.101.0)(@types/react@19.2.17)(react@19.2.7)(typescript@6.0.3)(use-sync-external-store@1.4.0(react@19.2.7))(viem@2.52.2(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)(zod@4.4.3)))(react-native@0.86.0(@babel/core@7.29.7)(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)(typescript@6.0.3)(use-sync-external-store@1.4.0(react@19.2.7))(viem@2.52.2(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)(zod@4.4.3))(wagmi@3.6.17)
       react:
         specifier: ^19.2.7
         version: 19.2.7
@@ -9979,8 +9976,8 @@ packages:
   des.js@1.1.0:
     resolution: {integrity: sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg==}
 
-  deslop-js@0.0.24:
-    resolution: {integrity: sha512-ygcRwJXCUedo+hN1L4Ysm7luo4VWOvKEz/kRKWMlFp5bAtTKeXo+8fk/hQaJKsJ/nfahiqkhlYTlrKIR/5nsQg==}
+  deslop-js@0.5.8:
+    resolution: {integrity: sha512-Vq9D2x4dAIW24zcH55DTrl3/vi13UNKfXgw0yj7ULTssZ6KOdw/oyBHtlvE94KFC9yYEhgFTrGjaqqZKvV9pwA==}
 
   destr@2.0.5:
     resolution: {integrity: sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==}
@@ -12760,8 +12757,8 @@ packages:
       rolldown:
         optional: true
 
-  oxlint-plugin-react-doctor@0.5.6:
-    resolution: {integrity: sha512-my/aMTDi2XmodqTK2ur+UeDLVAnOohIBfwj1AQ5LC3Q2vpcKsUiFjmwVxdy3RuanLXHXJ7hXwAqfmtIaYeyTpQ==}
+  oxlint-plugin-react-doctor@0.5.8:
+    resolution: {integrity: sha512-L0jveKAMbqF1qAqA2Ksu8aH0/Q8FDQxLwXmHYgALa2XlsxEUuamJ+1Da2MhPWJ2ahn+ekFbnWK20qixxD+fw6A==}
     engines: {node: ^20.19.0 || >=22.13.0}
 
   oxlint@1.66.0:
@@ -13569,8 +13566,8 @@ packages:
   react-devtools-core@6.1.5:
     resolution: {integrity: sha512-ePrwPfxAnB+7hgnEr8vpKxL9cmnp7F322t8oqcPshbIQQhDKgFDW4tjhF2wjVbdXF9O/nyuy3sQWd9JGpiLPvA==}
 
-  react-doctor@0.5.6:
-    resolution: {integrity: sha512-xiy7vRG08qFW5XCYvvB6zir1kWtfuEK68h4scBJtOvt1r6bUNyi4zSsUkq5jdU1afJ2+Uq8y8H9KIQlP2sCqQA==}
+  react-doctor@0.5.8:
+    resolution: {integrity: sha512-gDXDQ+48KeFq2jkVgsUhQ67oQ+kUMdnIaA+YeS9VXXZFXSg9wxY5dDxurEpILSh8RwO06W8p6uCnTR+wn5B/GA==}
     engines: {node: ^20.19.0 || >=22.13.0}
     hasBin: true
 
@@ -27815,7 +27812,7 @@ snapshots:
       inherits: 2.0.4
       minimalistic-assert: 1.0.1
 
-  deslop-js@0.0.24:
+  deslop-js@0.5.8:
     dependencies:
       '@oxc-project/types': 0.132.0
       fast-glob: 3.3.3
@@ -31515,12 +31512,12 @@ snapshots:
       oxc-parser: 0.133.0
       rolldown: 1.1.1
 
-  oxlint-plugin-react-doctor@0.5.6:
+  oxlint-plugin-react-doctor@0.5.8:
     dependencies:
       '@typescript-eslint/types': 8.61.1
       eslint-scope: 9.1.2
       eslint-visitor-keys: 5.0.1
-      oxc-parser: 0.132.0
+      oxc-parser: 0.135.0
 
   oxlint@1.66.0:
     optionalDependencies:
@@ -31868,6 +31865,7 @@ snapshots:
       - '@types/react'
       - immer
       - use-sync-external-store
+    optional: true
 
   poseidon-lite@0.2.1: {}
 
@@ -32372,19 +32370,19 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  react-doctor@0.5.6(eslint@10.5.0(jiti@2.7.0)):
+  react-doctor@0.5.8(eslint@10.5.0(jiti@2.7.0)):
     dependencies:
       '@babel/code-frame': 7.29.7
       '@sentry/node': 10.58.0
       agent-install: 0.0.5
       conf: 15.1.0
       confbox: 0.2.4
-      deslop-js: 0.0.24
+      deslop-js: 0.5.8
       eslint-plugin-react-hooks: 7.1.1(eslint@10.5.0(jiti@2.7.0))
       jiti: 2.7.0
       magicast: 0.5.3
       oxlint: 1.66.0
-      oxlint-plugin-react-doctor: 0.5.6
+      oxlint-plugin-react-doctor: 0.5.8
       prompts: 2.4.2
       typescript: 6.0.3
       vscode-languageserver: 9.0.1
@@ -32573,7 +32571,7 @@ snapshots:
       preact: 10.29.2
       prompts: 2.4.2
       react: 19.2.7
-      react-doctor: 0.5.6(eslint@10.5.0(jiti@2.7.0))
+      react-doctor: 0.5.8(eslint@10.5.0(jiti@2.7.0))
       react-dom: 19.2.7(react@19.2.7)
       react-grab: 0.1.47(react@19.2.7)
     optionalDependencies:


### PR DESCRIPTION
## Which Linear task is linked to this PR?

[EMB-458](https://linear.app/lifi-linear/issue/EMB-458/remove-porto-wallet-support-ithaca-sunset)

## Why was it implemented this way?

Ithaca is [sunsetting Porto](https://ithaca.xyz/updates/sunsetting-porto) — users must move funds out by **2026-07-24**, after which the connector stops being useful. Rather than ship a wallet option that's about to break, this removes Porto entirely:

- Deleted the `createPortoConnector` connector.
- Removed the public `porto?` option from `EthereumProviderConfig` and `createDefaultWagmiConfig`, plus its wiring in `EthereumBaseProvider` / `EthereumProviderValues`.
- Removed the Porto wallet icon (`xyz.ithaca.porto`) and its `GetStarted` tag in `@lifi/wallet-management`.
- Dropped the playground usage + `porto` devDependency and the `knip.json` ignore entry.

`porto` is also an optional peer of `@wagmi/connectors`, so it remains in the lockfile transitively, but nothing imports it now that the connector is gone.

**Release:** shipped as a **minor** changeset for `@lifi/widget-provider-ethereum` (4.0.0 → 4.1.0) + a patch for `@lifi/wallet-management`. Removing the `porto` field is technically a breaking type change, but is released as minor per team decision. The flagship `@lifi/widget` does not depend on `@lifi/widget-provider-ethereum`, so it is unaffected.

## Visual showcase (Screenshots or Videos)

Porto no longer appears in the playground wallet list. No UI changes beyond the removed entry.

## Checklist before requesting a review
- [x] I have performed a self-review and testing of my code.
- [x] This pull request is focused and addresses a single problem.
- [ ] If this PR modifies the Widget API or adds new features that require documentation, I have updated the documentation in the [public-docs](https://github.com/lifinance/public-docs) repository.
