### PR TITLE
chore: trim CLAUDE.md and move release docs into a skill

### DIFF
--- a/.claude/skills/changeset/references/bump-rules.md
+++ b/.claude/skills/changeset/references/bump-rules.md
@@ -6,9 +6,9 @@
 - **`fix:`** (bug fix, backwards-compatible) → **patch**
 - **breaking change** (removed/renamed export, changed signature, behavior break) → **major**
 
-While the repo is in **pre-beta** (see the `release` skill's `channels.md`), every bump
-lands as `4.0.0-beta.N` regardless of level — but still pick the level that *would* apply
-on the stable line, because it determines the eventual stable bump on `pre exit`.
+Changesets pre mode has been **exited** — there is no `.changeset/pre.json` and the `4.x`
+line is stable on the `latest` dist-tag, so standard semver applies and the level you pick
+is the version that ships. See the `release` skill for the release line and dist-tags.
 
 ## Publishable packages (these need a changeset when changed)
 
@@ -22,14 +22,19 @@ on the stable line, because it determines the eventual stable bump on `pre exit`
 - `@lifi/widget-provider-sui`
 - `@lifi/widget-provider-tron`
 
-> `@lifi/widget-checkout` and `@lifi/widget-provider-mesh` arrive with PR #727; add them
-> here when that lands.
-
-## Private / ignored (NEVER need a changeset)
+## Ignored (NEVER need a changeset)
 
 `@lifi/widget-embedded`, `@lifi/widget-playground`, `@lifi/widget-playground-next`,
 `@lifi/widget-playground-vite`, everything under `examples/` and `e2e/`. These are
 `private: true` and listed in `.changeset/config.json` `ignore`.
+
+## Private but versioned (declare these too)
+
+`@lifi/widget-checkout`, `@lifi/widget-provider-mesh`, `@lifi/widget-provider-transak` are
+`private: true` but **not** in `ignore`, and `privatePackages` is unset (defaults to
+`version: true`). Changesets bumps their versions and writes their CHANGELOGs; it just
+doesn't publish them. Declare them like any other changed package. Move one to the
+publishable list above only when its `private` flag is actually removed.
 
 ## Dependency graph — don't author cascade-only changesets
 

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: release
+description: >-
+  How releases work in this repo — Changesets automation, the `chore: version
+  packages` PR, the current release line and dist-tags, per-PR `release-preview`
+  builds, and what each `pnpm changeset:*` root script actually does. Use when
+  cutting or investigating a release, publishing a preview build for another
+  team, debugging the publish workflow, or answering "which version/dist-tag is
+  this on". For authoring a single changeset file, use the `changeset` skill
+  instead.
+---
+
+# Releasing — widget
+
+Releases are managed with **[Changesets](https://github.com/changesets/changesets)** (independent per-package versioning — no `fixed`/`linked`). Lerna and standard-version have been removed. Each published package owns its `CHANGELOG.md`; the root `CHANGELOG.md` is a frozen v3-era archive.
+
+## Per-PR rule (do this on every feature/fix PR)
+
+When a change touches a **publishable** package (not a private package, not docs-only), add a `.changeset/*.md` before committing:
+
+```bash
+pnpm changeset    # interactive: pick packages + bump type, write a summary
+```
+
+- `feat:` → **minor**, `fix:` → **patch**, breaking change → **major**.
+- Do **not** author changesets for cascade-only dependents — Changesets bumps internal dependents automatically from the dependency graph. (`updateInternalDependencies: patch` — the default — re-releases a dependent on *any* bump to one of its workspace dependencies, including a patch, so its pinned version stays current.)
+- Publishable packages: `@lifi/widget`, `@lifi/wallet-management`, `@lifi/widget-light`, `@lifi/widget-provider`, `@lifi/widget-provider-{bitcoin,ethereum,solana,sui,tron}`.
+- Private/ignored (never need a changeset): `@lifi/widget-embedded`, `@lifi/widget-playground`, `@lifi/widget-playground-next`, `@lifi/widget-playground-vite`, examples, e2e.
+- `changeset-bot` comments a reminder on any PR that edits a publishable package without a changeset (a nudge, not a hard block — the maintainer-reviewed Version PR is the real gate).
+
+## Release line — `4.x` stable (pre-mode exited)
+
+Changesets pre mode has been **exited** and stable **`@lifi/widget@4.0.0`** is published — npm `latest` is on the `4.x` line (the old `3.x` line is superseded). There is no `.changeset/pre.json`, so **standard semver applies**: `changeset version` bumps real `4.x` versions (`fix:` → patch, `feat:` → minor, breaking → major → `5.0.0`) and `changeset publish` publishes to the `latest` dist-tag. The historical `4.0.0-alpha.*` / `4.0.0-beta.*` prereleases remain parked under the `alpha` / `beta` dist-tags.
+
+## How a release happens (automated)
+
+1. Open PRs with changesets (per the rule above).
+2. On merge to `main`, `.github/workflows/publish.yaml` runs the `changesets` job, which opens/updates a **`chore: version packages`** PR aggregating all pending changesets (bumps versions, regenerates per-package CHANGELOGs, refreshes the lockfile).
+3. Merging that version PR triggers the `release` job: it runs `pnpm changeset:publish` (build → per-package prerelease transform → `changeset publish`) and creates GitHub Releases. npm provenance is enabled via `NPM_CONFIG_PROVENANCE=true` + OIDC (`id-token: write`).
+4. The `linear-*` jobs sync the published versions into Linear, deriving version/channel from the action's `publishedPackages` output.
+
+## Preview releases (per-PR, opt-in)
+
+To share an unmerged PR build with other teams or external integrators, add the
+**`release-preview`** label to the PR. The `preview` job in `publish.yaml` publishes a
+throwaway `0.0.0-preview-<sha>` build of the changed packages to npm under the
+**`preview`** dist-tag and comments the exact install command on the PR. The label is
+removed after a successful publish (one-shot — re-add it to cut another preview).
+
+- Install the **exact** version it prints (e.g. `npm i @lifi/widget@0.0.0-preview-<sha>`);
+  `@preview` moves with the newest preview across PRs. `0.0.0` can never become `latest`/`beta`.
+  The `<sha>` is the PR head's short commit hash, so the version traces to the exact source.
+- The repo is no longer in pre mode, so the preview job snapshots the changed packages
+  directly; the former `changeset pre exit` workaround (needed only while in pre mode) no
+  longer applies.
+- Guardrails: applying a label requires Triage+ on the repo, so external people / fork-PR
+  authors can't trigger it; the same-repo guard means the published code was pushed by
+  someone with Write access (forks excluded); and the job is isolated (no deploy/Linear
+  secrets). This is GitHub's native label-permission gate — no in-workflow role check.
+
+## Root scripts
+
+- `pnpm changeset:version` — `changeset version` + `build:version` (regenerates `src/config/version.ts` for `@lifi/widget` + `@lifi/widget-light` so the committed file rides along with the `package.json` bump) + `scripts/restore-example-versions.sh` + `pnpm install --lockfile-only` + `pnpm check:write`. **The version PR intentionally does not bump example pins.** `changeset version` rewrites every in-workspace example's `@lifi/*` range to the just-bumped, not-yet-published version (and neither `ignore` nor `privatePackages.version:false` prevents this), which then breaks `pnpm install`. `scripts/restore-example-versions.sh` reverts those edits so examples stay pinned to the *published* widget (so their bundlers — notably Next.js — consume the built package rather than the widget's TS source). Bump example pins manually when you want them to track a newer release.
+- `pnpm changeset:prepublish` — `pnpm build`, then `build:prerelease` across publishable packages. **This is where the publish transform runs:** `changeset publish` does flat per-package `npm publish` and does NOT run each package's `build:prerelease` lifecycle, so the transform (`scripts/prerelease.js` → `scripts/formatPackageJson.js`, rewriting entry points to `dist/esm/` and copying `README.md`) must run here.
+- `pnpm changeset:publish` — `pnpm changeset:prepublish && changeset publish` (used by CI).
+
+`workspace:*` internal deps are resolved to concrete versions by `changeset publish` at publish time; `formatPackageJson.js` leaves `dependencies` untouched. `scripts/version.js` generates `src/config/version.ts` during build for `@lifi/widget` and `@lifi/widget-light` only.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,35 +8,16 @@ LI.FI Widget monorepo — a cross-chain DeFi swap/bridge widget supporting Ether
 
 ## Commands
 
+Non-obvious ones only — the rest are in root `package.json` scripts.
+
 ```bash
-# Development
-pnpm dev                     # Start widget-playground-vite on port 3000
-pnpm dev:next                # Start Next.js playground
-
-# Building
-pnpm build                   # Build all packages in parallel
 pnpm --filter widget-playground-vite analyze   # source-map-explorer on the built bundle
-
-# Code Quality
-pnpm check                   # Biome lint + format check
-pnpm check:write             # Auto-fix Biome issues
-pnpm check:types             # TypeScript check all packages in parallel
-pnpm check:circular-deps     # Detect circular deps via madge
-
-# Single-package type check
-pnpm --filter @lifi/widget check:types
-
-# Testing (vitest)
-pnpm --filter @lifi/widget test        # Run widget tests
-pnpm --filter @lifi/widget-light test  # widget-light tests (no test files yet)
+pnpm --filter @lifi/widget check:types         # single-package type check
+pnpm --filter @lifi/widget test                # widget tests (widget-light has no test files yet)
 
 # Example E2E (build → serve → Playwright render; registry in e2e/examples.json)
-pnpm test:examples           # all active examples
 pnpm test:example <name>     # one example, e.g. nft-checkout (build + serve + render)
 pnpm e2e:examples            # Playwright only (servers managed externally / by CI)
-
-# Unused code detection
-pnpm knip:check
 ```
 
 ## Build Tooling
@@ -55,20 +36,7 @@ pnpm knip:check
 
 ## Architecture
 
-### Package Dependency Graph
-
-```
-@lifi/widget-provider          ← base contexts (Ethereum/Solana/Bitcoin/Sui/Tron)
-  ↑
-@lifi/widget-provider-{ethereum,solana,bitcoin,sui,tron}  ← chain-specific implementations
-  ↑
-@lifi/wallet-management        ← wallet UI + connection logic
-  ↑
-@lifi/widget                   ← full widget (MUI, Zustand, TanStack Router, i18next)
-
-@lifi/widget-light             ← lightweight iframe host/guest bridge (zero dependencies)
-@lifi/widget-embedded          ← Vite app that runs inside the iframe (private)
-```
+### Cross-package invariants
 
 **`@lifi/sdk` and `@lifi/types` must be single-copy in any consumer bundle** — the SDK keeps `executionState` as a module-level singleton; duplicates surface as `"Execution data not found"` errors during route execution. Use `pnpm.overrides` (in `pnpm-workspace.yaml`) or bundler `resolve.dedupe` to enforce.
 
@@ -86,21 +54,9 @@ pnpm knip:check
 - Guest sends `WIDGET_EVENT` for subscribed events → Host dispatches to `WidgetLightEventBus`
 - Host sends `WIDGET_EVENT_SUBSCRIBE`/`UNSUBSCRIBE` to control which events the guest forwards
 
-**Key modules**:
-- `src/host/useWidgetLightHost.ts` — React hook managing the host side (handshake, RPC routing, config updates)
-- `src/host/WidgetLightEventBus.ts` — Module-level singleton with ref-counted subscriptions
-- `src/host/useWidgetLightEvents.ts` — Public hook returning `{ on, off }` emitter
-- `src/guest/GuestBridge.ts` — Singleton managing guest-side communication
-- `src/shared/widgetConfig.ts` — Zero-dependency serializable config types (no React nodes, no callbacks, no MUI types)
-- `src/shared/widgetLightEvents.ts` — Serializable event types mirroring widget events
-
 ### widget internals
 
-- **State**: Zustand stores in `packages/widget/src/stores/` (form, routes, chains, settings)
-- **Routing**: TanStack Router with page components in `src/pages/`
-- **Theming**: MUI v9 + Emotion; custom themes in `src/themes/`
 - **Events**: `eventemitter3` (`widgetEvents` singleton in `src/hooks/useWidgetEvents.ts`) — clean up listeners with `.off(event, handler)` / `.removeAllListeners()`; there is no mitt-style `.all` map
-- **i18n**: i18next with language translations in `src/i18n/` (17 locales)
 
 ### Provider layering (widget)
 
@@ -109,16 +65,12 @@ QueryClient → Settings → WidgetConfig → I18n → Theme → SDK → Wallet 
 ## Conventions
 
 - **ESM only** — all packages output to `dist/esm/`. No CJS.
-- **Biome** for linting and formatting (not ESLint/Prettier). Single quotes, no semicolons, 2-space indent, trailing commas (ES5). **Always run `pnpm check:write` after making changes** so Biome can auto-fix formatting.
+- **Biome** for linting and formatting (not ESLint/Prettier). **Always run `pnpm check:write` after making changes** so Biome can auto-fix formatting.
 - **Biome sorts imports** — running `pnpm check:write` may reorder import/export statements. This is expected.
 - **Conventional commits** enforced by commitlint (`feat:`, `fix:`, `chore:`, etc.).
 - **pnpm settings live in `pnpm-workspace.yaml` only** — pnpm v11 silently ignores `package.json#pnpm` and most non-auth `.npmrc` keys. Verify any setting with `pnpm config get <kebab-name>` (returns `undefined` if pnpm isn't reading it). npm publish provenance is set via `NPM_CONFIG_PROVENANCE=true` env in `.github/workflows/publish.yaml`, not pnpm config.
-- **`console.log` is an error** — only `console.warn` and `console.error` are allowed (except in `examples/`).
-- **`useExhaustiveDependencies`** and **`useHookAtTopLevel`** are errors.
-- **No unused variables or imports** — enforced as errors.
 - **widget-light must have zero `dependencies`** — all types are self-contained duplicates. Chain-specific integrations are optional peer deps exposed via subpath exports (`@lifi/widget-light/ethereum`, etc.).
 - Package entry points use TypeScript source (`src/index.ts`). The `scripts/formatPackageJson.js` rewrites paths to `dist/esm/` at publish time.
-- TypeScript target is ES2020, module resolution is Bundler.
 - Library packages use `tsdown` with `unbundle: true` mode. The widget package needs `neverBundle: [/\.json$/]` for i18n JSON files.
 - **PR template** at `.github/pull_request_template.md` — always use it when creating PRs via `gh pr create`.
 - `packages/widget-embedded/README.md` — main integration guide for widget-light (not a typical package readme).
@@ -127,56 +79,7 @@ QueryClient → Settings → WidgetConfig → I18n → Theme → SDK → Wallet 
 
 ## Release
 
-Releases are managed with **[Changesets](https://github.com/changesets/changesets)** (independent per-package versioning — no `fixed`/`linked`). Lerna and standard-version have been removed. Each published package owns its `CHANGELOG.md`; the root `CHANGELOG.md` is a frozen v3-era archive.
-
-### Per-PR rule (do this on every feature/fix PR)
-
-When a change touches a **publishable** package (not a private package, not docs-only), add a `.changeset/*.md` before committing:
-
-```bash
-pnpm changeset    # interactive: pick packages + bump type, write a summary
-```
-
-- `feat:` → **minor**, `fix:` → **patch**, breaking change → **major**.
-- Do **not** author changesets for cascade-only dependents — Changesets bumps internal dependents automatically from the dependency graph. (`updateInternalDependencies: patch` — the default — re-releases a dependent on *any* bump to one of its workspace dependencies, including a patch, so its pinned version stays current.)
-- Publishable packages: `@lifi/widget`, `@lifi/wallet-management`, `@lifi/widget-light`, `@lifi/widget-provider`, `@lifi/widget-provider-{bitcoin,ethereum,solana,sui,tron}`.
-- Private/ignored (never need a changeset): `@lifi/widget-embedded`, `@lifi/widget-playground`, `@lifi/widget-playground-next`, `@lifi/widget-playground-vite`, examples, e2e.
-- `changeset-bot` comments a reminder on any PR that edits a publishable package without a changeset (a nudge, not a hard block — the maintainer-reviewed Version PR is the real gate).
-
-### Release line — `4.x` stable (pre-mode exited)
-
-Changesets pre mode has been **exited** and stable **`@lifi/widget@4.0.0`** is published — npm `latest` is on the `4.x` line (the old `3.x` line is superseded). There is no `.changeset/pre.json`, so **standard semver applies**: `changeset version` bumps real `4.x` versions (`fix:` → patch, `feat:` → minor, breaking → major → `5.0.0`) and `changeset publish` publishes to the `latest` dist-tag. The historical `4.0.0-alpha.*` / `4.0.0-beta.*` prereleases remain parked under the `alpha` / `beta` dist-tags.
-
-### How a release happens (automated)
-
-1. Open PRs with changesets (per the rule above).
-2. On merge to `main`, `.github/workflows/publish.yaml` runs the `changesets` job, which opens/updates a **`chore: version packages`** PR aggregating all pending changesets (bumps versions, regenerates per-package CHANGELOGs, refreshes the lockfile).
-3. Merging that version PR triggers the `release` job: it runs `pnpm changeset:publish` (build → per-package prerelease transform → `changeset publish`) and creates GitHub Releases. npm provenance is enabled via `NPM_CONFIG_PROVENANCE=true` + OIDC (`id-token: write`).
-4. The `linear-*` jobs sync the published versions into Linear, deriving version/channel from the action's `publishedPackages` output.
-
-### Preview releases (per-PR, opt-in)
-
-To share an unmerged PR build with other teams or external integrators, add the
-**`release-preview`** label to the PR. The `preview` job in `publish.yaml` publishes a
-throwaway `0.0.0-preview-<sha>` build of the changed packages to npm under the
-**`preview`** dist-tag and comments the exact install command on the PR. The label is
-removed after a successful publish (one-shot — re-add it to cut another preview).
-
-- Install the **exact** version it prints (e.g. `npm i @lifi/widget@0.0.0-preview-<sha>`);
-  `@preview` moves with the newest preview across PRs. `0.0.0` can never become `latest`/`beta`.
-  The `<sha>` is the PR head's short commit hash, so the version traces to the exact source.
-- The repo is no longer in pre mode, so the preview job snapshots the changed packages
-  directly; the former `changeset pre exit` workaround (needed only while in pre mode) no
-  longer applies.
-- Guardrails: applying a label requires Triage+ on the repo, so external people / fork-PR
-  authors can't trigger it; the same-repo guard means the published code was pushed by
-  someone with Write access (forks excluded); and the job is isolated (no deploy/Linear
-  secrets). This is GitHub's native label-permission gate — no in-workflow role check.
-
-### Root scripts
-
-- `pnpm changeset:version` — `changeset version` + `build:version` (regenerates `src/config/version.ts` for `@lifi/widget` + `@lifi/widget-light` so the committed file rides along with the `package.json` bump) + `scripts/restore-example-versions.sh` + `pnpm install --lockfile-only` + `pnpm check:write`. **The version PR intentionally does not bump example pins.** `changeset version` rewrites every in-workspace example's `@lifi/*` range to the just-bumped, not-yet-published version (and neither `ignore` nor `privatePackages.version:false` prevents this), which then breaks `pnpm install`. `scripts/restore-example-versions.sh` reverts those edits so examples stay pinned to the *published* widget (so their bundlers — notably Next.js — consume the built package rather than the widget's TS source). Bump example pins manually when you want them to track a newer release.
-- `pnpm changeset:prepublish` — `pnpm build`, then `build:prerelease` across publishable packages. **This is where the publish transform runs:** `changeset publish` does flat per-package `npm publish` and does NOT run each package's `build:prerelease` lifecycle, so the transform (`scripts/prerelease.js` → `scripts/formatPackageJson.js`, rewriting entry points to `dist/esm/` and copying `README.md`) must run here.
-- `pnpm changeset:publish` — `pnpm changeset:prepublish && changeset publish` (used by CI).
-
-`workspace:*` internal deps are resolved to concrete versions by `changeset publish` at publish time; `formatPackageJson.js` leaves `dependencies` untouched. `scripts/version.js` generates `src/config/version.ts` during build for `@lifi/widget` and `@lifi/widget-light` only.
+Changesets, independent per-package versioning. **Every PR touching a publishable package
+needs a `.changeset/*.md`** (`feat:` → minor, `fix:` → patch, breaking → major) — use the
+`changeset` skill to author one. Full release mechanics (version PR, dist-tags, preview
+builds, `pnpm changeset:*` scripts) live in the `release` skill.


### PR DESCRIPTION
## Which Linear task is linked to this PR?

_None — repo tooling / agent context._

## Why was it implemented this way?

`CLAUDE.md` loads into every Claude Code session in this repo, so anything a session can rediscover on its own is pure overhead. This trims it from 14.8k to 7.0k characters (~1.9k fewer tokens per session) without losing a single gotcha.

**Cut — derivable from the repo:**
- the package dependency graph (it's in the `package.json` files)
- widget-light's "Key modules" file list (`ls src/host/`)
- widget-internals file locations for Zustand / TanStack Router / MUI / i18next
- Biome style settings (quotes, semicolons, indent, trailing commas) — all in `biome.json`
- `console.log` / `useExhaustiveDependencies` / `useHookAtTopLevel` / unused-vars rules — all already `"error"` in `biome.json`, including the `examples/**` override for `noConsole`
- the TypeScript target/moduleResolution line — in `tsconfig.json`
- command-block entries that just restate root `package.json` scripts

**Kept:** every gotcha and agent directive — `@lifi/sdk`/`wagmi` single-copy, the `eventemitter3` `.off()` note, `.tsbuildinfo` phantom errors, `isolatedDeclarations` rules, `version.ts` sync, pnpm-workspace-only settings, the PR template rule, the comment policy, the examples registry.

**Moved:** the 55-line Release section → `.claude/skills/release/SKILL.md`, so it loads when someone is actually cutting a release instead of on every session. `CLAUDE.md` keeps the safety-relevant part resident: every PR touching a publishable package needs a changeset.

**Fixed** two stale claims in `.claude/skills/changeset/references/bump-rules.md`:
- it said the repo is "in pre-beta, every bump lands as `4.0.0-beta.N`" — pre mode is exited, there's no `.changeset/pre.json`, and `4.x` is stable on `latest`
- it said `widget-checkout` / `widget-provider-mesh` "arrive with PR #727" — they've landed, and since they're `private: true` but not in `.changeset/config.json` `ignore`, they're versioned and **do** need changesets (as #828 did)

No changeset here: this touches no publishable package source.

## Visual showcase (Screenshots or Videos)

_N/A._

## Checklist before requesting a review
- [x] I have performed a self-review and testing of my code.
- [x] This pull request is focused and addresses a single problem.
- [x] If this PR modifies the Widget API or adds new features that require documentation, I have updated the documentation in the [public-docs](https://github.com/lifinance/public-docs) repository.
