### PR TITLE
chore(widget-provider-stellar): trim comments in the wallets kit store

### DIFF
--- a/packages/widget-provider-stellar/src/stellar-kit/createStellarWalletsKitStore.test.ts
+++ b/packages/widget-provider-stellar/src/stellar-kit/createStellarWalletsKitStore.test.ts
@@ -71,8 +71,6 @@ const { createStellarWalletsKitStore } = await import(
 
 describe('createStellarWalletsKitStore', () => {
   beforeEach(() => {
-    // The default vitest environment is node, which has no `window`. The store
-    // takes its server path without one, so the client-path tests install a stub.
     globalThis.window = {} as Window & typeof globalThis
     moduleAvailable = true
     moduleSelected = true
@@ -181,11 +179,8 @@ describe('createStellarWalletsKitStore', () => {
     expect(store.getState().connected).toBe(false)
   })
 
-  // A Next.js prerender crashed with "window is not defined" inside the kit's
-  // module constructors, so the server must never touch SWK at all.
   describe('without a window (server render)', () => {
     beforeEach(() => {
-      // Runs after the outer hook, so this removes the stub it installed.
       // @ts-expect-error - emulating a server render
       delete globalThis.window
     })

--- a/packages/widget-provider-stellar/src/stellar-kit/createStellarWalletsKitStore.ts
+++ b/packages/widget-provider-stellar/src/stellar-kit/createStellarWalletsKitStore.ts
@@ -66,11 +66,7 @@ const assertWalletNetwork = async (expected: string): Promise<void> => {
   }
 }
 
-// SWK's wallet modules read `window` in their constructors, so nothing kit-related
-// may run during a server render — Next.js prerenders this provider. Hand back an
-// inert store instead: no kit, no availability probe, no listeners. The browser
-// builds the real one in its own module instance, and its first render also shows
-// no wallets and no address, so hydration stays consistent.
+// SWK's wallet modules read `window` when constructed, so the server gets an inert store.
 const createServerStore = (): StellarWalletsKitStore =>
   create<StellarWalletsKitState>(() => ({
     networkPassphrase: Networks.PUBLIC,


### PR DESCRIPTION
Comment-only follow-up to #853. Trims the SSR-guard commentary to a single line and drops three explanatory comments from the store's test file; the test names already say what each case covers.

No code changes — `git diff` touches only comment lines. `pnpm --filter @lifi/widget-provider-stellar test` still passes 13/13.

No changeset: comments do not affect the published output.