### PR TITLE
feat(checkout): embed checkout inline in playground and polish funding UI

### DIFF
--- a/packages/widget-checkout/src/CheckoutModal.tsx
+++ b/packages/widget-checkout/src/CheckoutModal.tsx
@@ -25,6 +25,7 @@ interface CheckoutModalContextValue {
   closeModal: () => void
   openCloseConfirmation: () => void
   panelEl: HTMLDivElement | null
+  inline: boolean
 }
 
 export const CheckoutModalContext: React.Context<CheckoutModalContextValue | null> =
@@ -39,7 +40,7 @@ export type { CheckoutModalRef }
 export const CheckoutModal: ForwardRefExoticComponent<
   PropsWithChildren<CheckoutModalProps> & RefAttributes<CheckoutModalRef>
 > = forwardRef<CheckoutModalRef, PropsWithChildren<CheckoutModalProps>>(
-  ({ elementRef, open, onClose, children }, ref) => {
+  ({ elementRef, open, onClose, inline, children }, ref) => {
     const openRef = useRef(Boolean(open))
     const [visible, setVisible] = useState(Boolean(open))
     const [confirmOpen, setConfirmOpen] = useState(false)
@@ -98,68 +99,103 @@ export const CheckoutModal: ForwardRefExoticComponent<
 
     const modalContext: CheckoutModalContextValue = useMemo(
       () => ({
-        closeModal: closePanel,
-        openCloseConfirmation: () => setConfirmOpen(true),
+        closeModal: inline ? () => {} : closePanel,
+        openCloseConfirmation: inline ? () => {} : () => setConfirmOpen(true),
         panelEl,
+        inline: Boolean(inline),
       }),
-      [closePanel, panelEl]
+      [inline, closePanel, panelEl]
+    )
+
+    const panel = (
+      <Box
+        ref={(el: HTMLDivElement | null) => {
+          setPanelEl(el)
+          if (elementRef) {
+            elementRef.current = el
+          }
+        }}
+        tabIndex={-1}
+        role="dialog"
+        aria-modal={inline ? undefined : 'true'}
+        aria-label="Checkout"
+        sx={(theme) =>
+          inline
+            ? {
+                position: 'relative',
+                display: 'flex',
+                flexDirection: 'column',
+                minHeight: 0,
+                outline: 'none',
+                width: `min(100%, ${theme.breakpoints.values.sm}px)`,
+                maxHeight: 'min(90dvh, 640px)',
+                overflow: 'hidden',
+                // Inherit only the host widget theme's card *appearance*
+                // (radius, shadow/border) so the inline panel matches the
+                // standard widget — never its layout props (display/height),
+                // which would break the panel's internal scroll.
+                background:
+                  theme.container?.background ??
+                  theme.vars.palette.background.default,
+                borderRadius:
+                  theme.container?.borderRadius ??
+                  theme.vars.shape.borderRadiusTertiary,
+                border: theme.container?.border,
+                boxShadow: theme.container?.boxShadow,
+                filter: theme.container?.filter,
+              }
+            : {
+                position: 'absolute',
+                top: '50%',
+                left: '50%',
+                transform: 'translate(-50%, -50%)',
+                width: `min(calc(100vw - 32px), ${theme.breakpoints.values.sm}px)`,
+                maxHeight: '90dvh',
+                display: 'flex',
+                flexDirection: 'column',
+                outline: 'none',
+                borderRadius: theme.vars.shape.borderRadiusTertiary,
+                boxShadow: theme.shadows[24],
+                bgcolor: 'background.default',
+                overflow: 'hidden',
+              }
+        }
+      >
+        {children}
+        <CloseConfirmationDialog
+          open={confirmOpen}
+          onCancel={handleCancelConfirm}
+          onConfirm={handleConfirmConfirm}
+          container={panelEl}
+        />
+      </Box>
     )
 
     return (
       <CheckoutModalContext.Provider value={modalContext}>
-        <Modal
-          open={visible}
-          onClose={handleModalClose}
-          keepMounted={false}
-          slotProps={
-            {
-              backdrop: {
-                sx: (theme: Theme) => ({
-                  backgroundColor: `rgba(${theme.vars.palette.common.onBackgroundChannel} / 0.48)`,
-                }),
-              },
-              transition: {
-                timeout: { appear: 0, enter: 160, exit: 80 },
-              },
-            } as Parameters<typeof Modal>[0]['slotProps']
-          }
-        >
-          <Box
-            ref={(el: HTMLDivElement | null) => {
-              setPanelEl(el)
-              if (elementRef) {
-                elementRef.current = el
-              }
-            }}
-            tabIndex={-1}
-            role="dialog"
-            aria-modal="true"
-            aria-label="Checkout"
-            sx={(theme) => ({
-              position: 'absolute',
-              top: '50%',
-              left: '50%',
-              transform: 'translate(-50%, -50%)',
-              width: `min(calc(100vw - 32px), ${theme.breakpoints.values.sm}px)`,
-              maxHeight: '90dvh',
-              display: 'flex',
-              flexDirection: 'column',
-              outline: 'none',
-              borderRadius: theme.vars.shape.borderRadiusTertiary,
-              boxShadow: theme.shadows[24],
-              bgcolor: 'background.default',
-              overflow: 'hidden',
-            })}
+        {inline ? (
+          panel
+        ) : (
+          <Modal
+            open={visible}
+            onClose={handleModalClose}
+            keepMounted={false}
+            slotProps={
+              {
+                backdrop: {
+                  sx: (theme: Theme) => ({
+                    backgroundColor: `rgba(${theme.vars.palette.common.onBackgroundChannel} / 0.48)`,
+                  }),
+                },
+                transition: {
+                  timeout: { appear: 0, enter: 160, exit: 80 },
+                },
+              } as Parameters<typeof Modal>[0]['slotProps']
+            }
           >
-            {children}
-            <CloseConfirmationDialog
-              open={confirmOpen}
-              onCancel={handleCancelConfirm}
-              onConfirm={handleConfirmConfirm}
-              container={panelEl}
-            />
-          </Box>
-        </Modal>
+            {panel}
+          </Modal>
+        )}
       </CheckoutModalContext.Provider>
     )
   }

--- a/packages/widget-checkout/src/LifiWidgetCheckout.tsx
+++ b/packages/widget-checkout/src/LifiWidgetCheckout.tsx
@@ -56,6 +56,7 @@ export const LifiWidgetCheckout: ForwardRefExoticComponent<
           elementRef={props.elementRef}
           open={props.open}
           onClose={props.onClose}
+          inline={props.inline}
         >
           <ErrorBoundary>
             <CheckoutConfigGuard>

--- a/packages/widget-checkout/src/components/Header.test.tsx
+++ b/packages/widget-checkout/src/components/Header.test.tsx
@@ -72,7 +72,12 @@ function setup({
   const Wrapper = ({ children }: { children: ReactNode }) => (
     <OnRampSessionsContext.Provider value={store}>
       <CheckoutModalContext.Provider
-        value={{ closeModal, openCloseConfirmation, panelEl: null }}
+        value={{
+          closeModal,
+          openCloseConfirmation,
+          panelEl: null,
+          inline: false,
+        }}
       >
         {children}
       </CheckoutModalContext.Provider>

--- a/packages/widget-checkout/src/components/Header.tsx
+++ b/packages/widget-checkout/src/components/Header.tsx
@@ -138,13 +138,15 @@ export const Header: React.FC<HeaderProps> = ({ title: titleProp }) => {
         <HeaderControlsContainer
           sx={{ justifyContent: 'flex-end', flexShrink: 0 }}
         >
-          <IconButton
-            onClick={handleClose}
-            size="medium"
-            aria-label={t('button.close')}
-          >
-            <CloseIcon />
-          </IconButton>
+          {!modalContext?.inline ? (
+            <IconButton
+              onClick={handleClose}
+              size="medium"
+              aria-label={t('button.close')}
+            >
+              <CloseIcon />
+            </IconButton>
+          ) : null}
         </HeaderControlsContainer>
       </HeaderAppBar>
       <AbandonConfirmationDialog

--- a/packages/widget-checkout/src/pages/SelectSourcePage/ConnectedAccountRow.tsx
+++ b/packages/widget-checkout/src/pages/SelectSourcePage/ConnectedAccountRow.tsx
@@ -4,6 +4,7 @@ import {
   FundingOptionRow,
   FundingOptionSubtitle,
   FundingOptionTitle,
+  GenericIconWrap,
   OptionTextCell,
 } from './SelectSourceFundingOptions.style.js'
 
@@ -33,18 +34,15 @@ export function ConnectedAccountRow({
 }: ConnectedAccountRowProps): JSX.Element {
   return (
     <FundingOptionRow sx={{ alignItems: 'center' }}>
-      <Avatar
-        src={iconSrc}
-        alt=""
-        sx={(theme) => ({
-          width: 40,
-          height: 40,
-          flexShrink: 0,
-          bgcolor: theme.vars.palette.action.hover,
-        })}
-      >
-        {!iconSrc ? fallbackIcon : null}
-      </Avatar>
+      {iconSrc ? (
+        <Avatar
+          src={iconSrc}
+          alt=""
+          sx={{ width: 40, height: 40, flexShrink: 0 }}
+        />
+      ) : (
+        <GenericIconWrap>{fallbackIcon}</GenericIconWrap>
+      )}
       <OptionTextCell>
         <FundingOptionTitle>{title}</FundingOptionTitle>
         <FundingOptionSubtitle noWrap>{subtitle}</FundingOptionSubtitle>

--- a/packages/widget-checkout/src/pages/SelectSourcePage/SelectSourcePage.tsx
+++ b/packages/widget-checkout/src/pages/SelectSourcePage/SelectSourcePage.tsx
@@ -1,5 +1,9 @@
 import { parseUnits } from '@lifi/sdk'
-import { useAccount, useWalletMenu } from '@lifi/wallet-management'
+import {
+  getConnectorIcon,
+  useAccount,
+  useWalletMenu,
+} from '@lifi/wallet-management'
 import {
   FormKeyHelper,
   PageContainer,
@@ -146,7 +150,7 @@ export const SelectSourcePage: React.FC = () => {
     }
     return {
       address: a.address,
-      icon: a.connector?.icon,
+      icon: getConnectorIcon(a.connector),
       walletName:
         a.connector?.displayName ?? a.connector?.name ?? a.name ?? undefined,
     }

--- a/packages/widget-checkout/src/types/config.ts
+++ b/packages/widget-checkout/src/types/config.ts
@@ -26,6 +26,8 @@ export interface CheckoutModalProps {
   elementRef?: RefObject<HTMLDivElement | null>
   open?: boolean
   onClose?(): void
+  /** Render inline (non-modal) instead of as a centered modal overlay. */
+  inline?: boolean
 }
 
 export type CheckoutProps = CheckoutModalProps &

--- a/packages/widget-playground/src/components/Widget/CheckoutWidgetView.tsx
+++ b/packages/widget-playground/src/components/Widget/CheckoutWidgetView.tsx
@@ -2,16 +2,16 @@ import { ChainType } from '@lifi/widget'
 import { LifiWidgetCheckout } from '@lifi/widget-checkout'
 import { meshProvider } from '@lifi/widget-provider-mesh'
 import { transakProvider } from '@lifi/widget-provider-transak'
-import { Box, Button, Typography } from '@mui/material'
-import { type JSX, useCallback, useMemo, useState } from 'react'
+import { Box } from '@mui/material'
+import { type JSX, useMemo } from 'react'
 import { widgetBaseConfig } from '../../defaultWidgetConfig.js'
 import { useEnvVariables } from '../../providers/EnvVariablesProvider.js'
 import { useConfig } from '../../store/widgetConfig/useConfig.js'
 
 const DEFAULT_CHECKOUT_INTEGRATOR = 'widget-transak-test'
-const DEFAULT_CHECKOUT_TO_CHAIN = 1
-// USDC on Ethereum mainnet — demo destination asset when none is configured.
-const DEFAULT_CHECKOUT_TO_TOKEN = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48'
+const DEFAULT_CHECKOUT_TO_CHAIN = 8453
+// USDC on Base — demo destination asset when none is configured.
+const DEFAULT_CHECKOUT_TO_TOKEN = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913'
 
 export function CheckoutWidgetView(): JSX.Element {
   const { config } = useConfig()
@@ -21,15 +21,6 @@ export function CheckoutWidgetView(): JSX.Element {
     checkoutToToken,
     checkoutToAddress,
   } = useEnvVariables()
-  const [open, setOpen] = useState(false)
-
-  const handleOpen = useCallback(() => {
-    setOpen(true)
-  }, [])
-
-  const handleClose = useCallback(() => {
-    setOpen(false)
-  }, [])
 
   // TODO(cleanup-remove-integrator-override-heuristic): Remove this heuristic comparison against
   // widgetBaseConfig.integrator and use a strict precedence contract.
@@ -75,38 +66,18 @@ export function CheckoutWidgetView(): JSX.Element {
         flexDirection: 'column',
         alignItems: 'center',
         justifyContent: 'center',
-        gap: 2,
         p: 3,
         flex: 1,
         minHeight: 320,
+        width: '100%',
       }}
     >
-      <Typography
-        variant="body2"
-        color="text.secondary"
-        sx={{ textAlign: 'center' }}
-      >
-        Checkout — opens as a centered widget
-      </Typography>
-      {resolvedToAddress ? (
-        <Typography
-          variant="caption"
-          color="text.secondary"
-          sx={{ textAlign: 'center', wordBreak: 'break-all' }}
-        >
-          Recipient: {resolvedToAddress}
-        </Typography>
-      ) : null}
-      <Button variant="contained" onClick={handleOpen}>
-        Deposit
-      </Button>
       <LifiWidgetCheckout
-        open={open}
+        inline
         integrator={resolvedIntegrator}
         config={checkoutConfig}
         allowUserDestinationAddress={!resolvedToAddress}
         onRampProviders={onRampProviders}
-        onClose={handleClose}
       />
     </Box>
   )


### PR DESCRIPTION
## Which Linear task is linked to this PR?

_N/A_

## Why was it implemented this way?

Three small, related improvements to the checkout experience (all in private packages — no changeset needed):

1. **Inline checkout embed (playground).** The playground's Checkout preview showed a `DEPOSIT` button that opened the checkout as a centered modal overlay (which dimmed the whole page). `@lifi/widget-checkout` was modal-only, so a new opt-in `inline` prop was added to `LifiWidgetCheckout`/`CheckoutModal` that renders the panel in-flow (no `<Modal>`/backdrop) and hides the header close button. The inline panel inherits **only** the host widget theme's card *appearance* (`theme.container` → border-radius + drop-shadow), matching the standard widget, while keeping its own structural layout (`display:flex` / `maxHeight` / `overflow:hidden`) so the internal scroll chain still engages on tall pages (e.g. the deposit-address screen). Spreading the whole `theme.container` was avoided because it pulls in layout props (`display`/`height`) that broke the flex-scroll and clipped tall content.

2. **Connected wallet icon fix.** The connected "Pay from Wallet" row read `account.connector?.icon`, which is `undefined` for the widget's custom EVM SDK connectors (metaMask/coinbase/walletConnect/…), leaving a near-invisible avatar. It now resolves through the existing `getConnectorIcon` helper (`getWalletIcon(id) || connector.icon`) and, when no icon is available, renders the same `GenericIconWrap` black glyph used by the disconnected state.

3. **Default checkout destination → USDC on Base** (playground demo default).

## Visual showcase (Screenshots or Videos)

Checkout now renders inline in the playground preview as a proper elevated card (white-on-grey, 16px radius, `drop-shadow(0 8px 32px rgba(0,0,0,0.08))` — identical to the standard widget), with a working close-button-less header, correct connected-wallet icon, and internal scrolling on tall pages.

## Checklist before requesting a review
- [x] I have performed a self-review and testing of my code.
- [x] This pull request is focused and addresses a single problem.
- [ ] If this PR modifies the Widget API or adds new features that require documentation, I have updated the documentation in the [public-docs](https://github.com/lifinance/public-docs) repository.

---
Verification: `check:types` + Biome pass; `@lifi/widget-checkout` tests 196/196; inline embed, shadow, scroll, and the connected wallet icon confirmed in the running playground.