### PR TITLE
fix: remove Phantom from Bitcoin wallet connectors

### DIFF
--- a/.changeset/remove-phantom-bitcoin.md
+++ b/.changeset/remove-phantom-bitcoin.md
@@ -1,0 +1,6 @@
+---
+'@lifi/widget-provider-bitcoin': patch
+'@lifi/widget-provider': patch
+---
+
+Remove Phantom from the Bitcoin wallet connectors. Phantom deprecated its Bitcoin wallet and removed the injected `window.phantom.bitcoin` provider, so it no longer connects for Bitcoin. The default Bitcoin config no longer registers the `phantom()` connector, and the `app.phantom.bitcoin` installed-wallet detection has been removed. Phantom for Solana/EVM is unaffected.

--- a/packages/widget-provider-bitcoin/src/utils/createDefaultBigmiConfig.ts
+++ b/packages/widget-provider-bitcoin/src/utils/createDefaultBigmiConfig.ts
@@ -9,7 +9,6 @@ import {
   okx,
   onekey,
   oyl,
-  phantom,
   unhosted,
   unisat,
   xverse,
@@ -55,7 +54,6 @@ export function createDefaultBigmiConfig(
   }
 ): DefaultBigmiConfigResult {
   const connectors: CreateConnectorFn[] = [
-    phantom(),
     xverse(),
     unisat(),
     ctrl(),

--- a/packages/widget-provider/src/utils/isWalletInstalled.ts
+++ b/packages/widget-provider/src/utils/isWalletInstalled.ts
@@ -19,8 +19,6 @@ export const isWalletInstalled = (id: string): boolean => {
           (provider: any) => provider.isCoinbaseWallet
         )
       )
-    case 'app.phantom.bitcoin':
-      return anyWindow?.phantom?.bitcoin?.isPhantom
     case 'com.okex.wallet.bitcoin':
       return anyWindow?.okxwallet?.bitcoin?.isOkxWallet
     case 'XverseProviders.BitcoinProvider':


### PR DESCRIPTION
Phantom deprecated its Bitcoin wallet and removed the injected `window.phantom.bitcoin` provider, so it no longer connects for Bitcoin (and was showing as a dead option in the Bitcoin wallet list).

- `widget-provider-bitcoin`: stop registering the `phantom()` connector in `createDefaultBigmiConfig`.
- `widget-provider`: drop the `app.phantom.bitcoin` case from `isWalletInstalled`.

Phantom for Solana/EVM is unaffected. Verified in the playground: Phantom no longer offers Bitcoin, other BTC wallets remain, and Phantom still connects for Solana/EVM.

Refs [EMB-454](https://linear.app/lifi-linear/issue/EMB-454).