### PR TITLE
feat(widget): add tokens.verified allowlist and mark included tokens as verified

### DIFF
--- a/.changeset/add-verified-token-allowlist.md
+++ b/.changeset/add-verified-token-allowlist.md
@@ -1,0 +1,6 @@
+---
+"@lifi/widget": minor
+"@lifi/widget-light": minor
+---
+
+Add `tokens.verified` config allowlist to mark specific tokens as trusted, suppressing the unverified token warning without adding them to the featured or popular categories. Tokens from `tokens.include` are now also marked as verified.

--- a/packages/widget-light/src/shared/widgetConfig.ts
+++ b/packages/widget-light/src/shared/widgetConfig.ts
@@ -229,6 +229,7 @@ export type WidgetTokens = {
   featured?: WidgetStaticToken[]
   include?: WidgetToken[]
   popular?: WidgetStaticToken[]
+  verified?: WidgetBaseToken[]
   from?: WidgetAllowDeny<WidgetBaseToken>
   to?: WidgetAllowDeny<WidgetBaseToken>
 } & WidgetAllowDeny<WidgetBaseToken>

--- a/packages/widget/src/hooks/useFilteredByTokenBalances.ts
+++ b/packages/widget/src/hooks/useFilteredByTokenBalances.ts
@@ -11,6 +11,7 @@ import { useSDKClient } from '../providers/SDKClientProvider.js'
 import { useWidgetConfig } from '../providers/WidgetProvider/WidgetProvider.js'
 import type { FormType } from '../stores/form/types.js'
 import { getConfigItemSets, isFormItemAllowed } from '../utils/item.js'
+import { getVerifiedTokensSets } from '../utils/token.js'
 import { isSupportedToken } from '../utils/tokenList.js'
 
 export const useFilteredTokensByBalance = (
@@ -56,11 +57,14 @@ export const useFilteredTokensByBalance = (
       return result
     }
 
+    const verifiedTokensSets = getVerifiedTokensSets(configTokens)
+
     for (const [address, { tokens }] of Object.entries(accountsWithTokens)) {
       result[address] = {}
 
       for (const [chainIdStr, chainTokens] of Object.entries(tokens)) {
         const chainId = Number(chainIdStr)
+        const verifiedAddresses = verifiedTokensSets?.get(chainId)
         // Get balances for this specific chain
         const balances = existingBalances?.[chainId]
         // If no balances, RPC all tokens of the chain
@@ -115,10 +119,11 @@ export const useFilteredTokensByBalance = (
               )
             )
           })
-          // Mark tokens from wallet balances as unverified
+          // Mark tokens from wallet balances as unverified unless allowlisted
           .map((token: WalletTokenExtended) => ({
             ...token,
-            verified: false,
+            verified:
+              verifiedAddresses?.has(token.address.toLowerCase()) ?? false,
           })) as TokenExtended[]
 
         // Combine both sets of tokens - convert WalletTokenExtended to TokenAmount

--- a/packages/widget/src/types/widget.ts
+++ b/packages/widget/src/types/widget.ts
@@ -302,6 +302,7 @@ export type WidgetTokens = {
   featured?: StaticToken[]
   include?: Token[]
   popular?: StaticToken[]
+  verified?: BaseToken[]
 } & AllowDenyItems<BaseToken>
 
 export type WidgetLanguages = {

--- a/packages/widget/src/utils/token.test.ts
+++ b/packages/widget/src/utils/token.test.ts
@@ -1,0 +1,143 @@
+import type { Token } from '@lifi/sdk'
+import { describe, expect, it } from 'vitest'
+import type { TokensByChain, TokenWithVerified } from '../types/token.js'
+import { filterAllowedTokens, getVerifiedTokensSets } from './token.js'
+
+const makeToken = (
+  chainId: number,
+  address: string,
+  verified?: boolean
+): TokenWithVerified => ({
+  chainId,
+  address,
+  symbol: 'TKN',
+  decimals: 18,
+  name: 'Token',
+  priceUSD: '1',
+  verified,
+})
+
+describe('getVerifiedTokensSets', () => {
+  it('should return undefined without a verified allowlist', () => {
+    expect(getVerifiedTokensSets(undefined)).toBeUndefined()
+    expect(getVerifiedTokensSets({})).toBeUndefined()
+    expect(getVerifiedTokensSets({ verified: [] })).toBeUndefined()
+  })
+
+  it('should group lowercase addresses by chain', () => {
+    const sets = getVerifiedTokensSets({
+      verified: [
+        { chainId: 1, address: '0xAbC1' },
+        { chainId: 1, address: '0xDeF2' },
+        { chainId: 137, address: '0xAbC1' },
+      ],
+    })
+    expect(sets?.get(1)).toEqual(new Set(['0xabc1', '0xdef2']))
+    expect(sets?.get(137)).toEqual(new Set(['0xabc1']))
+    expect(sets?.get(10)).toBeUndefined()
+  })
+})
+
+describe('filterAllowedTokens', () => {
+  it('should mark allowlisted tokens as verified', () => {
+    const dataTokens: TokensByChain = {
+      1: [makeToken(1, '0xAAA', false), makeToken(1, '0xBBB', false)],
+    }
+    const result = filterAllowedTokens(dataTokens, {
+      verified: [{ chainId: 1, address: '0xaaa' }],
+    })
+    expect(result?.[1].find((t) => t.address === '0xAAA')?.verified).toBe(true)
+    expect(result?.[1].find((t) => t.address === '0xBBB')?.verified).toBe(false)
+  })
+
+  it('should match allowlisted addresses case-insensitively', () => {
+    const dataTokens: TokensByChain = {
+      1: [makeToken(1, '0xAbCd', false)],
+    }
+    const result = filterAllowedTokens(dataTokens, {
+      verified: [{ chainId: 1, address: '0xABCD' }],
+    })
+    expect(result?.[1][0].verified).toBe(true)
+  })
+
+  it('should not mark tokens verified on a different chain', () => {
+    const dataTokens: TokensByChain = {
+      1: [makeToken(1, '0xAAA', false)],
+    }
+    const result = filterAllowedTokens(dataTokens, {
+      verified: [{ chainId: 137, address: '0xAAA' }],
+    })
+    expect(result?.[1][0].verified).toBe(false)
+  })
+
+  it('should keep verified tokens verified', () => {
+    const dataTokens: TokensByChain = {
+      1: [makeToken(1, '0xAAA', true)],
+    }
+    const result = filterAllowedTokens(dataTokens, {
+      verified: [{ chainId: 1, address: '0xaaa' }],
+    })
+    expect(result?.[1][0].verified).toBe(true)
+  })
+
+  it('should mark include tokens as verified', () => {
+    const includedToken: Token = {
+      chainId: 1,
+      address: '0xCCC',
+      symbol: 'INC',
+      decimals: 18,
+      name: 'Included',
+      priceUSD: '1',
+    }
+    const dataTokens: TokensByChain = {
+      1: [makeToken(1, '0xAAA', false)],
+    }
+    const result = filterAllowedTokens(dataTokens, {
+      include: [includedToken],
+    })
+    expect(result?.[1].find((t) => t.address === '0xCCC')?.verified).toBe(true)
+    expect(result?.[1].find((t) => t.address === '0xAAA')?.verified).toBe(false)
+  })
+
+  it('should not duplicate include tokens that exist in the data and mark the data token as verified', () => {
+    const includedToken: Token = {
+      chainId: 1,
+      address: '0xaaa',
+      symbol: 'INC',
+      decimals: 18,
+      name: 'Included',
+      priceUSD: '1',
+    }
+    const dataTokens: TokensByChain = {
+      1: [makeToken(1, '0xAAA', false)],
+    }
+    const result = filterAllowedTokens(dataTokens, {
+      include: [includedToken],
+    })
+    expect(result?.[1]).toHaveLength(1)
+    // The data token wins to keep its extended data
+    expect(result?.[1][0].address).toBe('0xAAA')
+    expect(result?.[1][0].verified).toBe(true)
+  })
+
+  it('should handle include tokens on chains without data tokens', () => {
+    const includedToken: Token = {
+      chainId: 137,
+      address: '0xCCC',
+      symbol: 'INC',
+      decimals: 18,
+      name: 'Included',
+      priceUSD: '1',
+    }
+    const result = filterAllowedTokens(
+      { 1: [makeToken(1, '0xAAA', true)] },
+      { include: [includedToken] }
+    )
+    expect(result?.[137]).toHaveLength(1)
+    expect(result?.[137][0].verified).toBe(true)
+  })
+
+  it('should return undefined without data tokens', () => {
+    expect(filterAllowedTokens(undefined, {})).toBeUndefined()
+  })
+})

--- a/packages/widget/src/utils/token.ts
+++ b/packages/widget/src/utils/token.ts
@@ -1,14 +1,31 @@
-import type {
-  BaseToken,
-  RouteExtended,
-  Token,
-  TokenAmount,
-  TokenExtended,
-} from '@lifi/sdk'
+import type { BaseToken, RouteExtended, Token, TokenAmount } from '@lifi/sdk'
 import type { FormType } from '../stores/form/types.js'
-import type { TokensByChain } from '../types/token.js'
+import type { TokensByChain, TokenWithVerified } from '../types/token.js'
 import type { WidgetChains, WidgetTokens } from '../types/widget.js'
 import { getConfigItemSets, isFormItemAllowed } from './item.js'
+
+/**
+ * Builds per-chain sets of lowercase token addresses from the
+ * `tokens.verified` config allowlist.
+ */
+export const getVerifiedTokensSets = (
+  configTokens?: WidgetTokens
+): Map<number, Set<string>> | undefined => {
+  if (!configTokens?.verified?.length) {
+    return undefined
+  }
+  const sets = new Map<number, Set<string>>()
+  for (const token of configTokens.verified) {
+    const chainId = Number(token.chainId)
+    let addresses = sets.get(chainId)
+    if (!addresses) {
+      addresses = new Set()
+      sets.set(chainId, addresses)
+    }
+    addresses.add(token.address.toLowerCase())
+  }
+  return sets
+}
 
 /**
  * Merges verified tokens with search tokens.
@@ -74,11 +91,11 @@ export const updateTokenInCache = (
 }
 
 export const filterAllowedTokens = (
-  dataTokens: { [chainId: number]: TokenExtended[] } | undefined,
+  dataTokens: TokensByChain | undefined,
   configTokens?: WidgetTokens,
   chainsConfig?: WidgetChains,
   formType?: FormType
-): { [chainId: number]: TokenExtended[] } | undefined => {
+): TokensByChain | undefined => {
   if (!dataTokens) {
     return
   }
@@ -103,12 +120,16 @@ export const filterAllowedTokens = (
       )
     : allChainIds
 
-  const allowedTokensByChain: { [chainId: number]: TokenExtended[] } = {}
+  const verifiedTokensSets = getVerifiedTokensSets(configTokens)
+
+  const allowedTokensByChain: TokensByChain = {}
   for (const chainId of allowedChainIds) {
-    const chainTokens = [
-      ...dataTokens[chainId],
-      ...includedTokens.filter((t) => Number(t.chainId) === chainId),
-    ]
+    const chainIncludedTokens = includedTokens.filter(
+      (t) => Number(t.chainId) === chainId
+    )
+    const includedAddresses = new Set(
+      chainIncludedTokens.map((t) => t.address.toLowerCase())
+    )
 
     const allowedAddresses = getConfigItemSets(
       configTokens,
@@ -121,11 +142,41 @@ export const filterAllowedTokens = (
       formType
     )
 
-    const filtered = chainTokens.filter((token) =>
-      isFormItemAllowed(token, allowedAddresses, formType, (t) =>
-        t.address.toLowerCase()
-      )
-    )
+    const verifiedAddresses = verifiedTokensSets?.get(chainId)
+
+    const chainTokens: TokenWithVerified[] = [
+      ...(dataTokens[chainId] ?? []),
+      ...chainIncludedTokens,
+    ]
+
+    const filtered: TokenWithVerified[] = []
+    const seenAddresses = new Set<string>()
+    for (const token of chainTokens) {
+      const address = token.address.toLowerCase()
+      // Data tokens come first and win over include duplicates,
+      // keeping their extended data
+      if (seenAddresses.has(address)) {
+        continue
+      }
+      seenAddresses.add(address)
+      if (
+        !isFormItemAllowed(token, allowedAddresses, formType, (t) =>
+          t.address.toLowerCase()
+        )
+      ) {
+        continue
+      }
+      // Include and verified-allowlist tokens are explicitly set by the
+      // integrator, mark them as verified
+      if (
+        !token.verified &&
+        (includedAddresses.has(address) || verifiedAddresses?.has(address))
+      ) {
+        filtered.push({ ...token, verified: true })
+      } else {
+        filtered.push(token)
+      }
+    }
 
     allowedTokensByChain[chainId] = filtered
   }


### PR DESCRIPTION
Adds a `tokens.verified` config allowlist (`{ chainId, address }[]`) that marks specific
tokens as trusted, suppressing the yellow "unverified token" warning for long-tail tokens
(e.g. Earn/vault tokens only reachable via search) without forcing them into the
featured/popular categories ([JUMEMB-4](https://linear.app/lifi-linear/issue/JUMEMB-4/add-a-token-verified-allowlist-to-override-the-yellow-unverified-token)).
Additionally, `tokens.include` entries are now treated as verified (mirroring the existing
featured/popular behavior) and deduplicated against API results — previously an included
token that also appeared in search results was rendered twice.

## Which Linear task is linked to this PR?
https://linear.app/lifi-linear/issue/JUMEMB-4/add-a-token-verified-allowlist-to-override-the-yellow-unverified-token

## Why was it implemented this way?  
I opted for both a `verified` list and to show the `included` tokens as `verified: true` to prefer API data if it exists and only add the verified tag if needbe.


## Checklist before requesting a review  
- [x] I have performed a self-review and testing of my code.  
- [x] This pull request is focused and addresses a single problem.  
- [x] If this PR modifies the Widget API or adds new features that require documentation, I have updated the documentation in the [public-docs](https://github.com/lifinance/public-docs) repository.
