### PR TITLE
fix(widget): resume the confirmation chain instead of executing from a sheet

### DIFF
--- a/.changeset/transaction-gate-chain.md
+++ b/.changeset/transaction-gate-chain.md
@@ -3,3 +3,5 @@
 ---
 
 Stop a confirmation sheet from skipping the sheets behind it. Continuing past the low-activity-address warning went straight to execution, so a route that was both going to a low-activity address and losing significant value never showed the high-value-loss warning. The same held on the retry path. Each sheet now resumes the chain at the gate after its own, and the order lives in one place instead of being re-decided by every sheet.
+
+This also makes `BottomSheet.close()` idempotent: closing an already-closed sheet no longer re-runs its `onClose`. Sheets that pass an `onCancel` therefore stop reporting a cancellation for a close they triggered themselves.

--- a/.changeset/transaction-gate-chain.md
+++ b/.changeset/transaction-gate-chain.md
@@ -1,0 +1,5 @@
+---
+"@lifi/widget": patch
+---
+
+Stop a confirmation sheet from skipping the sheets behind it. Continuing past the low-activity-address warning went straight to execution, so a route that was both going to a low-activity address and losing significant value never showed the high-value-loss warning. The same held on the retry path. Each sheet now resumes the chain at the gate after its own, and the order lives in one place instead of being re-decided by every sheet.

--- a/packages/widget/src/components/BottomSheet/BottomSheet.tsx
+++ b/packages/widget/src/components/BottomSheet/BottomSheet.tsx
@@ -27,6 +27,9 @@ export const BottomSheet = ({
   const [isInert, setIsInert] = useState(!open)
 
   const close = useCallback(() => {
+    if (!openRef.current) {
+      return
+    }
     // Set inert first to prevent focus issues
     setIsInert(true)
     // Push the state update to the next event loop tick

--- a/packages/widget/src/pages/TransactionPage/TokenValueBottomSheet.tsx
+++ b/packages/widget/src/pages/TransactionPage/TokenValueBottomSheet.tsx
@@ -36,8 +36,8 @@ export const TokenValueBottomSheet = ({
   ref?: Ref<BottomSheetBase>
 }): JSX.Element => {
   const handleCancel = () => {
+    // close() reaches onClose, which is onCancel
     ;(ref as RefObject<BottomSheetBase>).current?.close()
-    onCancel?.()
   }
 
   return (

--- a/packages/widget/src/pages/TransactionPage/TokenVerificationBottomSheet.tsx
+++ b/packages/widget/src/pages/TransactionPage/TokenVerificationBottomSheet.tsx
@@ -31,8 +31,8 @@ export const TokenVerificationBottomSheet = ({
   ref?: Ref<BottomSheetBase>
 }): JSX.Element => {
   const handleCancel = () => {
+    // close() reaches onClose, which is onCancel
     ;(ref as RefObject<BottomSheetBase>).current?.close()
-    onCancel?.()
   }
 
   return (

--- a/packages/widget/src/pages/TransactionPage/TransactionFailedButtons.tsx
+++ b/packages/widget/src/pages/TransactionPage/TransactionFailedButtons.tsx
@@ -10,7 +10,7 @@ import { getAccumulatedFeeCostsBreakdown } from '../../utils/fees.js'
 import { ConfirmToAddressSheet } from './ConfirmToAddressSheet.js'
 import { StartTransactionButton } from './StartTransactionButton.js'
 import { TokenValueBottomSheet } from './TokenValueBottomSheet.js'
-import { getTokenValueLossThreshold } from './utils.js'
+import { getTokenValueLossThreshold, nextGate } from './utils.js'
 
 interface TransactionFailedButtonsProps {
   route: RouteExtended
@@ -40,32 +40,55 @@ export const TransactionFailedButtons: React.FC<
     deleteRoute()
   }
 
-  const handleRetryClick = () => {
-    if (
-      toAddress &&
-      !hasActivity &&
-      !isLoadingAddressActivity &&
-      isActivityAddressFetched &&
-      !hiddenUI?.lowAddressActivityConfirmation
-    ) {
-      confirmToAddressSheetRef.current?.open()
-      return
-    }
+  type RetryGate = 'address' | 'value'
 
+  const retryGates: readonly (readonly [RetryGate, boolean])[] = (() => {
     const { gasCostUSD, feeCostUSD } = getAccumulatedFeeCostsBreakdown(route)
     const fromAmountUSD = Number.parseFloat(route.fromAmountUSD)
     const toAmountUSD = Number.parseFloat(route.toAmountUSD)
-    const tokenValueLossThresholdExceeded = getTokenValueLossThreshold(
-      fromAmountUSD,
-      toAmountUSD,
-      gasCostUSD,
-      feeCostUSD
-    )
-    if (tokenValueLossThresholdExceeded && mode !== 'custom') {
-      tokenValueBottomSheetRef.current?.open()
-    } else {
-      restartRoute()
+    return [
+      [
+        'address',
+        Boolean(
+          toAddress &&
+            !hasActivity &&
+            !isLoadingAddressActivity &&
+            isActivityAddressFetched &&
+            !hiddenUI?.lowAddressActivityConfirmation
+        ),
+      ],
+      [
+        'value',
+        getTokenValueLossThreshold(
+          fromAmountUSD,
+          toAmountUSD,
+          gasCostUSD,
+          feeCostUSD
+        ) && mode !== 'custom',
+      ],
+    ]
+  })()
+
+  // Opens the gate that follows the one the user cleared, so accepting a sheet
+  // never skips the sheets behind it.
+  const openNextGate = (after?: RetryGate) => {
+    switch (nextGate(retryGates, after)) {
+      case 'address':
+        confirmToAddressSheetRef.current?.open()
+        break
+      case 'value':
+        tokenValueBottomSheetRef.current?.open()
+        break
+      default:
+        restartRoute()
     }
+  }
+
+  const handleRetryClick = () => openNextGate()
+
+  const handleConfirmToAddressContinue = () => {
+    confirmToAddressSheetRef.current?.close()
+    openNextGate('address')
   }
 
   return (
@@ -95,7 +118,7 @@ export const TransactionFailedButtons: React.FC<
       {!hiddenUI?.lowAddressActivityConfirmation ? (
         <ConfirmToAddressSheet
           ref={confirmToAddressSheetRef}
-          onContinue={restartRoute}
+          onContinue={handleConfirmToAddressContinue}
           toAddress={toAddress!}
           toChainId={route.toChainId!}
         />

--- a/packages/widget/src/pages/TransactionPage/TransactionFailedButtons.tsx
+++ b/packages/widget/src/pages/TransactionPage/TransactionFailedButtons.tsx
@@ -5,12 +5,20 @@ import { useTranslation } from 'react-i18next'
 import type { BottomSheetBase } from '../../components/BottomSheet/types.js'
 import { useAddressActivity } from '../../hooks/useAddressActivity.js'
 import { useNavigateBack } from '../../hooks/useNavigateBack.js'
+import { useWidgetEvents } from '../../hooks/useWidgetEvents.js'
 import { useWidgetConfig } from '../../providers/WidgetProvider/WidgetProvider.js'
+import { WidgetEvent } from '../../types/events.js'
 import { getAccumulatedFeeCostsBreakdown } from '../../utils/fees.js'
 import { ConfirmToAddressSheet } from './ConfirmToAddressSheet.js'
 import { StartTransactionButton } from './StartTransactionButton.js'
 import { TokenValueBottomSheet } from './TokenValueBottomSheet.js'
-import { getTokenValueLossThreshold, nextGate } from './utils.js'
+import type { RetryGate } from './utils.js'
+import {
+  calculateValueLossPercentage,
+  getRetryGates,
+  getTokenValueLossThreshold,
+  openNextGate,
+} from './utils.js'
 
 interface TransactionFailedButtonsProps {
   route: RouteExtended
@@ -22,6 +30,7 @@ export const TransactionFailedButtons: React.FC<
   TransactionFailedButtonsProps
 > = ({ route, restartRoute, deleteRoute }) => {
   const { t } = useTranslation()
+  const emitter = useWidgetEvents()
   const navigateBack = useNavigateBack()
   const { mode, hiddenUI } = useWidgetConfig()
 
@@ -40,56 +49,60 @@ export const TransactionFailedButtons: React.FC<
     deleteRoute()
   }
 
-  type RetryGate = 'address' | 'value'
-
-  const retryGates: readonly (readonly [RetryGate, boolean])[] = (() => {
+  const retryGates = (() => {
     const { gasCostUSD, feeCostUSD } = getAccumulatedFeeCostsBreakdown(route)
-    const fromAmountUSD = Number.parseFloat(route.fromAmountUSD)
-    const toAmountUSD = Number.parseFloat(route.toAmountUSD)
-    return [
-      [
-        'address',
-        Boolean(
-          toAddress &&
-            !hasActivity &&
-            !isLoadingAddressActivity &&
-            isActivityAddressFetched &&
-            !hiddenUI?.lowAddressActivityConfirmation
-        ),
-      ],
-      [
-        'value',
-        getTokenValueLossThreshold(
+    return getRetryGates({
+      toAddress,
+      hasActivity,
+      isLoadingAddressActivity,
+      isActivityAddressFetched,
+      confirmationHidden: Boolean(hiddenUI?.lowAddressActivityConfirmation),
+      valueLossExceeded: getTokenValueLossThreshold(
+        Number.parseFloat(route.fromAmountUSD),
+        Number.parseFloat(route.toAmountUSD),
+        gasCostUSD,
+        feeCostUSD
+      ),
+      isCustomMode: mode === 'custom',
+    })
+  })()
+
+  const openGate = (after?: RetryGate) =>
+    openNextGate(
+      retryGates,
+      {
+        address: () => confirmToAddressSheetRef.current?.open(),
+        value: () => tokenValueBottomSheetRef.current?.open(),
+      },
+      handleRestartRoute,
+      after
+    )
+
+  const handleRestartRoute = () => {
+    if (tokenValueBottomSheetRef.current?.isOpen()) {
+      const { gasCostUSD, feeCostUSD } = getAccumulatedFeeCostsBreakdown(route)
+      const fromAmountUSD = Number.parseFloat(route.fromAmountUSD)
+      const toAmountUSD = Number.parseFloat(route.toAmountUSD)
+      emitter.emit(WidgetEvent.RouteHighValueLoss, {
+        fromAmountUSD,
+        toAmountUSD,
+        gasCostUSD,
+        feeCostUSD,
+        valueLoss: calculateValueLossPercentage(
           fromAmountUSD,
           toAmountUSD,
           gasCostUSD,
           feeCostUSD
-        ) && mode !== 'custom',
-      ],
-    ]
-  })()
-
-  // Opens the gate that follows the one the user cleared, so accepting a sheet
-  // never skips the sheets behind it.
-  const openNextGate = (after?: RetryGate) => {
-    switch (nextGate(retryGates, after)) {
-      case 'address':
-        confirmToAddressSheetRef.current?.open()
-        break
-      case 'value':
-        tokenValueBottomSheetRef.current?.open()
-        break
-      default:
-        restartRoute()
+        ),
+      })
     }
+    tokenValueBottomSheetRef.current?.close()
+    restartRoute()
   }
 
-  const handleRetryClick = () => openNextGate()
+  const handleRetryClick = () => openGate()
 
-  const handleConfirmToAddressContinue = () => {
-    confirmToAddressSheetRef.current?.close()
-    openNextGate('address')
-  }
+  const handleConfirmToAddressContinue = () => openGate('address')
 
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
@@ -112,7 +125,7 @@ export const TransactionFailedButtons: React.FC<
         <TokenValueBottomSheet
           route={route}
           ref={tokenValueBottomSheetRef}
-          onContinue={restartRoute}
+          onContinue={handleRestartRoute}
         />
       ) : null}
       {!hiddenUI?.lowAddressActivityConfirmation ? (

--- a/packages/widget/src/pages/TransactionPage/TransactionReview.tsx
+++ b/packages/widget/src/pages/TransactionPage/TransactionReview.tsx
@@ -20,10 +20,12 @@ import { ConfirmToAddressSheet } from './ConfirmToAddressSheet.js'
 import { StartTransactionButton } from './StartTransactionButton.js'
 import { TokenValueBottomSheet } from './TokenValueBottomSheet.js'
 import { TokenVerificationBottomSheet } from './TokenVerificationBottomSheet.js'
+import type { StartGate } from './utils.js'
 import {
   calculateValueLossPercentage,
+  getStartGates,
   getTokenValueLossThreshold,
-  nextGate,
+  openNextGate,
 } from './utils.js'
 
 interface TransactionReviewProps {
@@ -87,65 +89,45 @@ export const TransactionReview: React.FC<TransactionReviewProps> = ({
     })
   }
 
-  type StartGate = 'flagged' | 'address' | 'value'
-
-  const startGates: readonly (readonly [StartGate, boolean])[] = (() => {
+  const startGates = (() => {
     const { gasCostUSD, feeCostUSD } = getAccumulatedFeeCostsBreakdown(route)
-    const fromAmountUSD = Number.parseFloat(route.fromAmountUSD)
-    const toAmountUSD = Number.parseFloat(route.toAmountUSD)
-    return [
-      ['flagged', flaggedTokens.length > 0],
-      [
-        'address',
-        Boolean(
-          toAddress &&
-            !hasActivity &&
-            !isLoadingAddressActivity &&
-            isActivityAddressFetched &&
-            !hiddenUI?.lowAddressActivityConfirmation
-        ),
-      ],
-      [
-        'value',
-        getTokenValueLossThreshold(
-          fromAmountUSD,
-          toAmountUSD,
-          gasCostUSD,
-          feeCostUSD
-        ) && mode !== 'custom',
-      ],
-    ]
+    return getStartGates({
+      flaggedTokenCount: flaggedTokens.length,
+      toAddress,
+      hasActivity,
+      isLoadingAddressActivity,
+      isActivityAddressFetched,
+      confirmationHidden: Boolean(hiddenUI?.lowAddressActivityConfirmation),
+      valueLossExceeded: getTokenValueLossThreshold(
+        Number.parseFloat(route.fromAmountUSD),
+        Number.parseFloat(route.toAmountUSD),
+        gasCostUSD,
+        feeCostUSD
+      ),
+      isCustomMode: mode === 'custom',
+    })
   })()
 
-  // Opens the gate that follows the one the user cleared, so accepting a sheet
-  // never skips the sheets behind it.
-  const openNextGate = (after?: StartGate) => {
-    switch (nextGate(startGates, after)) {
-      case 'flagged':
-        flaggedTokenSheetRef.current?.open()
-        break
-      case 'address':
-        confirmToAddressSheetRef.current?.open()
-        break
-      case 'value':
-        tokenValueBottomSheetRef.current?.open()
-        break
-      default:
-        handleExecuteRoute()
-    }
-  }
+  const openGate = (after?: StartGate) =>
+    openNextGate(
+      startGates,
+      {
+        flagged: () => flaggedTokenSheetRef.current?.open(),
+        address: () => confirmToAddressSheetRef.current?.open(),
+        value: () => tokenValueBottomSheetRef.current?.open(),
+      },
+      handleExecuteRoute,
+      after
+    )
 
-  const handleStartClick = () => openNextGate()
+  const handleStartClick = () => openGate()
 
   const handleFlaggedTokensContinue = () => {
     flaggedTokenSheetRef.current?.close()
-    openNextGate('flagged')
+    openGate('flagged')
   }
 
-  const handleConfirmToAddressContinue = () => {
-    confirmToAddressSheetRef.current?.close()
-    openNextGate('address')
-  }
+  const handleConfirmToAddressContinue = () => openGate('address')
 
   const getButtonText = (): string => {
     switch (mode) {

--- a/packages/widget/src/pages/TransactionPage/TransactionReview.tsx
+++ b/packages/widget/src/pages/TransactionPage/TransactionReview.tsx
@@ -23,6 +23,7 @@ import { TokenVerificationBottomSheet } from './TokenVerificationBottomSheet.js'
 import {
   calculateValueLossPercentage,
   getTokenValueLossThreshold,
+  nextGate,
 } from './utils.js'
 
 interface TransactionReviewProps {
@@ -86,47 +87,64 @@ export const TransactionReview: React.FC<TransactionReviewProps> = ({
     })
   }
 
-  // Runs the remaining gates. The flagged-token sheet continues into this
-  // rather than executing, so accepting it does not skip the others.
-  const handleStartAfterTokenCheck = () => {
-    if (
-      toAddress &&
-      !hasActivity &&
-      !isLoadingAddressActivity &&
-      isActivityAddressFetched &&
-      !hiddenUI?.lowAddressActivityConfirmation
-    ) {
-      confirmToAddressSheetRef.current?.open()
-      return
-    }
+  type StartGate = 'flagged' | 'address' | 'value'
 
+  const startGates: readonly (readonly [StartGate, boolean])[] = (() => {
     const { gasCostUSD, feeCostUSD } = getAccumulatedFeeCostsBreakdown(route)
     const fromAmountUSD = Number.parseFloat(route.fromAmountUSD)
     const toAmountUSD = Number.parseFloat(route.toAmountUSD)
-    const tokenValueLossThresholdExceeded = getTokenValueLossThreshold(
-      fromAmountUSD,
-      toAmountUSD,
-      gasCostUSD,
-      feeCostUSD
-    )
-    if (tokenValueLossThresholdExceeded && mode !== 'custom') {
-      tokenValueBottomSheetRef.current?.open()
-    } else {
-      handleExecuteRoute()
+    return [
+      ['flagged', flaggedTokens.length > 0],
+      [
+        'address',
+        Boolean(
+          toAddress &&
+            !hasActivity &&
+            !isLoadingAddressActivity &&
+            isActivityAddressFetched &&
+            !hiddenUI?.lowAddressActivityConfirmation
+        ),
+      ],
+      [
+        'value',
+        getTokenValueLossThreshold(
+          fromAmountUSD,
+          toAmountUSD,
+          gasCostUSD,
+          feeCostUSD
+        ) && mode !== 'custom',
+      ],
+    ]
+  })()
+
+  // Opens the gate that follows the one the user cleared, so accepting a sheet
+  // never skips the sheets behind it.
+  const openNextGate = (after?: StartGate) => {
+    switch (nextGate(startGates, after)) {
+      case 'flagged':
+        flaggedTokenSheetRef.current?.open()
+        break
+      case 'address':
+        confirmToAddressSheetRef.current?.open()
+        break
+      case 'value':
+        tokenValueBottomSheetRef.current?.open()
+        break
+      default:
+        handleExecuteRoute()
     }
   }
 
-  const handleStartClick = () => {
-    if (flaggedTokens.length) {
-      flaggedTokenSheetRef.current?.open()
-      return
-    }
-    handleStartAfterTokenCheck()
-  }
+  const handleStartClick = () => openNextGate()
 
   const handleFlaggedTokensContinue = () => {
     flaggedTokenSheetRef.current?.close()
-    handleStartAfterTokenCheck()
+    openNextGate('flagged')
+  }
+
+  const handleConfirmToAddressContinue = () => {
+    confirmToAddressSheetRef.current?.close()
+    openNextGate('address')
   }
 
   const getButtonText = (): string => {
@@ -180,7 +198,7 @@ export const TransactionReview: React.FC<TransactionReviewProps> = ({
       {!hiddenUI?.lowAddressActivityConfirmation ? (
         <ConfirmToAddressSheet
           ref={confirmToAddressSheetRef}
-          onContinue={handleExecuteRoute}
+          onContinue={handleConfirmToAddressContinue}
           toAddress={toAddress!}
           toChainId={route.toChainId!}
         />

--- a/packages/widget/src/pages/TransactionPage/TransactionReview.tsx
+++ b/packages/widget/src/pages/TransactionPage/TransactionReview.tsx
@@ -77,7 +77,6 @@ export const TransactionReview: React.FC<TransactionReviewProps> = ({
       })
     }
     tokenValueBottomSheetRef.current?.close()
-    flaggedTokenSheetRef.current?.close()
     executeRoute()
     setFieldValue('fromAmount', '')
     if (mode === 'custom') {

--- a/packages/widget/src/pages/TransactionPage/utils.test.ts
+++ b/packages/widget/src/pages/TransactionPage/utils.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import { nextGate } from './utils.js'
+
+type Gate = 'address' | 'tokens' | 'value'
+
+const gates = (
+  address: boolean,
+  tokens: boolean,
+  value: boolean
+): readonly (readonly [Gate, boolean])[] => [
+  ['address', address],
+  ['tokens', tokens],
+  ['value', value],
+]
+
+describe('nextGate', () => {
+  it('should return the first gate that is needed', () => {
+    expect(nextGate(gates(true, true, true))).toBe('address')
+  })
+
+  it('should skip gates that are not needed', () => {
+    expect(nextGate(gates(false, false, true))).toBe('value')
+  })
+
+  it('should return undefined when no gate is needed', () => {
+    expect(nextGate(gates(false, false, false))).toBeUndefined()
+  })
+
+  it('should resume after the gate the user cleared', () => {
+    expect(nextGate(gates(true, true, true), 'address')).toBe('tokens')
+  })
+
+  it('should skip cleared gates that are still needed', () => {
+    expect(nextGate(gates(true, false, true), 'address')).toBe('value')
+  })
+
+  it('should return undefined after the last needed gate', () => {
+    expect(nextGate(gates(true, true, true), 'value')).toBeUndefined()
+  })
+
+  it('should return undefined when nothing follows the cleared gate', () => {
+    expect(nextGate(gates(true, false, false), 'address')).toBeUndefined()
+  })
+})

--- a/packages/widget/src/pages/TransactionPage/utils.test.ts
+++ b/packages/widget/src/pages/TransactionPage/utils.test.ts
@@ -1,44 +1,142 @@
-import { describe, expect, it } from 'vitest'
-import { nextGate } from './utils.js'
+import { describe, expect, it, vi } from 'vitest'
+import {
+  getRetryGates,
+  getStartGates,
+  nextGate,
+  openNextGate,
+} from './utils.js'
 
-type Gate = 'address' | 'tokens' | 'value'
-
-const gates = (
-  address: boolean,
-  tokens: boolean,
-  value: boolean
-): readonly (readonly [Gate, boolean])[] => [
-  ['address', address],
-  ['tokens', tokens],
-  ['value', value],
-]
+const addressClear = {
+  toAddress: '0xabc',
+  hasActivity: true,
+  isLoadingAddressActivity: false,
+  isActivityAddressFetched: true,
+  confirmationHidden: false,
+}
+const addressNeeded = { ...addressClear, hasActivity: false }
 
 describe('nextGate', () => {
+  const gates = [
+    ['a', true],
+    ['b', false],
+    ['c', true],
+  ] as const
+
   it('should return the first gate that is needed', () => {
-    expect(nextGate(gates(true, true, true))).toBe('address')
+    expect(nextGate(gates)).toBe('a')
   })
 
   it('should skip gates that are not needed', () => {
-    expect(nextGate(gates(false, false, true))).toBe('value')
-  })
-
-  it('should return undefined when no gate is needed', () => {
-    expect(nextGate(gates(false, false, false))).toBeUndefined()
-  })
-
-  it('should resume after the gate the user cleared', () => {
-    expect(nextGate(gates(true, true, true), 'address')).toBe('tokens')
-  })
-
-  it('should skip cleared gates that are still needed', () => {
-    expect(nextGate(gates(true, false, true), 'address')).toBe('value')
+    expect(nextGate(gates, 'a')).toBe('c')
   })
 
   it('should return undefined after the last needed gate', () => {
-    expect(nextGate(gates(true, true, true), 'value')).toBeUndefined()
+    expect(nextGate(gates, 'c')).toBeUndefined()
   })
 
-  it('should return undefined when nothing follows the cleared gate', () => {
-    expect(nextGate(gates(true, false, false), 'address')).toBeUndefined()
+  it('should return undefined when no gate is needed', () => {
+    expect(nextGate([['a', false]] as const)).toBeUndefined()
+  })
+
+  it('should return undefined for a gate that is not in the list', () => {
+    expect(nextGate(gates, 'z' as 'a')).toBeUndefined()
+  })
+})
+
+describe('openNextGate', () => {
+  it('should open the next needed gate and not finish', () => {
+    const open = { a: vi.fn(), b: vi.fn() }
+    const done = vi.fn()
+    openNextGate(
+      [
+        ['a', true],
+        ['b', true],
+      ] as const,
+      open,
+      done
+    )
+    expect(open.a).toHaveBeenCalledOnce()
+    expect(open.b).not.toHaveBeenCalled()
+    expect(done).not.toHaveBeenCalled()
+  })
+
+  it('should finish when no gate is left', () => {
+    const open = { a: vi.fn() }
+    const done = vi.fn()
+    openNextGate([['a', false]] as const, open, done)
+    expect(open.a).not.toHaveBeenCalled()
+    expect(done).toHaveBeenCalledOnce()
+  })
+})
+
+describe('getRetryGates', () => {
+  const base = {
+    ...addressClear,
+    valueLossExceeded: false,
+    isCustomMode: false,
+  }
+
+  it('should order the address gate before the value gate', () => {
+    expect(getRetryGates(base).map(([gate]) => gate)).toEqual([
+      'address',
+      'value',
+    ])
+  })
+
+  it('should need the address gate only for an unused address', () => {
+    expect(getRetryGates(base)[0][1]).toBe(false)
+    expect(getRetryGates({ ...base, ...addressNeeded })[0][1]).toBe(true)
+  })
+
+  it('should not need the address gate while activity is still loading', () => {
+    const loading = {
+      ...base,
+      ...addressNeeded,
+      isLoadingAddressActivity: true,
+    }
+    expect(getRetryGates(loading)[0][1]).toBe(false)
+  })
+
+  it('should not need the address gate when the confirmation is hidden', () => {
+    const hidden = { ...base, ...addressNeeded, confirmationHidden: true }
+    expect(getRetryGates(hidden)[0][1]).toBe(false)
+  })
+
+  it('should not need the value gate in custom mode', () => {
+    const custom = { ...base, valueLossExceeded: true, isCustomMode: true }
+    expect(getRetryGates(custom)[1][1]).toBe(false)
+    expect(getRetryGates({ ...base, valueLossExceeded: true })[1][1]).toBe(true)
+  })
+})
+
+describe('getStartGates', () => {
+  const base = {
+    ...addressClear,
+    flaggedTokenCount: 0,
+    valueLossExceeded: false,
+    isCustomMode: false,
+  }
+
+  it('should warn about a flagged token before anything else', () => {
+    expect(getStartGates(base).map(([gate]) => gate)).toEqual([
+      'flagged',
+      'address',
+      'value',
+    ])
+  })
+
+  it('should need the flagged gate for any flagged token', () => {
+    expect(getStartGates(base)[0][1]).toBe(false)
+    expect(getStartGates({ ...base, flaggedTokenCount: 1 })[0][1]).toBe(true)
+  })
+
+  it('should still warn about a flagged token in custom mode', () => {
+    const custom = { ...base, flaggedTokenCount: 1, isCustomMode: true }
+    expect(getStartGates(custom)[0][1]).toBe(true)
+  })
+
+  it('should not need the value gate in custom mode', () => {
+    const custom = { ...base, valueLossExceeded: true, isCustomMode: true }
+    expect(getStartGates(custom)[2][1]).toBe(false)
   })
 })

--- a/packages/widget/src/pages/TransactionPage/utils.ts
+++ b/packages/widget/src/pages/TransactionPage/utils.ts
@@ -23,3 +23,17 @@ export const getTokenValueLossThreshold = (
   }
   return toAmountUSD / (fromAmountUSD + gasCostUSD + feeCostUSD) < 0.9
 }
+
+/**
+ * The next gate to open before a transaction starts, given the gates in order
+ * and the one the user just cleared. Returns undefined when none is left, so
+ * the caller executes. Keeping the order in one place stops each sheet from
+ * deciding what follows it, which is how gates came to be skipped.
+ */
+export const nextGate = <T extends string>(
+  gates: readonly (readonly [gate: T, needed: boolean])[],
+  after?: T
+): T | undefined => {
+  const start = after ? gates.findIndex(([gate]) => gate === after) + 1 : 0
+  return gates.slice(start).find(([, needed]) => needed)?.[0]
+}

--- a/packages/widget/src/pages/TransactionPage/utils.ts
+++ b/packages/widget/src/pages/TransactionPage/utils.ts
@@ -24,16 +24,80 @@ export const getTokenValueLossThreshold = (
   return toAmountUSD / (fromAmountUSD + gasCostUSD + feeCostUSD) < 0.9
 }
 
-/**
- * The next gate to open before a transaction starts, given the gates in order
- * and the one the user just cleared. Returns undefined when none is left, so
- * the caller executes. Keeping the order in one place stops each sheet from
- * deciding what follows it, which is how gates came to be skipped.
- */
+interface AddressGateInput {
+  toAddress?: string
+  hasActivity?: boolean
+  isLoadingAddressActivity: boolean
+  isActivityAddressFetched: boolean
+  confirmationHidden: boolean
+}
+
+const needsAddressConfirmation = ({
+  toAddress,
+  hasActivity,
+  isLoadingAddressActivity,
+  isActivityAddressFetched,
+  confirmationHidden,
+}: AddressGateInput): boolean =>
+  Boolean(
+    toAddress &&
+      !hasActivity &&
+      !isLoadingAddressActivity &&
+      isActivityAddressFetched &&
+      !confirmationHidden
+  )
+
+export type RetryGate = 'address' | 'value'
+
+export const getRetryGates = (
+  input: AddressGateInput & {
+    valueLossExceeded: boolean
+    isCustomMode: boolean
+  }
+): readonly (readonly [gate: RetryGate, needed: boolean])[] => [
+  ['address', needsAddressConfirmation(input)],
+  ['value', input.valueLossExceeded && !input.isCustomMode],
+]
+
+/** Ordering lives here so no sheet decides what follows it — that is how gates came to be skipped. */
 export const nextGate = <T extends string>(
   gates: readonly (readonly [gate: T, needed: boolean])[],
   after?: T
 ): T | undefined => {
-  const start = after ? gates.findIndex(([gate]) => gate === after) + 1 : 0
-  return gates.slice(start).find(([, needed]) => needed)?.[0]
+  if (!after) {
+    return gates.find(([, needed]) => needed)?.[0]
+  }
+  const index = gates.findIndex(([gate]) => gate === after)
+  if (index < 0) {
+    return undefined
+  }
+  return gates.slice(index + 1).find(([, needed]) => needed)?.[0]
 }
+
+export const openNextGate = <T extends string>(
+  gates: readonly (readonly [gate: T, needed: boolean])[],
+  open: Record<T, () => void>,
+  done: () => void,
+  after?: T
+): void => {
+  const gate = nextGate(gates, after)
+  if (gate) {
+    open[gate]()
+    return
+  }
+  done()
+}
+
+export type StartGate = 'flagged' | 'address' | 'value'
+
+export const getStartGates = (
+  input: AddressGateInput & {
+    flaggedTokenCount: number
+    valueLossExceeded: boolean
+    isCustomMode: boolean
+  }
+): readonly (readonly [gate: StartGate, needed: boolean])[] => [
+  ['flagged', input.flaggedTokenCount > 0],
+  ['address', needsAddressConfirmation(input)],
+  ['value', input.valueLossExceeded && !input.isCustomMode],
+]

--- a/packages/widget/src/pages/TransactionPage/utils.ts
+++ b/packages/widget/src/pages/TransactionPage/utils.ts
@@ -25,8 +25,8 @@ export const getTokenValueLossThreshold = (
 }
 
 interface AddressGateInput {
-  toAddress?: string
-  hasActivity?: boolean
+  toAddress: string | undefined
+  hasActivity: boolean | undefined
   isLoadingAddressActivity: boolean
   isActivityAddressFetched: boolean
   confirmationHidden: boolean


### PR DESCRIPTION
Each confirmation sheet decided for itself what came next, and all of them chose execution. Continuing past the low-activity-address warning therefore skipped the high-value-loss warning, on both the start and the retry path — a route going to an unused address that also lost significant value showed one warning and swallowed the other. The retry path's value sheet also never closed or emitted `RouteHighValueLoss`.

`nextGate` now holds the order, `getStartGates` / `getRetryGates` are pure and tested, and each sheet asks for the gate after its own. `BottomSheet.close()` became idempotent, so closing an already-closed sheet no longer re-runs its `onClose`.

Order is unchanged: flagged → address → value.

The flagged-token sheet already resumed the chain correctly — it arrived with #859. This fixes the sibling sheets that did not, and removes the shape that produced the bug.

https://linear.app/lifi-linear/issue/JUMEMB-82/flagged-token-sheet-continue-skips-the-high-value-loss-check-jumper
https://linear.app/lifi-linear/issue/JUMEMB-65/widget-confirming-the-token-verification-modal-skips-the-high-value