### PR TITLE
chore(ci): bump pinned GitHub Action versions

### DIFF
--- a/.github/actions/pnpm-install/action.yaml
+++ b/.github/actions/pnpm-install/action.yaml
@@ -12,7 +12,7 @@ runs:
   using: 'composite'
   steps:
     - name: Set up pnpm
-      uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+      uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
     - name: Set up Node.js
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:

--- a/.github/workflows/deploy-test-app.yaml
+++ b/.github/workflows/deploy-test-app.yaml
@@ -24,7 +24,7 @@ jobs:
     name: Publish to Cloudflare Pages
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install dependencies
         uses: ./.github/actions/pnpm-install

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -18,10 +18,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@acca2b1b2070338fb9fd1ca27ecee81d687e58e5 # v6.1.2
+        uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v6.2.1
         with:
           role-to-assume: arn:aws:iam::403372804574:role/github-actions
           role-session-name: github-actions-role-session

--- a/.github/workflows/e2e-examples.yml
+++ b/.github/workflows/e2e-examples.yml
@@ -23,7 +23,7 @@ jobs:
       has-examples: ${{ steps.build-matrix.outputs.has-examples }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
@@ -91,7 +91,7 @@ jobs:
         example: ${{ fromJson(needs.detect-changes.outputs.matrix) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install dependencies
         uses: ./.github/actions/pnpm-install

--- a/.github/workflows/e2e-playground-dev.yml
+++ b/.github/workflows/e2e-playground-dev.yml
@@ -56,7 +56,7 @@ jobs:
       smoke: ${{ steps.smoke.outcome }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install dependencies
         uses: ./.github/actions/pnpm-install
@@ -89,7 +89,7 @@ jobs:
 
       - name: Cache Playwright browsers
         id: playwright-cache
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/ms-playwright
           key: playwright-browsers-${{ runner.os }}-${{ hashFiles('e2e/package.json') }}
@@ -148,7 +148,7 @@ jobs:
       actions: read # download-artifact (same grant as e2e-playground.yml's report job)
     steps:
       - name: Download JSON report
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         # Tolerate a missing report: an early failure (e.g. dev server never started)
         # produces no JSON. The summary step then falls back to a generic message.
         continue-on-error: true

--- a/.github/workflows/e2e-playground.yml
+++ b/.github/workflows/e2e-playground.yml
@@ -45,7 +45,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install dependencies
         uses: ./.github/actions/pnpm-install
@@ -91,13 +91,13 @@ jobs:
         shard: [1, 2, 3, 4]
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install dependencies
         uses: ./.github/actions/pnpm-install
 
       - name: Restore playground dist
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: playground-dist
           # upload-artifact strips the common ancestor (packages/) from stored paths,
@@ -106,7 +106,7 @@ jobs:
 
       - name: Cache Playwright browsers
         id: playwright-cache
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/ms-playwright
           key: playwright-browsers-${{ runner.os }}-${{ hashFiles('e2e/package.json') }}
@@ -154,10 +154,10 @@ jobs:
       actions: read
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Download all blob reports
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: all-blob-reports
           pattern: blob-report-*

--- a/.github/workflows/linear-release.yaml
+++ b/.github/workflows/linear-release.yaml
@@ -47,14 +47,14 @@ jobs:
           echo "release_tag=${PACKAGE}@${FULL}" >> "$GITHUB_OUTPUT"
           echo "Resolved $PACKAGE $FULL -> version=$VERSION channel=$CHANNEL"
 
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           fetch-tags: true
           persist-credentials: false
 
       - name: Sync issues to release
-        uses: linear/linear-release-action@ad7da502eec3a93dd17e2e249e6c1cd84e3ee588 # v0.14.0
+        uses: linear/linear-release-action@c0cb8354a362c24c6d3e0948f37fd66d07588e3f # v0.14.5
         with:
           access_key: ${{ secrets.access_key }}
           command: sync
@@ -66,7 +66,7 @@ jobs:
       # prerelease: advance the stage; the release stays open
       - name: Advance stage (alpha/beta)
         if: steps.meta.outputs.channel != 'stable'
-        uses: linear/linear-release-action@ad7da502eec3a93dd17e2e249e6c1cd84e3ee588 # v0.14.0
+        uses: linear/linear-release-action@c0cb8354a362c24c6d3e0948f37fd66d07588e3f # v0.14.5
         with:
           access_key: ${{ secrets.access_key }}
           command: update
@@ -76,7 +76,7 @@ jobs:
       # stable: complete the release (fires the "→ Done" automation)
       - name: Complete release (stable)
         if: steps.meta.outputs.channel == 'stable'
-        uses: linear/linear-release-action@ad7da502eec3a93dd17e2e249e6c1cd84e3ee588 # v0.14.0
+        uses: linear/linear-release-action@c0cb8354a362c24c6d3e0948f37fd66d07588e3f # v0.14.5
         with:
           access_key: ${{ secrets.access_key }}
           command: complete

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -25,7 +25,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Install dependencies
         uses: ./.github/actions/pnpm-install
       - name: Check code
@@ -47,7 +47,7 @@ jobs:
     outputs:
       hasChangesets: ${{ steps.changesets.outputs.hasChangesets }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           # Fetch full history so Changesets can generate changelogs.
           fetch-depth: 0
@@ -57,7 +57,7 @@ jobs:
           cache: 'false' # privileged job — don't restore a potentially poisoned cache
       - name: Create version pull request
         id: changesets
-        uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1.8.0
+        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
           version: pnpm changeset:version
           title: 'chore: version packages'
@@ -78,7 +78,7 @@ jobs:
     outputs:
       publishedPackages: ${{ steps.changesets.outputs.publishedPackages }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
       - name: Install dependencies
@@ -87,7 +87,7 @@ jobs:
           cache: 'false' # privileged job — don't restore a potentially poisoned cache
       - name: Publish to npm
         id: changesets
-        uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1.8.0
+        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
           publish: pnpm changeset:publish
           createGithubReleases: true
@@ -145,7 +145,7 @@ jobs:
       pull-requests: write # post the install comment + remove the label
     steps:
       - name: Checkout PR head
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0

--- a/.github/workflows/qa-review-trigger.yml
+++ b/.github/workflows/qa-review-trigger.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - name: Create GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.QA_APP_ID }}
           private-key: ${{ secrets.QA_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## What

Bumps all pinned GitHub Action versions used across our workflows and composite actions to their latest releases. All actions remain SHA-pinned with a trailing `# vX.Y.Z` version comment.

| Action | Before | After | Type |
|---|---|---|---|
| `actions/checkout` | v6.0.2 | **v7.0.0** | major |
| `actions/cache` | v4.3.0 | **v6.1.0** | major |
| `actions/download-artifact` | v4.1.8 | **v8.0.1** | major |
| `actions/create-github-app-token` | v2 | **v3.2.0** | major |
| `changesets/action` | v1.8.0 | **v1.9.0** | minor |
| `aws-actions/configure-aws-credentials` | v6.1.2 | **v6.2.1** | minor |
| `linear/linear-release-action` | v0.14.0 | **v0.14.5** | patch |
| `pnpm/action-setup` | v6.0.8 | **v6.0.9** | patch |

Already on the latest release, left unchanged: `actions/upload-artifact` v7.0.1, `actions/github-script` v9.0.0, `actions/setup-node` v6.4.0, `marocchino/sticky-pull-request-comment` v3.0.4, `daun/playwright-report-summary` v4.0.0.

## Why

Routine maintenance — companion to the same bump in the `sdk` repo. Brings all actions current; several were a major version or more behind.

## Breaking-change review (the four major bumps)

All verified safe for how this repo uses them:

- **`actions/checkout` v6→v7**: only behavioral change is blocking fork-PR checkout for `pull_request_target`/`workflow_run` (security hardening) + ESM upgrade. We don't use `pull_request_target`.
- **`actions/cache` v4→v6**: Node-24 runtime (v5) + internal ESM migration (v6). No API change. Usage is plain `path`/`key` Playwright-browser caching. GitHub-hosted runners meet the runner ≥2.327.1 requirement.
- **`actions/download-artifact` v4→v8**: the only behavioral break (v5) is for single downloads **by ID** (`artifact-ids:`); every usage here is **by name/pattern**, so unaffected. v6–v8 are Node-runtime + dependency bumps. Compatible with our `upload-artifact` v7 (both produce/consume v4-format artifacts).
- **`actions/create-github-app-token` v2→v3**: Node-24 + removed custom proxy handling (only matters if `HTTP_PROXY`/`HTTPS_PROXY` is set — it isn't here). Usage is `owner`/`repositories` only.

## Files

`.github/actions/pnpm-install/action.yaml`, `.github/workflows/{deploy,deploy-test-app,e2e-examples,e2e-playground,e2e-playground-dev,linear-release,publish,qa-review-trigger}.{yml,yaml}`

No changeset — CI/config-only change.