### PR TITLE
chore(ci): bump CI Node 24 → 26

### DIFF
--- a/.github/actions/pnpm-install/action.yaml
+++ b/.github/actions/pnpm-install/action.yaml
@@ -16,7 +16,7 @@ runs:
     - name: Set up Node.js
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
-        node-version: '24'
+        node-version: '26'
         registry-url: 'https://registry.npmjs.org'
         # '' disables caching entirely (no restore, no save) for privileged jobs.
         cache: ${{ inputs.cache == 'true' && 'pnpm' || '' }}


### PR DESCRIPTION
## What

Bumps the CI Node version **24 → 26** in the shared `pnpm-install` composite action (the only place `node-version` is pinned). Mirrors lifinance/sdk#417.

## Why

This repo's `Release & Publish` → `Changesets` job has been failing with the same error as sdk:

```
🦋  error  Failed to parse data from GitHub
🦋  error  Invalid response body while trying to fetch https://api.github.com/graphql: Premature close
   at .../@changesets/get-github-info@0.8.0/.../changesets-get-github-info.cjs.js:185:11
```

Diagnosis (from the sdk investigation): **not** a GitHub outage, **not** payload size, **not** rate-limiting — the exact `get-github-info` GraphQL query succeeds reliably from outside the runner, but the GitHub-hosted runner fails repeatably. That points at an intermittent **Node 24 HTTP-client (undici) "Premature close"** against GitHub's GraphQL API. Node 26 ships a newer undici.

## Honest caveat

**Unproven** — the failure can't be reproduced outside the runner, so the fix can't be validated locally. The real test is the `Changesets` job on the next push to `main` after merge (it doesn't run on this PR).

## Blast radius

`pnpm-install` is shared by all CI jobs, so this also moves build / test / publish to Node 26. pnpm 11.8.0 supports Node 26; the repo has no `engines.node` / `engine-strict` constraint.

## Fallback if it doesn't help

Wrap `changeset version` in a retry (handles isolated blips), or temporarily bypass the GitHub changelog enrichment for one release.