### PR TITLE
chore: changeset for @lifi/widget maintenance release

### DIFF
--- a/.changeset/widget-maintenance-release.md
+++ b/.changeset/widget-maintenance-release.md
@@ -1,0 +1,5 @@
+---
+"@lifi/widget": patch
+---
+
+Maintenance release (CI/tooling updates).


### PR DESCRIPTION
## What

Adds a single Changesets entry bumping **`@lifi/widget` (patch)** for a maintenance release.

```md
---
"@lifi/widget": patch
---

Maintenance release (CI/tooling updates).
```

## Why

Cuts a patch release of `@lifi/widget` to fold in recent CI/tooling maintenance (pinned-action bumps, CI Node 24 → 26). Per the repo's `updateInternalDependencies: patch` default, bumping `@lifi/widget` cascades a patch to its internal dependents automatically — no need to author changesets for them.

## What happens on merge

On merge to `main`, the `Release & Publish` → `Changesets` job folds this into the aggregated **`chore: version packages`** PR (alongside the other pending changesets). Merging *that* PR is what actually publishes.

Scope intentionally minimal — one changeset file, no code changes.