### PR TITLE
fix(ci): prevent command injection via PR branch name in test-app workflows (DO-691)

### DIFF
--- a/.github/workflows/delete-test-app.yaml
+++ b/.github/workflows/delete-test-app.yaml
@@ -19,8 +19,8 @@ jobs:
     steps:
       - name: Set Project Name
         run: |
-          export NAME=$(echo ${{ env.BRANCH_NAME }} | tr -d -c '[:alnum:]' | tr '[:upper:]' '[:lower:]')
-          echo "PROJECT_NAME=widget-${NAME:0:10}" >> $GITHUB_ENV
+          export NAME=$(printf '%s' "$BRANCH_NAME" | tr -d -c '[:alnum:]' | tr '[:upper:]' '[:lower:]')
+          echo "PROJECT_NAME=widget-${NAME:0:10}" >> "$GITHUB_ENV"
 
       - name: Delete project if present
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0

--- a/.github/workflows/delete-test-app.yaml
+++ b/.github/workflows/delete-test-app.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Set Project Name
         run: |
           export NAME=$(printf '%s' "$BRANCH_NAME" | tr -d -c '[:alnum:]' | tr '[:upper:]' '[:lower:]')
-          echo "PROJECT_NAME=widget-${NAME:0:10}" >> "$GITHUB_ENV"
+          echo "PROJECT_NAME=widget-${NAME:0:10}" >> $GITHUB_ENV
 
       - name: Delete project if present
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0

--- a/.github/workflows/deploy-test-app.yaml
+++ b/.github/workflows/deploy-test-app.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: Set Project Name
         run: |
           export NAME=$(printf '%s' "$BRANCH_NAME" | tr -d -c '[:alnum:]' | tr '[:upper:]' '[:lower:]')
-          echo "PROJECT_NAME=widget-${NAME:0:10}" >> "$GITHUB_ENV"
+          echo "PROJECT_NAME=widget-${NAME:0:10}" >> $GITHUB_ENV
 
       - name: Create project if not present
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0

--- a/.github/workflows/deploy-test-app.yaml
+++ b/.github/workflows/deploy-test-app.yaml
@@ -36,8 +36,8 @@ jobs:
 
       - name: Set Project Name
         run: |
-          export NAME=$(echo ${{ env.BRANCH_NAME }} | tr -d -c '[:alnum:]' | tr '[:upper:]' '[:lower:]')
-          echo "PROJECT_NAME=widget-${NAME:0:10}" >> $GITHUB_ENV
+          export NAME=$(printf '%s' "$BRANCH_NAME" | tr -d -c '[:alnum:]' | tr '[:upper:]' '[:lower:]')
+          echo "PROJECT_NAME=widget-${NAME:0:10}" >> "$GITHUB_ENV"
 
       - name: Create project if not present
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -104,7 +104,7 @@ jobs:
                   },
                   latest_deployment: null,
                   name: "${{ env.PROJECT_NAME }}",
-                  production_branch: "${{ env.BRANCH_NAME }}"
+                  production_branch: process.env.BRANCH_NAME
                 })
               })
               .then(r => r.json())
@@ -121,7 +121,7 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_PAGES_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
         run: |
-          pnpm dlx wrangler@4.90.1 pages deploy ./packages/widget-playground-vite/dist/ --project-name ${{ env.PROJECT_NAME }} --branch ${{ env.BRANCH_NAME }}
+          pnpm dlx wrangler@4.90.1 pages deploy ./packages/widget-playground-vite/dist/ --project-name "$PROJECT_NAME" --branch "$BRANCH_NAME"
 
       - name: Resolve preview URL
         id: preview-url


### PR DESCRIPTION
Fixes command injection from PR branch names: `${{ env.BRANCH_NAME }}` was templated into shell/JS bodies. Now referenced as a quoted env var (`"$BRANCH_NAME"` / `process.env.BRANCH_NAME`).

DO-691
