### PR TITLE
fix: route-label token address rules never match integrator config addresses

### DIFF
--- a/.changeset/fix-route-label-address-casing.md
+++ b/.changeset/fix-route-label-address-casing.md
@@ -1,0 +1,5 @@
+---
+"@lifi/widget": patch
+---
+
+fix: route-label token address rules never match integrator config addresses

--- a/packages/widget/src/components/RouteCard/getMatchingLabels.test.ts
+++ b/packages/widget/src/components/RouteCard/getMatchingLabels.test.ts
@@ -1,0 +1,83 @@
+import type { Route } from '@lifi/sdk'
+import { describe, expect, it } from 'vitest'
+import { getMatchingLabels } from './getMatchingLabels.js'
+
+const checksummedFromAddress = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48'
+const checksummedToAddress = '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174'
+
+const route = {
+  fromChainId: 1,
+  toChainId: 137,
+  fromToken: { address: checksummedFromAddress },
+  toToken: { address: checksummedToAddress },
+  steps: [],
+} as unknown as Route
+
+describe('getMatchingLabels', () => {
+  it('matches when the config address is checksummed like the route', () => {
+    const labels = getMatchingLabels(route, [
+      {
+        label: { text: 'USDC Bonus' },
+        fromTokenAddress: [checksummedFromAddress],
+      },
+    ])
+    expect(labels).toEqual([{ text: 'USDC Bonus' }])
+  })
+
+  it('matches when the config address is lowercase (as the repo default config writes it)', () => {
+    const labels = getMatchingLabels(route, [
+      {
+        label: { text: 'USDC Bonus' },
+        fromTokenAddress: [checksummedFromAddress.toLowerCase()],
+      },
+    ])
+    expect(labels).toEqual([{ text: 'USDC Bonus' }])
+  })
+
+  it('matches on toTokenAddress regardless of casing', () => {
+    const labels = getMatchingLabels(route, [
+      {
+        label: { text: 'POL Bonus' },
+        toTokenAddress: [checksummedToAddress.toLowerCase()],
+      },
+    ])
+    expect(labels).toEqual([{ text: 'POL Bonus' }])
+  })
+
+  it('matches on the numeric fromChainId criterion, unaffected by address-casing logic', () => {
+    const labels = getMatchingLabels(route, [
+      { label: { text: 'Chain rule' }, fromChainId: [1] },
+    ])
+    expect(labels).toEqual([{ text: 'Chain rule' }])
+  })
+
+  it('does not case-fold non-EVM (e.g. Solana base58) token identifiers', () => {
+    const solanaRoute = {
+      fromChainId: 1151111081099710,
+      toChainId: 137,
+      fromToken: { address: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v' },
+      toToken: { address: checksummedToAddress },
+      steps: [],
+    } as unknown as Route
+
+    // A lowercase variant is a DIFFERENT, distinct base58 identifier on
+    // Solana - it must not match the real (differently-cased) address.
+    const lowercaseVariant = 'epjfwdd5aufqssqem2qn1xzybapc8g4weggkzwytdt1v'
+
+    const labels = getMatchingLabels(solanaRoute, [
+      {
+        label: { text: 'Should not match' },
+        fromTokenAddress: [lowercaseVariant],
+      },
+    ])
+    expect(labels).toEqual([])
+
+    const exactMatchLabels = getMatchingLabels(solanaRoute, [
+      {
+        label: { text: 'USDC on Solana' },
+        fromTokenAddress: ['EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v'],
+      },
+    ])
+    expect(exactMatchLabels).toEqual([{ text: 'USDC on Solana' }])
+  })
+})

--- a/packages/widget/src/components/RouteCard/getMatchingLabels.ts
+++ b/packages/widget/src/components/RouteCard/getMatchingLabels.ts
@@ -2,6 +2,28 @@ import type { Route } from '@lifi/sdk'
 import type { RouteLabel, RouteLabelRule } from '../../types/widget.js'
 import { getConfigItemSets, isItemAllowedForSets } from '../../utils/item.js'
 
+const isEvmAddress = (value: string): boolean =>
+  /^0x[a-fA-F0-9]{40}$/.test(value)
+
+// The LI.FI API returns EIP-55 checksummed (mixed-case) EVM addresses, while
+// integrator config commonly writes them lowercase (including this repo's
+// own default config), so EVM addresses must be compared case-insensitively.
+// Non-EVM chains (Solana base58, Sui coin types, etc.) use case-sensitive
+// identifiers and must be compared exactly.
+const matchesTokenAddress = (
+  configAddresses: string[],
+  routeAddress: string
+): boolean => {
+  if (isEvmAddress(routeAddress)) {
+    const lowerRouteAddress = routeAddress.toLowerCase()
+    return configAddresses.some(
+      (address) =>
+        isEvmAddress(address) && address.toLowerCase() === lowerRouteAddress
+    )
+  }
+  return configAddresses.includes(routeAddress)
+}
+
 export const getMatchingLabels = (
   route: Route,
   routeLabels?: RouteLabelRule[]
@@ -38,11 +60,15 @@ export const getMatchingLabels = (
 
       // Check token matches if specified
       if (rule.fromTokenAddress?.length) {
-        conditions.push(rule.fromTokenAddress.includes(route.fromToken.address))
+        conditions.push(
+          matchesTokenAddress(rule.fromTokenAddress, route.fromToken.address)
+        )
       }
 
       if (rule.toTokenAddress?.length) {
-        conditions.push(rule.toTokenAddress.includes(route.toToken.address))
+        conditions.push(
+          matchesTokenAddress(rule.toTokenAddress, route.toToken.address)
+        )
       }
 
       // Check chain matches if specified


### PR DESCRIPTION
## What it says on the box

`routeLabels`' `fromTokenAddress`/`toTokenAddress` rules never match unless the integrator writes their config address in the exact EIP-55 checksummed case the LI.FI API returns.

## The bug

`getMatchingLabels.ts` compared config addresses against `route.fromToken.address`/`route.toToken.address` via case-sensitive `Array.includes`:

```ts
conditions.push(rule.fromTokenAddress.includes(route.fromToken.address))
```

The LI.FI API always returns mixed-case (checksummed) EVM addresses. A live quote confirms this — `fromToken.address` / `toToken.address` come back checksummed on every response I checked. Config addresses are commonly written lowercase, and **this repo's own default example config does exactly that**:

```ts
// packages/widget-playground/src/defaultWidgetConfig.ts:143
address: '0x195e3087ea4d7eec6e9c37e9640162fe32433d5e',
```

So a rule using that config's own address would silently never match.

## Why it went unnoticed

Every other config-address-vs-API-address comparison in this package lowercases both sides first (`utils/token.ts`, `useTokenSearch.ts`, `useToken.ts`, `useTokenBalances.ts`, `utils/tokenList.ts`, `pinnedTokens`). This file was the one exception - and the only one with no test coverage. The sibling `fromChainId`/`toChainId` criteria in the same rule are numeric, so they're case-free and kept passing while the address criterion silently failed next to them.

Related prior art with the same root-cause class (address-casing mismatch), different location: #165.

## Fix

Compare EVM addresses (0x-prefixed, 40 hex chars) case-insensitively; fall back to exact string comparison for everything else. This widget supports Solana, Bitcoin, Sui, Tron and Stellar alongside EVM chains, and several of those use genuinely case-sensitive identifiers (Solana base58 addresses, Sui coin types) - blanket-lowercasing every token identifier would introduce a *new* false-positive-match bug on those chains. Codex's adversarial review caught exactly this on the first pass; the fix and the added non-EVM regression test both reflect it.

## Scope

`routeLabels` is opt-in integrator config. Labels are purely display/cosmetic - no effect on route ordering, selection, or amounts. **No fund impact.** Not reachable through the default widget configuration shipped to end users with no custom config.

## receipts

```
$ npx vitest run src/components/RouteCard/getMatchingLabels.test.ts
 Test Files  1 passed (1)
      Tests  5 passed (5)

$ npx vitest run   # full widget package suite
 Test Files  10 passed (10)
      Tests  89 passed (89)   # was 84, +5 new

$ npx tsc --noEmit -p tsconfig.json
(clean, 0 errors)

$ npx biome check src/components/RouteCard/getMatchingLabels.ts src/components/RouteCard/getMatchingLabels.test.ts
Checked 2 files. No fixes needed.
```

Red-before/green-after verified genuinely: the new non-EVM regression test fails against a naive blanket-`.toLowerCase()` fix (the exact gap Codex flagged) and passes only against the correctly EVM-scoped fix in this diff.

Codex (`gpt-5.6-sol`) ran adversarially against the diff and found one real P2 (the EVM-scoping gap above, applied) plus a test-wording nit (also applied). No other issues.
