### PR TITLE
fix: normalize comma decimal separator in slippage input

### DIFF
--- a/packages/widget/src/utils/format.test.ts
+++ b/packages/widget/src/utils/format.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { formatInputAmount } from './format.js'
+import { formatInputAmount, formatSlippage } from './format.js'
 
 describe('formatInputAmount', () => {
   it('should handle empty input', () => {
@@ -49,5 +49,62 @@ describe('formatInputAmount', () => {
     expect(formatInputAmount('0.00', 2, false)).toBe('')
     expect(formatInputAmount('.0', 2, false)).toBe('')
     expect(formatInputAmount('0..', 2, false)).toBe('')
+  })
+})
+
+describe('formatSlippage', () => {
+  it('should handle empty input', () => {
+    expect(formatSlippage('')).toBe('')
+  })
+
+  it('should pass through plain dot-decimal values', () => {
+    expect(formatSlippage('0.5', '0.5', false)).toBe('0.5')
+    expect(formatSlippage('1.5', '0.5', false)).toBe('1.5')
+    expect(formatSlippage('5', '0.5', false)).toBe('5')
+  })
+
+  // Regression: a comma decimal separator (the default in many non-en-US
+  // locales) used to be silently truncated instead of normalized, e.g.
+  // '0,5' -> '0' (10x-off or zero slippage depending on the call site),
+  // mirroring the comma handling formatInputAmount already has.
+  it('should normalize a comma decimal separator', () => {
+    expect(formatSlippage('0,5', '0.5', false)).toBe('0.5')
+    expect(formatSlippage('1,5', '0.5', false)).toBe('1.5')
+    expect(formatSlippage('0,25', '0.5', false)).toBe('0.25')
+  })
+
+  it('should normalize a comma decimal separator while typing (returnInitial)', () => {
+    // Simulates typing '0,5' one keystroke at a time with returnInitial=true,
+    // as the widget's onChange handler does.
+    expect(formatSlippage('0', '0.5', true)).toBe('0')
+    expect(formatSlippage('0,', '0.5', true)).toBe('0.')
+    expect(formatSlippage('0,5', '0.5', true)).toBe('0.5')
+  })
+
+  it('should clamp to 100', () => {
+    expect(formatSlippage('150', '0.5', false)).toBe('100')
+    expect(formatSlippage('150,5', '0.5', false)).toBe('100')
+  })
+
+  it('should take the absolute value of a negative input', () => {
+    expect(formatSlippage('-3', '0.5', false)).toBe('3')
+    expect(formatSlippage('-3,5', '0.5', false)).toBe('3.5')
+  })
+
+  it('should fall back to defaultValue on unparseable input', () => {
+    expect(formatSlippage('abc', '0.5', false)).toBe('0.5')
+  })
+
+  // The comma-decimal normalization is intentionally narrow: it only fires
+  // for an unambiguous single comma with no existing dot. Anything more
+  // ambiguous (multiple commas, or a comma alongside a dot, e.g.
+  // thousands-style '1,234.5') is left untouched rather than guessed at, so
+  // these all keep exactly their pre-fix behavior (verified against the
+  // unmodified function) instead of being mangled through multiple dots.
+  it('should not attempt to normalize ambiguous separator combinations', () => {
+    expect(formatSlippage('1,,5', '0.5', false)).toBe('1')
+    expect(formatSlippage('1,234.5', '0.5', false)).toBe('1')
+    expect(formatSlippage('150,,5', '0.5', false)).toBe('150')
+    expect(formatSlippage('-150,,5', '0.5', false)).toBe('-150')
   })
 })

--- a/packages/widget/src/utils/format.ts
+++ b/packages/widget/src/utils/format.ts
@@ -28,6 +28,14 @@ export function formatSlippage(
   if (!slippage) {
     return slippage
   }
+  // Normalize a comma decimal separator (common outside en-US locales) to a dot
+  // before any numeric parsing below, but only when unambiguous: exactly one
+  // comma and no existing dot. Anything else (multiple commas, or a comma
+  // alongside a dot, e.g. thousands-style '1,234.5') is left as-is rather than
+  // guessing the intended locale, and falls through to the existing handling.
+  if (!slippage.includes('.') && (slippage.match(/,/g)?.length ?? 0) === 1) {
+    slippage = slippage.replace(',', '.')
+  }
   const parsedSlippage = Number.parseFloat(slippage)
   if (Number.isNaN(Number(slippage)) && !Number.isNaN(parsedSlippage)) {
     return parsedSlippage.toString()


### PR DESCRIPTION
## What

`formatSlippage` (`packages/widget/src/utils/format.ts`) silently truncated a comma decimal separator instead of treating it as a decimal point, so a user in a comma-decimal locale entering a custom slippage value gets a wrong tolerance sent to the SDK.

```ts
const parsedSlippage = Number.parseFloat(slippage)
if (Number.isNaN(Number(slippage)) && !Number.isNaN(parsedSlippage)) {
  return parsedSlippage.toString()
}
```

`Number.parseFloat('0,5')` stops at the first non-numeric character and returns `0`, while `Number('0,5')` is `NaN` — so this branch fires and returns `'0'`, discarding everything after the comma.

The sibling `formatInputAmount` in the same file already normalizes commas (`amount.trim().replaceAll(',', '.')`) and has a test proving it (`formatInputAmount('  1,23  ', null, true) -> '1.23'`). `formatSlippage`, 20 lines above, did not — and had zero test coverage at all before this PR.

## Why it matters

The widget ships 30+ locales, many comma-decimal (fr/de/es/it/pt-BR). `SlippageInput` is a plain MUI `InputBase` (`type="text"`, `inputMode: 'decimal'`) with no numeric filtering, so a comma is freely enterable via keyboard or paste.

Traced end-to-end through the real `formatAndSetSlippage` handler (`SlippagePage.tsx`) and `useRoutes.ts`'s `Number.parseFloat(slippage) / 100` conversion, on this repo state:

```
keystroke "0" -> stored "0"
keystroke "0," -> stored "0"
keystroke "0,5" -> stored "0"
blur -> "0"

paste "0,5" -> blur "0"
paste "1,5" -> blur "1"
paste "0,25" -> blur "0"
paste "0.5" -> blur "0.5"   (control, correct)
```

`slippage: "0"` sent through `useRoutes.ts`'s `Number.parseFloat(slippage) / 100` becomes `slippage: 0` in the quote request — `toAmountMin == toAmount`, so routes revert or return no quotes. The bad value is zustand-persisted, so it survives reloads.

I independently reproduced this myself by transcribing the real functions rather than trusting a description — full transcript in the PR discussion if useful. Note: the exact wrong numbers above are what I actually observed on this repo's current `formatSlippage`/`formatAndSetSlippage`; I did not assume a specific magnitude in advance.

## Fix

Normalize the separator before parsing, but **only when unambiguous**: no existing dot, and exactly one comma.

```ts
if (!slippage.includes('.') && (slippage.match(/,/g)?.length ?? 0) === 1) {
  slippage = slippage.replace(',', '.')
}
```

Anything more ambiguous — multiple commas, or a comma alongside a dot (e.g. thousands-style `'1,234.5'`) — is left completely untouched and falls through to the pre-existing handling, verified byte-identical to the current (unfixed) output for those inputs. An earlier version of this fix did a blanket `replaceAll(',', '.')`, which mangled `'1,234.5'` into `'1.234.5'` and silently lost precision through `parseFloat` — a second Codex review pass caught this before it shipped; see receipts below.

## Receipts

Real red-before/green-after via `git stash` on just `format.ts` (keeping the new tests):

```
$ pnpm vitest run src/utils/format.test.ts   # unfixed format.ts, new tests present
 FAIL  should normalize a comma decimal separator
 FAIL  should normalize a comma decimal separator while typing (returnInitial)
 FAIL  should clamp to 100
 FAIL  should take the absolute value of a negative input
 Tests  4 failed | 11 passed (15)

$ git stash pop && pnpm vitest run src/utils/format.test.ts   # fixed
 Tests  15 passed (15)

$ pnpm vitest run   # full widget package suite
 Test Files  9 passed (9)
      Tests  92 passed (92)

$ pnpm check packages/widget/src/utils/format.ts packages/widget/src/utils/format.test.ts
Checked 2 files in 978ms. No fixes applied.

$ pnpm --filter widget check:types   # after building wallet-management (pre-existing, unrelated project-reference ordering gap on a clean checkout too)
0 errors
```

Adjacent, not fixed here (flagging only): `useRoutes.ts:203` guards with `!Number.isNaN(slippage)` where `slippage` is a **string** — `Number.isNaN` doesn't coerce, so that guard is vacuously `true` for every string input. Benign today since it's ANDed with other real checks, but it isn't the check it looks like.

## Codex adversarial review

Ran `codex exec` synchronously twice.

**First pass (NEEDS-WORK):** flagged that a blanket `replaceAll(',', '.')` mangles `'1,234.5'`, `'1,,5'`, `'150,,5'`, `'-150,,5'` through multiple dots, silently truncating precision or bypassing the 100 clamp — exactly the class of bug this PR fixes, reintroduced for a different input shape. Fixed by narrowing the normalization to the unambiguous no-dot/single-comma case; added regression tests asserting the ambiguous cases are byte-identical to pre-fix output (verified against the original unmodified function).

**Second pass (SHIP):** confirmed the fix fully addresses the prior concern. Non-blocking notes: `'1,234'` (no dot) is interpreted as decimal `1.234` rather than a grouped integer — intentional, since slippage is a 0-100 percentage field where thousands-grouping doesn't apply in practice; negative magnitudes above 100 remain unclamped in the ambiguous-input paths, matching pre-existing (unchanged) behavior.

## Risk

Low. Two files touched, no runtime dependency changes. The normalization is deliberately conservative — it only ever changes behavior for the specific class of input it's designed to fix (unambiguous single-comma decimals), and is provably a no-op for everything else.
