### PR TITLE
fix(widget): allow a Stellar receiver that equals the signing account

### DIFF
--- a/.changeset/stellar-receiver-equals-signer.md
+++ b/.changeset/stellar-receiver-equals-signer.md
@@ -1,0 +1,6 @@
+---
+"@lifi/widget": patch
+---
+
+Load Stellar-to-Stellar routes when the receiver is your own connected Stellar account — the widget
+fills that receiver in for you, and it no longer counts as a recipient Stellar cannot honour.

--- a/packages/widget/src/hooks/useRoutes.ts
+++ b/packages/widget/src/hooks/useRoutes.ts
@@ -29,7 +29,7 @@ import { defaultSlippage } from '../stores/settings/createSettingsStore.js'
 import { useSettings } from '../stores/settings/useSettings.js'
 import { WidgetEvent } from '../types/events.js'
 import type { TokensByChain } from '../types/token.js'
-import { isCustomReceiverUnsupported } from '../utils/customReceiver.js'
+import { isCustomReceiverBlocked } from '../utils/customReceiver.js'
 import { getQueryKey } from '../utils/queries.js'
 import { updateTokenInCache } from '../utils/token.js'
 import { useChain } from './useChain.js'
@@ -178,10 +178,13 @@ export const useRoutes = ({
     ? hasToAddressAndChainTypeSatisfied
     : true
 
-  // Stellar settles to the signer, so a set receiver makes the route unfulfillable.
-  const customReceiverBlocked =
-    isCustomReceiverUnsupported(fromChain?.chainType, toChain?.chainType) &&
-    Boolean(toAddress)
+  // Not `effectiveFromAddress`: a quote placeholder must never match a receiver.
+  const customReceiverBlocked = isCustomReceiverBlocked({
+    fromChainType: fromChain?.chainType,
+    toChainType: toChain?.chainType,
+    toAddress,
+    signerAddress: account.address,
+  })
 
   // toAddress might be an empty string, but we need to pass undefined if there is no value
   const toWalletAddress = toAddress || undefined

--- a/packages/widget/src/hooks/useToAddressRequirements.ts
+++ b/packages/widget/src/hooks/useToAddressRequirements.ts
@@ -4,7 +4,10 @@ import { useEthereumContext } from '@lifi/widget-provider'
 import { useChain } from '../hooks/useChain.js'
 import { useWidgetConfig } from '../providers/WidgetProvider/WidgetProvider.js'
 import { useFieldValues } from '../stores/form/useFieldValues.js'
-import { isCustomReceiverUnsupported } from '../utils/customReceiver.js'
+import {
+  isCustomReceiverBlocked,
+  isCustomReceiverUnsupported,
+} from '../utils/customReceiver.js'
 import { useIsContractAddress } from './useIsContractAddress.js'
 
 export const useToAddressRequirements = (
@@ -76,10 +79,13 @@ export const useToAddressRequirements = (
     toChain?.chainType
   )
 
-  // Stellar routes settle to the signer, so a required receiver is never honoured.
-  const unsupportedReceiverBlocking = Boolean(
-    unsupportedToAddress && (toAddress || requiredUI?.toAddress)
-  )
+  const unsupportedReceiverBlocking = isCustomReceiverBlocked({
+    fromChainType: fromChain?.chainType,
+    toChainType: toChain?.chainType,
+    toAddress,
+    signerAddress: fromAddress,
+    receiverRequired: requiredUI?.toAddress,
+  })
 
   const requiredToAddress = Boolean(
     (isDifferentChainType ||

--- a/packages/widget/src/utils/customReceiver.test.ts
+++ b/packages/widget/src/utils/customReceiver.test.ts
@@ -1,6 +1,9 @@
 import { ChainType } from '@lifi/sdk'
 import { describe, expect, it } from 'vitest'
-import { isCustomReceiverUnsupported } from './customReceiver.js'
+import {
+  isCustomReceiverBlocked,
+  isCustomReceiverUnsupported,
+} from './customReceiver.js'
 
 describe('isCustomReceiverUnsupported', () => {
   it('is true only when both sides are Stellar', () => {
@@ -29,5 +32,104 @@ describe('isCustomReceiverUnsupported', () => {
     expect(isCustomReceiverUnsupported(undefined, ChainType.STL)).toBe(false)
     expect(isCustomReceiverUnsupported(ChainType.STL, undefined)).toBe(false)
     expect(isCustomReceiverUnsupported(undefined, undefined)).toBe(false)
+  })
+})
+
+describe('isCustomReceiverBlocked', () => {
+  const signer = 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN'
+  const other = 'GBUQWP3BOUZX34TOND2QV7QQ7K7VJTG6VSE7WMLBTMDJLLAW7YKGU6EP'
+  const stellarRoute = {
+    fromChainType: ChainType.STL,
+    toChainType: ChainType.STL,
+  }
+
+  it('allows a receiver that equals the connected Stellar account', () => {
+    expect(
+      isCustomReceiverBlocked({
+        ...stellarRoute,
+        toAddress: signer,
+        signerAddress: signer,
+      })
+    ).toBe(false)
+  })
+
+  it('blocks a receiver that differs from the connected Stellar account', () => {
+    expect(
+      isCustomReceiverBlocked({
+        ...stellarRoute,
+        toAddress: other,
+        signerAddress: signer,
+      })
+    ).toBe(true)
+  })
+
+  it('blocks a receiver while no Stellar account is connected', () => {
+    expect(
+      isCustomReceiverBlocked({
+        ...stellarRoute,
+        toAddress: signer,
+        signerAddress: undefined,
+      })
+    ).toBe(true)
+  })
+
+  it('allows a Stellar route with no receiver', () => {
+    expect(
+      isCustomReceiverBlocked({ ...stellarRoute, signerAddress: signer })
+    ).toBe(false)
+  })
+
+  it('blocks an integrator receiver requirement that cannot be filled', () => {
+    expect(
+      isCustomReceiverBlocked({
+        ...stellarRoute,
+        signerAddress: signer,
+        receiverRequired: true,
+      })
+    ).toBe(true)
+  })
+
+  it('allows a required receiver that equals the connected Stellar account', () => {
+    expect(
+      isCustomReceiverBlocked({
+        ...stellarRoute,
+        toAddress: signer,
+        signerAddress: signer,
+        receiverRequired: true,
+      })
+    ).toBe(false)
+  })
+
+  it('allows a different receiver on a route that bridges out of Stellar', () => {
+    expect(
+      isCustomReceiverBlocked({
+        fromChainType: ChainType.STL,
+        toChainType: ChainType.EVM,
+        toAddress: '0x000000000000000000000000000000000000dEaD',
+        signerAddress: signer,
+      })
+    ).toBe(false)
+  })
+
+  it('allows a different receiver on a non-Stellar route', () => {
+    expect(
+      isCustomReceiverBlocked({
+        fromChainType: ChainType.SVM,
+        toChainType: ChainType.SVM,
+        toAddress: other,
+        signerAddress: signer,
+        receiverRequired: true,
+      })
+    ).toBe(false)
+  })
+
+  it('compares the receiver and the signer case-insensitively', () => {
+    expect(
+      isCustomReceiverBlocked({
+        ...stellarRoute,
+        toAddress: signer.toLowerCase(),
+        signerAddress: signer,
+      })
+    ).toBe(false)
   })
 })

--- a/packages/widget/src/utils/customReceiver.ts
+++ b/packages/widget/src/utils/customReceiver.ts
@@ -5,3 +5,27 @@ export const isCustomReceiverUnsupported = (
   fromChainType?: ChainType,
   toChainType?: ChainType
 ): boolean => fromChainType === ChainType.STL && toChainType === ChainType.STL
+
+export interface CustomReceiverBlockedArgs {
+  fromChainType?: ChainType
+  toChainType?: ChainType
+  toAddress?: string
+  signerAddress?: string
+  receiverRequired?: boolean
+}
+
+export const isCustomReceiverBlocked = ({
+  fromChainType,
+  toChainType,
+  toAddress,
+  signerAddress,
+  receiverRequired,
+}: CustomReceiverBlockedArgs): boolean => {
+  if (!isCustomReceiverUnsupported(fromChainType, toChainType)) {
+    return false
+  }
+  if (!toAddress) {
+    return Boolean(receiverRequired)
+  }
+  return toAddress.toLowerCase() !== signerAddress?.toLowerCase()
+}


### PR DESCRIPTION
## Which Linear task is linked to this PR?

[JUMEMB-75](https://linear.app/lifi-linear/issue/JUMEMB-75/stellar-custom-receiver-block-fires-when-the-receiver-is-the)

## Why was it implemented this way?

**The bug.** The widget auto-fills `toAddress` with the connected account when a route crosses ecosystems (`useToAddressAutoPopulate`). Switching the send token to a Stellar token then makes both sides Stellar and leaves that receiver behind in the form and the URL, where both receiver gates flagged it as a custom recipient: no `/advanced/routes` request went out and the receive amount stayed at zero. The widget was blocking on a receiver it had filled in itself.

Repro: connect Freighter → route Solana USDC → XLM on Stellar with the connected Freighter account as receiver → change the send token to a token on Stellar (XLM → PYUSD). The widget showed "Stellar transfers always settle to the account that signs them, so a different recipient can't be used for this route", with Receive stuck at 0.

**The approach.** `isCustomReceiverBlocked` keeps the existing both-sides-Stellar predicate and adds the signer comparison on top. Both gates call it — `useRoutes.ts` with the form receiver and `account.address`, `useToAddressRequirements.ts` with the derived receiver, `fromAddress` and `requiredUI?.toAddress`.

| Receiver | Wallet | `requiredUI.toAddress` | Blocked |
|---|---|---|---|
| empty | any | no | no |
| empty | any | yes | yes — unsatisfiable requirement |
| equals signer | connected | any | **no — the fix** |
| differs from signer | connected | any | yes |
| set | disconnected | any | yes |

**Alternatives considered.**

- *Widen `isCustomReceiverUnsupported` instead of adding a predicate.* Rejected. That function drives `unsupportedToAddress`, which correctly hides the Send-to-wallet affordance on a Stellar-internal route. "The field does not apply here" and "this receiver cannot be honoured" are two concepts, and `useToAddressRequirements` has no test file — a separate pure predicate is the only testable seam.
- *Clear the carried-over `toAddress` in `useToAddressAutoPopulate`.* Rejected. It would fight the URL sync, and silently dropping a receiver the user genuinely typed would send funds to the signer instead.
- *Strip `toAddress` from the request when it equals the signer.* Rejected as unnecessary — see below.
- *Unify the two call sites on one derived receiver.* Rejected. They legitimately read different values, so the predicate takes the receiver as an argument.

**Why the receiver is still forwarded.** On a Stellar XLM → USDC same-chain swap, `/advanced/routes` returns the same single route whether `toAddress` is absent or equal to `fromAddress` (echoing it back), and zero routes for a different Stellar account. Passing the signer's own address is a no-op server-side, so no stripping is needed, and a different receiver genuinely returns nothing.

**Why the predicate still requires both sides Stellar.** A route that bridges out of Stellar does honour a different destination — `/advanced/routes` quotes Stellar → Arbitrum with a foreign receiver. Only a Stellar-internal route refuses one. Solana same-chain with a different receiver quotes fine, so no other ecosystem needs this gate.

I compare against `account.address`, never `effectiveFromAddress` — a quote placeholder must never count as a match.

## Visual showcase (Screenshots or Videos)

Repro video is attached to JUMEMB-75.

## Checklist before requesting a review

- [x] I have performed a self-review and testing of my code.
- [x] This pull request is focused and addresses a single problem.
- [x] If this PR modifies the Widget API or adds new features that require documentation, I have updated the documentation in the [public-docs](https://github.com/lifinance/public-docs) repository. — n/a, no API change.

**Verification.** 9 new unit tests on the predicate, written first; all 9 failed before the implementation, then passed. Widget suite 10 files / 115 tests, 0 failures. `pnpm check:types` clean across all packages, Biome clean (2 pre-existing warnings in `examples/dynamic/vite.config.ts`), `knip:check` clean. The two call sites are wiring, traced by hand — neither hook has a test file. **The end-to-end repro is not verified yet**; it needs a preview build and a connected Freighter wallet.

The same fix goes to `jumperexchange/jumper-widget` in [PR #108](https://github.com/jumperexchange/jumper-widget/pull/108). That fork has a `sameAddress` helper, so its predicate calls it instead of comparing inline — the only difference between the two.
