### PR TITLE
fix(widget): parse fee/gas wei amounts without overflowing BigInt

### DIFF
--- a/.changeset/fix-bigint-toFixed-fee-overflow.md
+++ b/.changeset/fix-bigint-toFixed-fee-overflow.md
@@ -1,0 +1,5 @@
+---
+"@lifi/widget": patch
+---
+
+Fix `getAccumulatedFeeCostsBreakdown` and `useGasSufficiency` throwing `SyntaxError: Cannot convert Xe+Y to a BigInt` for real fee/gas amounts at or above 1e21 wei (routes involving high-supply, low-value tokens like SHIB or PEPE routinely exceed this). The old code round-tripped wei strings through `Number(...).toFixed(0)`, which switches to exponential notation above that threshold; `BigInt()` rejects exponential-notation strings.

--- a/packages/widget/src/hooks/useGasSufficiency.ts
+++ b/packages/widget/src/hooks/useGasSufficiency.ts
@@ -5,6 +5,7 @@ import { useQuery } from '@tanstack/react-query'
 import { useMemo } from 'react'
 import { useSDKClient } from '../providers/SDKClientProvider.js'
 import { useWidgetConfig } from '../providers/WidgetProvider/WidgetProvider.js'
+import { parseAmountToBigInt } from '../utils/fees.js'
 import { getSelfFundedGasAmount } from '../utils/gas.js'
 import { getQueryKey } from '../utils/queries.js'
 import { useAvailableChains } from './useAvailableChains.js'
@@ -106,7 +107,7 @@ export const useGasSufficiency = (
               const { token } = step.estimate.gasCosts[0]
               const gasCostAmount = step.estimate.gasCosts.reduce(
                 (amount, gasCost) =>
-                  amount + BigInt(Number(gasCost.amount).toFixed(0)),
+                  amount + parseAmountToBigInt(gasCost.amount),
                 0n
               )
               // A previous step can deliver this step's gas token (XLM bridged to
@@ -134,7 +135,7 @@ export const useGasSufficiency = (
               const { token } = nonIncludedFeeCosts[0]
               const feeCostAmount = nonIncludedFeeCosts.reduce(
                 (amount, feeCost) =>
-                  amount + BigInt(Number(feeCost.amount).toFixed(0)),
+                  amount + parseAmountToBigInt(feeCost.amount),
                 0n
               )
               if (feeCostAmount > 0n) {

--- a/packages/widget/src/utils/fees.test.ts
+++ b/packages/widget/src/utils/fees.test.ts
@@ -1,0 +1,104 @@
+import type { FeeCost, RouteExtended, Token } from '@lifi/sdk'
+import { describe, expect, it } from 'vitest'
+import { getAccumulatedFeeCostsBreakdown, parseAmountToBigInt } from './fees.js'
+
+const mockToken = (overrides: Partial<Token> = {}): Token =>
+  ({
+    address: '0x95aD61b0a150d79219dCF64E1E6Cc01f0B64C4cE',
+    chainId: 1,
+    symbol: 'SHIB',
+    decimals: 18,
+    name: 'Shiba Inu',
+    priceUSD: '0.000005185205517',
+    ...overrides,
+  }) as Token
+
+const mockFeeCost = (
+  amount: string,
+  included: boolean,
+  token: Token = mockToken()
+): FeeCost =>
+  ({
+    name: 'LIFI Fixed Fee',
+    description: 'Fixed LIFI fee',
+    token,
+    amount,
+    amountUSD: '0',
+    percentage: '0.0025',
+    included,
+  }) as FeeCost
+
+const mockRoute = (feeCosts: FeeCost[]): RouteExtended =>
+  ({
+    steps: [
+      {
+        estimate: {
+          feeCosts,
+          gasCosts: [],
+        },
+      },
+    ],
+  }) as unknown as RouteExtended
+
+describe('parseAmountToBigInt', () => {
+  it('parses a real LI.FI production fee amount above the toFixed(0) exponential-notation threshold (1e21)', () => {
+    // Real amount observed from a live GET https://li.quest/v1/quote
+    // (SHIB -> USDT, chain 1 -> 56): "LIFI Fixed Fee", 2.5e24 wei.
+    expect(parseAmountToBigInt('2500000000000000000000000')).toBe(
+      2500000000000000000000000n
+    )
+  })
+
+  it('does not throw for the exact value that crashes Number(...).toFixed(0)', () => {
+    // Number('1250000000000000000000000').toFixed(0) === '1.25e+24', and
+    // BigInt('1.25e+24') throws SyntaxError. Confirm the old failure mode
+    // for documentation, then confirm the new parser is unaffected by it.
+    expect(() =>
+      BigInt(Number('1250000000000000000000000').toFixed(0))
+    ).toThrow(SyntaxError)
+    expect(parseAmountToBigInt('1250000000000000000000000')).toBe(
+      1250000000000000000000000n
+    )
+  })
+
+  it('preserves exact precision above Number.MAX_SAFE_INTEGER (2^53)', () => {
+    // A real Polygon gas cost observed above 2^53 (9007199254740992).
+    const wei = '188437049834009000'
+    expect(parseAmountToBigInt(wei)).toBe(188437049834009000n)
+    // The old Number-based path drifts by design - document the delta so a
+    // future revert of this fix is caught by a failing assertion here too.
+    expect(Number(wei).toFixed(0)).not.toBe(wei)
+  })
+
+  it('returns 0n for an empty or missing amount', () => {
+    expect(parseAmountToBigInt('')).toBe(0n)
+  })
+
+  it('truncates a decimal string at the integer part', () => {
+    expect(parseAmountToBigInt('123.456')).toBe(123n)
+  })
+
+  it('handles small integer amounts unchanged', () => {
+    expect(parseAmountToBigInt('42')).toBe(42n)
+    expect(parseAmountToBigInt('0')).toBe(0n)
+  })
+})
+
+describe('getAccumulatedFeeCostsBreakdown', () => {
+  it('does not throw for a route carrying a real above-1e21 included fee', () => {
+    // This is the exact shape returned by a live LI.FI quote where the old
+    // `BigInt(Number(feeCost.amount).toFixed(0))` line threw
+    // "Cannot convert 1.25e+24 to a BigInt" inside getStepFeeCostsBreakdown.
+    const route = mockRoute([mockFeeCost('2500000000000000000000000', true)])
+    expect(() => getAccumulatedFeeCostsBreakdown(route, true)).not.toThrow()
+    const { feeCosts } = getAccumulatedFeeCostsBreakdown(route, true)
+    expect(feeCosts[0]?.amount).toBe(2500000000000000000000000n)
+  })
+
+  it('still returns zero fees for the default included=false path when only an included fee is present', () => {
+    const route = mockRoute([mockFeeCost('2500000000000000000000000', true)])
+    const { feeCosts, feeCostUSD } = getAccumulatedFeeCostsBreakdown(route)
+    expect(feeCosts).toHaveLength(0)
+    expect(feeCostUSD).toBe(0)
+  })
+})

--- a/packages/widget/src/utils/fees.ts
+++ b/packages/widget/src/utils/fees.ts
@@ -7,6 +7,15 @@ export interface FeesBreakdown {
   token: Token
 }
 
+// LI.FI fee/gas amounts are integer wei strings. Parsing through Number and
+// toFixed(0) throws for any value >= 1e21 (toFixed switches to exponential
+// notation, which BigInt() rejects) and silently loses precision above
+// Number.MAX_SAFE_INTEGER for smaller values. Parse the string directly.
+export const parseAmountToBigInt = (amount: string): bigint => {
+  const [whole] = String(amount).split('.')
+  return whole ? BigInt(whole) : 0n
+}
+
 export const getAccumulatedFeeCostsBreakdown = (
   route: RouteExtended,
   included: boolean = false
@@ -114,7 +123,7 @@ const getStepFeeCostsBreakdown = (
 
   const { amount, amountUSD } = feeCosts.reduce(
     (acc, feeCost) => {
-      const feeAmount = BigInt(Number(feeCost.amount).toFixed(0) || 0)
+      const feeAmount = parseAmountToBigInt(feeCost.amount)
       const amountUSD = formatTokenPrice(
         feeAmount,
         feeCost.token.priceUSD,


### PR DESCRIPTION
## What

`getAccumulatedFeeCostsBreakdown` (exported publicly from `@lifi/widget/shared`) and `useGasSufficiency` throw `SyntaxError: Cannot convert Xe+Y to a BigInt` for any real fee or gas amount at or above 1e21 wei. This is not a corner case — routes involving high-supply, low-value tokens (SHIB, PEPE, and similar) routinely cross this threshold.

## Root cause

Three sites (`packages/widget/src/utils/fees.ts:117`, `packages/widget/src/hooks/useGasSufficiency.ts:109` and `:137`) parsed integer wei strings like this:

```ts
const feeAmount = BigInt(Number(feeCost.amount).toFixed(0) || 0)
```

`Number.prototype.toFixed` switches to exponential notation for values `>= 1e21` (e.g. `"1.25e+24"`), and `BigInt()` rejects exponential-notation strings. Separately, round-tripping through `Number` at all loses precision above `Number.MAX_SAFE_INTEGER` (2^53) even for values that don't crash.

## Evidence — real production data, not synthetic

Live `GET https://li.quest/v1/quote` for SHIB → USDT (chain 1 → 56):

```json
{
  "name": "LIFI Fixed Fee",
  "token": { "symbol": "SHIB", "decimals": 18 },
  "amount": "2500000000000000000000000",
  "included": true
}
```

`2500000000000000000000000` = 2.5e24, well past the crash threshold.

```
node -e "BigInt(Number('2500000000000000000000000').toFixed(0))"
Uncaught SyntaxError: Cannot convert 2.5e+24 to a BigInt
```

Confirmed this crashes `getAccumulatedFeeCostsBreakdown(route, true)` when fed a route carrying this real fee.

## Fix

Added `parseAmountToBigInt(amount: string): bigint` in `fees.ts`, exported and reused at all three sites:

```ts
export const parseAmountToBigInt = (amount: string): bigint => {
  const [whole] = String(amount).split('.')
  return whole ? BigInt(whole) : 0n
}
```

No `Number` round-trip, so no exponential-notation crash and no precision loss. Grepped the whole repo (`grep -rn "BigInt(Number" --include="*.ts" --include="*.tsx"`) to confirm these were the only three occurrences of the buggy pattern — all three are fixed.

## Honest scoping

All current in-widget render call sites of `getAccumulatedFeeCostsBreakdown` (`RouteCard.tsx`, `RouteCardEssentials.tsx`, `RouteDetails.tsx`, `TransactionReview.tsx`, `TokenValueBottomSheet.tsx`, `TransactionFailedButtons.tsx`, `RouteProviderCard.tsx`) use the default `included = false`, and across five routes I probed I could not produce a non-included fee crossing the threshold — so this is a **proven crash on the public `getAccumulatedFeeCostsBreakdown(route, true)` API surface**, not an observed in-widget render crash today. Worth noting: there is no `ErrorBoundary` anywhere in `packages/widget/src` (confirmed via grep), so if a non-included fee or a gas cost ever does cross the threshold, the crash would unmount the whole integrator tree with no recovery — `getGasCostsBreakdown` in particular processes gas costs through the same buggy expression completely unfiltered by `included` (that field doesn't apply to gas costs at all), on every single call regardless of the `included` param passed in.

One minor, unreachable-with-real-data behavior change worth flagging in review: `"5.999".split('.')` truncates to `5`, where the old `Number(...).toFixed(0)` rounded to `6`. LI.FI wei amounts are always integers on the wire (confirmed via the live capture above), so this isn't reachable in practice, but noting it for transparency.

## receipts

```
$ pnpm vitest run src/utils/fees.test.ts
 Test Files  1 passed (1)
      Tests  8 passed (8)
```

Red-before/green-after independently confirmed: stashed the fix and re-ran the same test file against the unmodified code — 7/8 tests failed, including the exact production crash:

```
FAIL src/utils/fees.test.ts > getAccumulatedFeeCostsBreakdown > does not throw for a route carrying a real above-1e21 included fee
AssertionError: expected [Function] to not throw an error but 'SyntaxError: Cannot convert 2.5e+24 t…' was thrown
```

Full package suite after the fix:
```
$ pnpm vitest run
 Test Files  10 passed (10)
      Tests  92 passed (92)
```

`pnpm check:types` and `biome check` clean on all changed files (pre-existing implicit-any warnings elsewhere in `useGasSufficiency.ts`, unrelated to the two lines touched here, are unchanged from baseline).

Codex adversarial review timed out with no output after 5 minutes; killed it and did a thorough self-review instead (edge cases tested directly: negative amounts, leading `+`, scientific-notation input, whitespace, `null`/`undefined`, leading zeros — all match or strictly improve on prior behavior, no new failure modes; confirmed via repo-wide grep that no other instance of the buggy pattern remains).

## risk

Low — pure parsing fix, no behavior change for any value below the crash threshold, no new dependencies.
