### PR TITLE
fix(examples): render the dynamic example on @dynamic-labs v5

### DIFF
--- a/e2e/examples.json
+++ b/e2e/examples.json
@@ -194,8 +194,7 @@
     "serveCmd": "preview",
     "profile": "standard",
     "mountPath": "/",
-    "status": "broken",
-    "brokenReason": "Dynamic SDK reads a bare `process` global (nextTick/versions/emit) and imports `buffer/index.js`, so it needs Node shims. vite-plugin-node-polyfills declares Vite 8 support but is broken under its rolldown resolver: it aliases its own shims by bare specifier, and its exports map still has legacy trailing-slash keys pointing at files, which rolldown rejects (\"Expecting folder to folder mapping\"). Fails on 0.26.0 and 0.28.0 alike, in build and in dep pre-bundling. Blocked on upstream davidmyersdev/vite-plugin-node-polyfills#158, #161 and #154. The @dynamic-labs v5 upgrade itself is fine — it type-checks and bundles."
+    "status": "active"
   },
   {
     "name": "nuxt",

--- a/e2e/tests/profiles/widget-smoke.spec.ts
+++ b/e2e/tests/profiles/widget-smoke.spec.ts
@@ -5,8 +5,9 @@ import { expect, test, waitForTokens } from '../fixtures/base.fixture.js'
  * Widget smoke profile — covers standard (widget at /) and routed (widget at custom path).
  * mountPath is read from project metadata so the same spec handles both profiles.
  *
- * Standard  (13): vite, connectkit, privy, privy-ethers, rainbowkit, reown, svelte,
- *                 zustand-widget-config, vue, nextjs, nextjs15, remix, react-router
+ * Standard  (14): vite, connectkit, privy, privy-ethers, rainbowkit, reown, svelte,
+ *                 zustand-widget-config, vue, nextjs, nextjs15, remix, react-router,
+ *                 dynamic
  * Routed     (1): tanstack-router (mountPath: /widget)
  */
 

--- a/examples/dynamic/package.json
+++ b/examples/dynamic/package.json
@@ -36,7 +36,6 @@
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
     "viem": ">=2.52.0",
-    "vite-plugin-env-compatible": "^2.0.1",
     "wagmi": "^3.7.6"
   },
   "devDependencies": {
@@ -45,6 +44,7 @@
     "@vitejs/plugin-react": "^6.0.5",
     "globals": "^17.11.0",
     "typescript": "^7.0.2",
-    "vite": "^8.2.1"
+    "vite": "^8.2.1",
+    "vite-plugin-node-polyfills": "^0.26.0"
   }
 }

--- a/examples/dynamic/src/components/WalletHeader.tsx
+++ b/examples/dynamic/src/components/WalletHeader.tsx
@@ -4,17 +4,19 @@ import { Box, Typography } from '@mui/material'
 export function WalletHeader() {
   return (
     <Box
-      p={2}
-      mb={2}
-      display="flex"
-      justifyContent="space-between"
-      alignItems="center"
-      borderBottom="1px solid #EEE"
+      sx={{
+        p: 2,
+        mb: 2,
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        borderBottom: '1px solid #EEE',
+      }}
     >
-      <Typography px={2} fontWeight={600} fontSize={24}>
+      <Typography sx={{ px: 2, fontWeight: 600, fontSize: 24 }}>
         Dynamic + LI.FI widget Example
       </Typography>
-      <Box display="flex" alignItems="center">
+      <Box sx={{ display: 'flex', alignItems: 'center' }}>
         <DynamicWidget />
       </Box>
     </Box>

--- a/examples/dynamic/vite.config.ts
+++ b/examples/dynamic/vite.config.ts
@@ -6,39 +6,88 @@ import { nodePolyfills } from 'vite-plugin-node-polyfills'
 
 // The Dynamic SDK reads a bare `process` global (nextTick/versions/emit) and its own
 // polyfills.js imports `buffer/index.js`, so it needs real Node shims — build-time
-// `process.env.*` substitution is not enough. nodePolyfills() supplies them, but it
-// aliases its own shims by bare specifier, and its exports map still carries legacy
-// trailing-slash keys that resolve to files. Rolldown (Vite 8) rejects those with
-// "Expecting folder to folder mapping". 0.28.0 ships an identical exports map and
-// fails the same way, so bumping the plugin does not help; the upstream fixes are
-// open but unreleased (davidmyersdev/vite-plugin-node-polyfills#161 and #154).
+// `process.env.*` substitution is not enough.
 //
-// Resolving the shims to their real files keeps rolldown out of that exports map.
-// This fixes `vite build` and `vite preview`, which is what the e2e suite covers.
-// `vite dev` still fails: dependency pre-bundling resolves the plugin's injected
-// banner in a separate plugin container that this hook cannot reach.
+// nodePolyfills() supplies those shims, but it points at them by bare specifier, and
+// its exports map still carries legacy trailing-slash keys that resolve to files.
+// Rolldown (Vite 8) rejects that with "Expecting folder to folder mapping", which
+// breaks both `vite build` and dev dependency pre-bundling. 0.28.0 ships an identical
+// exports map and fails the same way, so bumping the plugin does not help — the
+// upstream fixes are open but unreleased (davidmyersdev/vite-plugin-node-polyfills#161
+// and #154).
+//
+// So we resolve the shims to their real files, which keeps rolldown out of the exports
+// map. Two places need it, because pre-bundling runs its own resolver:
+//   - the module graph, via resolveId (also covers subpaths like `buffer/index.js`)
+//   - the plugin's own returned config, patched before Vite merges it, which is where
+//     the pre-bundle alias maps and injected banner come from
+// Both become deletable once upstream ships.
 const require = createRequire(import.meta.url)
 const pkgRoot = resolve(
   dirname(require.resolve('vite-plugin-node-polyfills')),
   '..'
 )
+const SHIM_PREFIX = 'vite-plugin-node-polyfills/shims/'
 const SHIM_RE =
   /^(?:node:)?(?:vite-plugin-node-polyfills\/shims\/)?(buffer|global|process)(?:\/.*)?$/
+const QUOTED_SHIM_RE =
+  /(['"])vite-plugin-node-polyfills\/shims\/(buffer|global|process)\1/g
+// Alias values point at the shim *directory*: aliases substitute by prefix, so a
+// directory keeps both `buffer` and `buffer/index.js` resolvable. Import specifiers
+// (the injected banner) get the file itself.
+const shimDir = (name: string) => join(pkgRoot, 'shims', name, 'dist')
+const shimPath = (name: string) => join(shimDir(name), 'index.js')
 
-function resolveNodePolyfillShims(): Plugin {
-  return {
-    name: 'resolve-node-polyfill-shims',
-    enforce: 'pre',
-    resolveId(id) {
-      const match = SHIM_RE.exec(id)
-      return match ? join(pkgRoot, 'shims', match[1], 'dist', 'index.js') : null
-    },
+/** Rewrite every bare shim specifier in a value tree to an absolute path. */
+function absolutizeShims<T>(value: T): T {
+  if (typeof value === 'string') {
+    const exact = value.startsWith(SHIM_PREFIX)
+      ? shimDir(value.slice(SHIM_PREFIX.length))
+      : value.replace(
+          QUOTED_SHIM_RE,
+          (_, quote: string, name: string) =>
+            `${quote}${shimPath(name)}${quote}`
+        )
+    return exact as unknown as T
   }
+  if (Array.isArray(value)) return value.map(absolutizeShims) as unknown as T
+  if (value && typeof value === 'object') {
+    for (const [key, inner] of Object.entries(value)) {
+      ;(value as Record<string, unknown>)[key] = absolutizeShims(inner)
+    }
+  }
+  return value
+}
+
+/** nodePolyfills() with every bare shim reference resolved to a real file. */
+function nodePolyfillsResolved(): Plugin[] {
+  const plugins = [nodePolyfills()].flat() as Plugin[]
+  for (const plugin of plugins) {
+    const original = plugin.config
+    if (typeof original !== 'function') continue
+    plugin.config = async function config(
+      this: ThisParameterType<typeof original>,
+      ...args: Parameters<typeof original>
+    ) {
+      return absolutizeShims(await original.apply(this, args))
+    }
+  }
+  return [
+    {
+      name: 'resolve-node-polyfill-shims',
+      enforce: 'pre',
+      resolveId(id) {
+        const match = SHIM_RE.exec(id)
+        return match ? shimPath(match[1]) : null
+      },
+    },
+    ...plugins,
+  ]
 }
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react(), nodePolyfills(), resolveNodePolyfillShims()],
+  plugins: [react(), nodePolyfillsResolved()],
   server: {
     port: 3000,
     open: true,

--- a/examples/dynamic/vite.config.ts
+++ b/examples/dynamic/vite.config.ts
@@ -1,10 +1,44 @@
+import { createRequire } from 'node:module'
+import { dirname, join, resolve } from 'node:path'
 import react from '@vitejs/plugin-react'
-import { defineConfig } from 'vite'
-import EnvCompatible from 'vite-plugin-env-compatible'
+import { defineConfig, type Plugin } from 'vite'
+import { nodePolyfills } from 'vite-plugin-node-polyfills'
+
+// The Dynamic SDK reads a bare `process` global (nextTick/versions/emit) and its own
+// polyfills.js imports `buffer/index.js`, so it needs real Node shims — build-time
+// `process.env.*` substitution is not enough. nodePolyfills() supplies them, but it
+// aliases its own shims by bare specifier, and its exports map still carries legacy
+// trailing-slash keys that resolve to files. Rolldown (Vite 8) rejects those with
+// "Expecting folder to folder mapping". 0.28.0 ships an identical exports map and
+// fails the same way, so bumping the plugin does not help; the upstream fixes are
+// open but unreleased (davidmyersdev/vite-plugin-node-polyfills#161 and #154).
+//
+// Resolving the shims to their real files keeps rolldown out of that exports map.
+// This fixes `vite build` and `vite preview`, which is what the e2e suite covers.
+// `vite dev` still fails: dependency pre-bundling resolves the plugin's injected
+// banner in a separate plugin container that this hook cannot reach.
+const require = createRequire(import.meta.url)
+const pkgRoot = resolve(
+  dirname(require.resolve('vite-plugin-node-polyfills')),
+  '..'
+)
+const SHIM_RE =
+  /^(?:node:)?(?:vite-plugin-node-polyfills\/shims\/)?(buffer|global|process)(?:\/.*)?$/
+
+function resolveNodePolyfillShims(): Plugin {
+  return {
+    name: 'resolve-node-polyfill-shims',
+    enforce: 'pre',
+    resolveId(id) {
+      const match = SHIM_RE.exec(id)
+      return match ? join(pkgRoot, 'shims', match[1], 'dist', 'index.js') : null
+    },
+  }
+}
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react(), EnvCompatible()],
+  plugins: [react(), nodePolyfills(), resolveNodePolyfillShims()],
   server: {
     port: 3000,
     open: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -302,9 +302,6 @@ importers:
       viem:
         specifier: '>=2.52.0'
         version: 2.55.19(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6)(zod@4.4.3)
-      vite-plugin-env-compatible:
-        specifier: ^2.0.1
-        version: 2.0.1
       wagmi:
         specifier: ^3.7.6
         version: 3.7.6(5b3fe36345e22f8c086849e354cafa04)
@@ -327,6 +324,9 @@ importers:
       vite:
         specifier: ^8.2.1
         version: 8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0)
+      vite-plugin-node-polyfills:
+        specifier: ^0.26.0
+        version: 0.26.0(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))
 
   examples/nextjs:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14934,18 +14934,6 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
-  ws@7.5.13:
-    resolution: {integrity: sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==}
-    engines: {node: '>=8.3.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: 6.0.6
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
   ws@8.21.3:
     resolution: {integrity: sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==}
     engines: {node: '>=10.0.0'}
@@ -19706,7 +19694,7 @@ snapshots:
       tsconfig-paths: 4.2.0
       valibot: 1.4.2(typescript@7.0.2)
       vite-node: 3.2.4(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.33.0)(supports-color@10.2.2)(terser@5.50.0)(yaml@2.9.0)
-      ws: 7.5.13(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.21.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     optionalDependencies:
       '@remix-run/serve': 2.17.5(supports-color@10.2.2)(typescript@7.0.2)
       typescript: 7.0.2
@@ -28089,9 +28077,9 @@ snapshots:
 
   isomorphic-timers-promises@1.0.1: {}
 
-  isomorphic-ws@4.0.1(ws@7.5.13(bufferutil@4.1.0)(utf-8-validate@6.0.6)):
+  isomorphic-ws@4.0.1(ws@8.21.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)):
     dependencies:
-      ws: 7.5.13(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.21.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   isows@1.0.7(ws@8.21.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)):
     dependencies:
@@ -28120,11 +28108,11 @@ snapshots:
       delay: 5.0.0
       es6-promisify: 5.0.0
       eyes: 0.1.8
-      isomorphic-ws: 4.0.1(ws@7.5.13(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      isomorphic-ws: 4.0.1(ws@8.21.3(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       json-stringify-safe: 5.0.1
       stream-json: 1.9.1
       uuid: 8.3.2
-      ws: 7.5.13(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.21.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -33166,11 +33154,6 @@ snapshots:
       strip-ansi: 7.2.0
 
   wrappy@1.0.2: {}
-
-  ws@7.5.13(bufferutil@4.1.0)(utf-8-validate@6.0.6):
-    optionalDependencies:
-      bufferutil: 4.1.0
-      utf-8-validate: 6.0.6
 
   ws@8.21.3(bufferutil@4.1.0)(utf-8-validate@6.0.6):
     optionalDependencies:


### PR DESCRIPTION
## Which Linear task is linked to this PR?

_Follow-up to #847 — no Linear task._

## Why was it implemented this way?

#847 bumped `@dynamic-labs/*` from 4.92.3 to **5.3.1**, but `examples/dynamic` was
`status: broken` in `e2e/examples.json`, so the harness skipped it and the v5 major was never
render-verified. This makes the example work and returns it to the active set — **18 examples**.

### What was actually broken

The old `brokenReason` blamed `vite-plugin-env-compatible` and prescribed swapping in
`vite-plugin-node-polyfills`. The **diagnosis was right**: `vite-plugin-env-compatible` only
substitutes `process.env.*` at build time, while the Dynamic SDK reads a bare `process` global
and its own `polyfills.js` imports `buffer/index.js`. Confirmed from the built bundle:

```
process.nextTick   process.versions.node   process.emit   process.version
```

But the prescribed **fix no longer works on its own**. `vite-plugin-node-polyfills` advertises a
Vite 8 peer range (`^2 || … || ^8`), yet aliases its own shims by *bare specifier*, and its
exports map still carries legacy trailing-slash keys (`"./shims/process/"`) that resolve to files.
Rolldown validates those strictly where Vite 7's rollup ignored them:

```
[builtin:vite-alias] plugin `builtin:vite-alias` threw an error
Caused by:
  Expecting folder to folder mapping.
  ".../vite-plugin-node-polyfills/package.json" should end with "/"
```

Things I ruled out along the way:

- **Not the plugin version.** 0.28.0 (latest, May 2026) ships a byte-identical exports map and
  the same shim files, and fails the same way. Bumping does not help.
- **Not Vite.** Holding Vite at the new 8.2.1 and varying only the plugin isolates the plugin.
- **Not something you can simply delete.** Dropping the plugin and adding the real `buffer`
  package *does* build — the SDK's `polyfills.js` assigns `window.global`/`window.Buffer` itself —
  but the free `process` global is still undefined at runtime.
- **No upstream fix exists yet.** The fixes are open and unreleased:
  [#161](https://github.com/davidmyersdev/vite-plugin-node-polyfills/pull/161) (build root shims
  export) and [#154](https://github.com/davidmyersdev/vite-plugin-node-polyfills/pull/154) (use
  oxc when Rolldown is detected), with
  [#158](https://github.com/davidmyersdev/vite-plugin-node-polyfills/issues/158) and
  [#140](https://github.com/davidmyersdev/vite-plugin-node-polyfills/issues/140) reporting this
  exact error.

### The fix

`nodePolyfills()` is kept — it is what actually injects the shims. Its bare shim references are
resolved to real files in the two places that need it, because dependency pre-bundling runs its
own resolver:

1. **The module graph**, via a `resolveId` hook. The regex is anchored so it matches only
   `buffer` / `global` / `process`, their `node:` forms, their subpaths (`buffer/index.js`), and
   the plugin's own `vite-plugin-node-polyfills/shims/*` — and **not** lookalikes such as
   `some-pkg/process`, `processing`, or `my-buffer` (unit-tested).
2. **The plugin's own returned config**, patched before Vite merges it. This is where the
   pre-bundle alias maps and the injected banner come from, and a `resolveId` hook cannot reach
   them — which is why `vite dev` stayed broken until this was added.

Alias values point at the shim *directory* rather than the file: aliases substitute by prefix, so
a directory keeps both `buffer` and `buffer/index.js` resolvable. Import specifiers in the banner
still get the file.

Both are deletable as soon as upstream ships; the comment in the config says so.

### MUI system props on Box

Fixing dev mode surfaced a second, real bug. `WalletHeader` passed `display`,
`justifyContent`, `alignItems` and `borderBottom` as direct `Box` props. MUI 9 no longer forwards
those, so they leaked to the DOM — React logged *"does not recognize the prop"* for each, and the
header styling was **silently lost**. Moving them into `sx` restores the layout and clears the
last `tsc -b` errors here, so `examples/dynamic` now type-checks clean.

### Bundled in: `pnpm dedupe`

#850 added `ws@>=7.0.0 <8.0.0` and `ws@>=8.0.0` overrides but never ran `pnpm dedupe`, so the
lockfile still carried **ws@7.5.13 alongside ws@8.21.3**. The vulnerable copy stayed in the tree
via `@remix-run/dev` and `jayson` (through `isomorphic-ws`) — precisely what those overrides were
meant to remove, so that security fix was only half-applied, and `pnpm dedupe --check` failed on
`main`. Deduping collapses `ws` to a single `8.21.3`; the diff is 27 lines.

`vite-plugin-node-polyfills` moves to `devDependencies` at `^0.26.0`, matching the twelve other
examples that already use it, and `vite-plugin-env-compatible` is dropped.

## Visual showcase (Screenshots or Videos)

`examples/dynamic` renders the widget alongside Dynamic's own connect button, in **both**
`vite dev` and `vite preview`. Page text from a headless load:

```
Dynamic + LI.FI widget Example
Connect wallet
Exchange
From   Select...
To     Select...
Send   $0.00
```

Console is clean — no `process is not defined`, no app errors.

## Verification

| Gate | Result |
| --- | --- |
| `examples/dynamic` widget-smoke | 3 / 3 — container renders, Settings opens, tokens selectable |
| `examples/dynamic` `vite dev` | widget renders, 0 pre-bundle errors, 0 React prop warnings |
| `examples/dynamic` `tsc -b` | passes (was 3 errors) |
| `pnpm test:examples` | 18 / 18 passed on the rebased base, before the dev-mode and dedupe commits; CI's per-example E2E jobs cover the final tree |
| `pnpm build` | pass |
| `pnpm check` (Biome) | pass |
| `pnpm check:types` | pass |
| `pnpm check:circular-deps` | pass |
| `pnpm install --frozen-lockfile` | pass |
| `pnpm dedupe --check` | pass (**failed on `main`** before this PR) |

Also updated the profile enumeration in `e2e/tests/profiles/widget-smoke.spec.ts` — the standard
profile is now 14, not 13.

### Not addressed here

The same MUI `TS2769` overload errors still fail `tsc -b` in `privy`, `connectkit` and `reown`,
from the same system-props-on-`Box` pattern. That is long-standing and why those examples carry
`buildCmd: vite-build`, which skips `tsc`. `dynamic` is fixed because its errors were in the file
I had to touch anyway; the other three are a separate sweep.

## Checklist before requesting a review
- [x] I have performed a self-review and testing of my code.
- [x] This pull request is focused and addresses a single problem.
- [ ] If this PR modifies the Widget API or adds new features that require documentation, I have updated the documentation in the [public-docs](https://github.com/lifinance/public-docs) repository.
