### PR TITLE
fix(widget-provider-stellar): keep the wallets kit off the server render

### DIFF
--- a/.changeset/stellar-ssr-safe-store.md
+++ b/.changeset/stellar-ssr-safe-store.md
@@ -1,0 +1,5 @@
+---
+'@lifi/widget-provider-stellar': patch
+---
+
+Keep the Stellar Wallets Kit off the server render. The kit's wallet modules read `window` in their constructors, so a framework that server-renders the provider — Next.js prerendering, for example — crashed with `ReferenceError: window is not defined` inside `initStellarWalletsKit`. Without a `window` the store is now built inert: no kit, no availability probe, no listeners. The browser still builds the real singleton in its own module instance, and because its first render also shows no wallets and no address, hydration stays consistent.

--- a/packages/widget-provider-stellar/src/stellar-kit/createStellarWalletsKitStore.test.ts
+++ b/packages/widget-provider-stellar/src/stellar-kit/createStellarWalletsKitStore.test.ts
@@ -71,6 +71,9 @@ const { createStellarWalletsKitStore } = await import(
 
 describe('createStellarWalletsKitStore', () => {
   beforeEach(() => {
+    // The default vitest environment is node, which has no `window`. The store
+    // takes its server path without one, so the client-path tests install a stub.
+    globalThis.window = {} as Window & typeof globalThis
     moduleAvailable = true
     moduleSelected = true
     for (const key of Object.keys(listeners)) {
@@ -176,5 +179,39 @@ describe('createStellarWalletsKitStore', () => {
 
     expect(store.getState().address).toBe('GRESTORED')
     expect(store.getState().connected).toBe(false)
+  })
+
+  // A Next.js prerender crashed with "window is not defined" inside the kit's
+  // module constructors, so the server must never touch SWK at all.
+  describe('without a window (server render)', () => {
+    beforeEach(() => {
+      // Runs after the outer hook, so this removes the stub it installed.
+      // @ts-expect-error - emulating a server render
+      delete globalThis.window
+    })
+
+    it('builds an inert store and registers no kit listeners', () => {
+      const store = createStellarWalletsKitStore()
+
+      expect(Object.keys(listeners)).toHaveLength(0)
+      expect(store.getState().wallets).toEqual([])
+      expect(store.getState().address).toBeNull()
+      expect(store.getState().connected).toBe(false)
+      expect(store.getState().networkPassphrase).toBe(
+        'Public Global Stellar Network ; September 2015'
+      )
+    })
+
+    it('leaves every action safe to call', async () => {
+      const store = createStellarWalletsKitStore()
+
+      await expect(store.getState().connect('freighter')).resolves.toBeNull()
+      await expect(store.getState().refreshWallets()).resolves.toBeUndefined()
+      await expect(store.getState().disconnect()).resolves.toBeUndefined()
+      await expect(store.getState().isWalletReachable()).resolves.toBe(false)
+      await expect(store.getState().getWalletNetwork()).resolves.toBe(
+        'Public Global Stellar Network ; September 2015'
+      )
+    })
   })
 })

--- a/packages/widget-provider-stellar/src/stellar-kit/createStellarWalletsKitStore.ts
+++ b/packages/widget-provider-stellar/src/stellar-kit/createStellarWalletsKitStore.ts
@@ -66,7 +66,38 @@ const assertWalletNetwork = async (expected: string): Promise<void> => {
   }
 }
 
+// SWK's wallet modules read `window` in their constructors, so nothing kit-related
+// may run during a server render — Next.js prerenders this provider. Hand back an
+// inert store instead: no kit, no availability probe, no listeners. The browser
+// builds the real one in its own module instance, and its first render also shows
+// no wallets and no address, so hydration stays consistent.
+const createServerStore = (): StellarWalletsKitStore =>
+  create<StellarWalletsKitState>(() => ({
+    networkPassphrase: Networks.PUBLIC,
+    wallets: [],
+    selectedWalletId: null,
+    selectedWallet: null,
+    address: null,
+    connected: false,
+    connecting: false,
+    async connect() {
+      return null
+    },
+    async disconnect() {},
+    async refreshWallets() {},
+    async isWalletReachable() {
+      return false
+    },
+    async getWalletNetwork() {
+      return Networks.PUBLIC
+    },
+  }))
+
 export function createStellarWalletsKitStore(): StellarWalletsKitStore {
+  if (typeof window === 'undefined') {
+    return createServerStore()
+  }
+
   const { networkPassphrase } = initStellarWalletsKit()
 
   let refreshing: Promise<void> | undefined


### PR DESCRIPTION
## Which Linear task is linked to this PR?

None — found while adopting `@lifi/widget-provider-stellar` in a Next.js app.

## Why was it implemented this way?

**The bug.** SWK's wallet modules read `window` in their constructors, so `initStellarWalletsKit()` throws during a server render. Any framework that server-renders `StellarProvider` crashes:

```
ReferenceError: window is not defined
    at initStellarWalletsKit
    at createStellarWalletsKitStore
    at getStellarWalletsKitStore
    at useStellarWalletsKit
    at StellarProviderValues
```

That trace is from a real Next.js 16 prerender, which failed every prerendered page.

**Why CI did not catch it.** `widget-playground-vite` is a client-only Vite app, so nothing in this repo ever server-renders a provider. The Stellar PR was fully green with the bug present. Worth knowing as a general gap: SSR regressions in any provider package are invisible to the current suite.

**The fix.** Without a `window`, `createStellarWalletsKitStore` returns an inert store — no kit, no availability probe, no listeners — instead of touching SWK at all. The browser builds the real singleton in its own module instance, exactly as before.

Hydration stays consistent because the inert state is what the client's own first render shows anyway: `wallets: []`, `address: null`, `connected: false`. The availability probe is async, so even in the browser the first paint has no wallets.

I chose this over guarding each SWK call site because the module constructors run before any call site is reachable, and over asking consumers to gate the provider behind a hydration flag, which would push the trap onto every SSR consumer.

**Release note:** `@lifi/widget-provider-stellar` has not been published yet — `changeset status` still lists it at `minor` from the original `stellar-support` changeset. So this patch folds into the same first release, and no released version is ever broken.

## Visual showcase (Screenshots or Videos)

Not applicable — no UI change. Behaviour in the browser is unchanged.

## Checklist before requesting a review

- [x] I have performed a self-review and testing of my code.
- [x] This pull request is focused and addresses a single problem.

### Verification

- `pnpm --filter @lifi/widget-provider-stellar test` — **13 passed**, including two new cases that delete `globalThis.window` and assert the store registers no kit listeners and that every action stays safe to call.
- `pnpm check` — passes.
- `pnpm check:types` — 17 packages, 0 errors.
- `pnpm --filter @lifi/widget-provider-stellar build` — exit 0, `dist/esm/index.js` emitted.
- End to end: the same fix, applied to a downstream fork of this package, turned a Next.js build that failed on every prerendered page into a green one (20/20 CI checks).

One thing the tests exposed, worth a look on its own: this package has **no vitest config**, so its suite runs in the `node` environment with no `window`. Before this change all 11 existing tests were taking the browser path only because nothing checked for `window`. The client-path tests now install a `window` stub explicitly, which makes that assumption visible rather than accidental.
