### PR TITLE
fix(widget): keep the route's price in Token's logo fallback

### DIFF
--- a/.changeset/route-token-price-fallback.md
+++ b/.changeset/route-token-price-fallback.md
@@ -1,0 +1,19 @@
+---
+'@lifi/widget': patch
+---
+
+fix(widget): value a route's tokens with the route's own price
+
+`Token` falls back to the cached token whenever a token has no `logoURI`, and
+that fallback merged the cached token *over* the route token — so the cached
+`priceUSD` replaced the route's. The receive card reads the route price
+directly, so the same output amount could show two different USD values on the
+receive card and on the quote card. Thin or newly listed tokens are the ones
+affected: they are the tokens without a logo, and their feed price drifts
+furthest from the route price.
+
+The fallback now fills only the gaps the route leaves, so a known route price
+always wins. An unknown price arrives as `'0'` or `''` rather than as an absent
+key, and those still fall back to the cache. `updateTokenInCache` also compares
+addresses case-insensitively, so a casing difference between the token list and
+the route no longer silently skips the token-list update.

--- a/packages/widget/src/components/Token/Token.tsx
+++ b/packages/widget/src/components/Token/Token.tsx
@@ -7,6 +7,7 @@ import { useChain } from '../../hooks/useChain.js'
 import { useToken } from '../../hooks/useToken.js'
 import { formatTokenAmount, formatTokenPrice } from '../../utils/format.js'
 import { getPriceImpact } from '../../utils/getPriceImpact.js'
+import { mergeFallbackToken } from '../../utils/token.js'
 import { AvatarBadgedSkeleton } from '../Avatar/Avatar.js'
 import { SmallAvatar } from '../Avatar/SmallAvatar.js'
 import { TokenAvatar } from '../Avatar/TokenAvatar.js'
@@ -42,7 +43,7 @@ const TokenFallback: FC<TokenProps & BoxProps> = ({
 
   return (
     <TokenBase
-      token={{ ...token, ...chainToken } as TokenAmount}
+      token={mergeFallbackToken(token, chainToken)}
       isLoading={isLoading || isLoadingToken}
       {...other}
     />

--- a/packages/widget/src/utils/token.test.ts
+++ b/packages/widget/src/utils/token.test.ts
@@ -1,4 +1,9 @@
-import type { ExtendedChain, Token } from '@lifi/sdk'
+import type {
+  ExtendedChain,
+  Token,
+  TokenAmount,
+  TokenExtended,
+} from '@lifi/sdk'
 import { describe, expect, it } from 'vitest'
 import type { TokensByChain, TokenWithFlags } from '../types/token.js'
 import {
@@ -6,6 +11,8 @@ import {
   getNativeTokenAddresses,
   getTokenVerificationProvider,
   getVerifiedTokensSets,
+  mergeFallbackToken,
+  updateTokenInCache,
 } from './token.js'
 
 const makeToken = (
@@ -267,5 +274,123 @@ describe('getNativeTokenAddresses', () => {
 
   it('should return an empty map without chains', () => {
     expect(getNativeTokenAddresses(undefined).size).toBe(0)
+  })
+})
+
+describe('mergeFallbackToken', () => {
+  const routeToken: TokenAmount = {
+    chainId: 4663,
+    address: '0xe8ffd7e24187f72afb08d75b1bb13088a989a791',
+    symbol: 'DELTA',
+    decimals: 18,
+    name: 'Delta',
+    priceUSD: '0.01308276789',
+    amount: 759159353996000000000000n,
+  }
+
+  const cachedToken: TokenExtended = {
+    chainId: 4663,
+    address: '0xe8ffd7e24187f72afb08d75b1bb13088a989a791',
+    symbol: 'DELTA',
+    decimals: 18,
+    name: 'Delta',
+    priceUSD: '0.01298884081',
+    logoURI: 'https://example.test/delta.png',
+  }
+
+  it('should keep the route price when the cache holds a different one', () => {
+    expect(mergeFallbackToken(routeToken, cachedToken).priceUSD).toBe(
+      '0.01308276789'
+    )
+  })
+
+  it('should take the logo from the cache when the route has none', () => {
+    expect(mergeFallbackToken(routeToken, cachedToken).logoURI).toBe(
+      'https://example.test/delta.png'
+    )
+  })
+
+  it('should keep the route logo when the route has one', () => {
+    const withLogo = {
+      ...routeToken,
+      logoURI: 'https://example.test/route.png',
+    }
+    expect(mergeFallbackToken(withLogo, cachedToken).logoURI).toBe(
+      'https://example.test/route.png'
+    )
+  })
+
+  it('should take the cache price when the route price is empty', () => {
+    expect(
+      mergeFallbackToken({ ...routeToken, priceUSD: '' }, cachedToken).priceUSD
+    ).toBe('0.01298884081')
+  })
+
+  it('should take the cache price when the route price is zero', () => {
+    expect(
+      mergeFallbackToken({ ...routeToken, priceUSD: '0' }, cachedToken).priceUSD
+    ).toBe('0.01298884081')
+  })
+
+  it('should take the cache logo when the route logo is empty', () => {
+    expect(
+      mergeFallbackToken({ ...routeToken, logoURI: '' }, cachedToken).logoURI
+    ).toBe('https://example.test/delta.png')
+  })
+
+  it('should keep the route amount when the cache holds a balance', () => {
+    const withBalance = { ...cachedToken, amount: 42n } as TokenExtended
+    expect(mergeFallbackToken(routeToken, withBalance).amount).toBe(
+      759159353996000000000000n
+    )
+  })
+
+  it('should keep the route decimals when the cache disagrees', () => {
+    expect(
+      mergeFallbackToken(routeToken, { ...cachedToken, decimals: 6 }).decimals
+    ).toBe(18)
+  })
+
+  it('should return the route token without a cached token', () => {
+    expect(mergeFallbackToken(routeToken, undefined)).toEqual(routeToken)
+  })
+})
+
+describe('updateTokenInCache', () => {
+  const cache: TokensByChain = {
+    4663: [makeToken(4663, '0xE8FFd7E24187F72AFB08D75B1bb13088A989A791')],
+  }
+
+  it('should update a token whose cached address differs only in case', () => {
+    const updated = updateTokenInCache(cache, {
+      ...makeToken(4663, '0xe8ffd7e24187f72afb08d75b1bb13088a989a791'),
+      priceUSD: '0.01308276789',
+    })
+    expect(updated?.[4663][0].priceUSD).toBe('0.01308276789')
+  })
+
+  it('should keep the cached address casing while updating the price', () => {
+    const updated = updateTokenInCache(cache, {
+      ...makeToken(4663, '0xe8ffd7e24187f72afb08d75b1bb13088a989a791'),
+      priceUSD: '0.01308276789',
+    })
+    expect(updated?.[4663][0]).toEqual({
+      ...makeToken(4663, '0xE8FFd7E24187F72AFB08D75B1bb13088A989A791'),
+      priceUSD: '0.01308276789',
+    })
+  })
+
+  it('should return the cache unchanged for a token that is not in it', () => {
+    expect(updateTokenInCache(cache, makeToken(4663, '0xabc'))).toBe(cache)
+  })
+
+  it('should return the cache unchanged for a chain that is not in it', () => {
+    expect(updateTokenInCache(cache, makeToken(1, '0xe8ffd7e2'))).toBe(cache)
+  })
+
+  it('should return undefined without a cache', () => {
+    expect(
+      updateTokenInCache(undefined, makeToken(4663, '0xabc'))
+    ).toBeUndefined()
   })
 })

--- a/packages/widget/src/utils/token.ts
+++ b/packages/widget/src/utils/token.ts
@@ -5,6 +5,7 @@ import type {
   StaticToken,
   Token,
   TokenAmount,
+  TokenExtended,
 } from '@lifi/sdk'
 import { ChainId } from '@lifi/sdk'
 import type { FormType } from '../stores/form/types.js'
@@ -72,8 +73,34 @@ export const mergeVerifiedWithSearchTokens = (
 }
 
 /**
+ * Merges a cached token into a route token for display. The route wins on every
+ * field it carries; the cache only fills gaps. Letting the cache win instead
+ * swaps the quoted price for a stale feed price.
+ *
+ * `priceUSD` is a required string, so an unknown price arrives as `'0'` or `''`
+ * rather than as an absent key, and a plain spread would let it beat a known
+ * cached price. Treat both, and an empty `logoURI`, as gaps.
+ */
+export const mergeFallbackToken = (
+  routeToken: TokenAmount,
+  cachedToken: TokenExtended | undefined
+): TokenAmount =>
+  cachedToken
+    ? {
+        ...cachedToken,
+        ...routeToken,
+        priceUSD: Number(routeToken.priceUSD)
+          ? routeToken.priceUSD
+          : cachedToken.priceUSD,
+        logoURI: routeToken.logoURI || cachedToken.logoURI,
+      }
+    : routeToken
+
+/**
  * Updates a token in the cache by chainId and address.
  * Returns a new cache object with the token updated, or the original if not found.
+ * Addresses are compared case-insensitively: the token list and the route can
+ * spell the same address differently.
  */
 export const updateTokenInCache = (
   data: TokensByChain | undefined,
@@ -86,14 +113,18 @@ export const updateTokenInCache = (
   if (!chainTokens) {
     return data
   }
-  const index = chainTokens.findIndex((t) => t.address === token.address)
+  const address = token.address.toLowerCase()
+  const index = chainTokens.findIndex(
+    (t) => t.address.toLowerCase() === address
+  )
   if (index < 0) {
     return data
   }
   return {
     ...data,
     [token.chainId]: chainTokens.map((t, i) =>
-      i === index ? { ...t, ...token } : t
+      // Keep the cached address: other cache readers hold it as the identity.
+      i === index ? { ...t, ...token, address: t.address } : t
     ),
   }
 }


### PR DESCRIPTION
## Which Linear task is linked to this PR?

JUMEMB-80 (Jumper tracker). The defect is in shared widget code, so it is fixed here too.

## Why was it implemented this way?

`Token` renders `TokenFallback` whenever a token has no `priceUSD` **or** no `logoURI`, and
that fallback did `{ ...token, ...chainToken }` — the cached token spread **last**, so the
cached `priceUSD` overwrote the route's. `ReceiveAmountCard` reads `route.toToken.priceUSD`
directly and never passes through `Token`, so the same output amount could be valued at two
different prices on the receive card and on a quote card.

Only tokens without a logo are affected, because only they take the fallback branch — and
those are disproportionately thin or newly listed tokens, whose feed price drifts furthest
from the route price. Across 7,094 tokens on three chains, 54% carry no `logoURI`.

A logo fallback should not re-source economic fields, so `mergeFallbackToken` inverts the
precedence: the route wins on every field it carries, and the cache supplies only the gaps.

Two details drove the shape:

- **`priceUSD` is a required `string`** in `@lifi/types`, so an unknown price arrives as
  `'0'` or `''`, not as an absent key. A plain spread reversal would let `'0'` beat a known
  cached price and render `$0.00` — worse than before. The merge therefore treats a
  non-numeric price, and an empty `logoURI`, as gaps. `'0'`-as-unknown follows the existing
  convention in `useLimitMarketRate.ts`.
- **`amount` and `decimals` now always come from the route.** `TokenExtended` carries no
  `amount` today, so no wallet balance can leak into a quote card; the invariant is now
  explicit rather than incidental.

`updateTokenInCache` also compares addresses case-insensitively. The token list and the
route can spell the same address differently, and the mismatch silently skipped the price
update, leaving a stale price in the cache.

### Alternative considered

Narrowing the cache write to `priceUSD` alone. Rejected for now: `{ ...t, ...token }` is
long-standing behaviour and other route-token fields (`verificationStatus` in particular)
may be relied on downstream. Worth a separate, deliberate change.

## Visual showcase (Screenshots or Videos)

Verified in a browser against a live quote (9450 USDG → DELTA, Robinhood Chain, wallet
disconnected). Route `toToken.priceUSD` = `0.01243272363`; cached feed price
`0.01223128405`, 1.65% apart.

| # | Tool | toAmount | amount × route price | API `toAmountUSD` | Displayed |
| -- | -- | -- | -- | -- | -- |
| 1 | Nordstern Finance | 739,663.457517 | 9196.03 | 9196.0313 | $9,196.03 |
| 2 | Rialto | 738,477.012337 | 9181.28 | 9181.2806 | $9,181.28 |
| 3 | Fly | 738,270.834772 | 9178.72 | 9178.7173 | $9,178.72 |
| 4 | Smart Deposits | 735,877.761208 | 9148.96 | 9148.9648 | $9,148.96 |

All four match to the cent, and match the API's own figure. Before the fix, card 1 read
**$9,047.03**.

Isolating the merge from any cache refresh: forcing the cached DELTA price to `0.05` (card 1
would read $36,983.17 if the cache were read) left all four cards unmoved, while a control
that forced the cached USDG price to `2.00` moved the send card immediately. The quote cards
read the route price.

## Checklist before requesting a review

- [x] I have performed a self-review and testing of my code.
- [x] This pull request is focused and addresses a single problem.
- [x] If this PR modifies the Widget API or adds new features that require documentation, I have updated the documentation in the [public-docs](https://github.com/lifinance/public-docs) repository.

## Known residual, not fixed here

The two cards read the output **amount** from different fields — the receive card from
`route.toAmount`, `RouteTokens` from `route.steps[last].estimate.toAmount`. On `li.quest`
those were identical in every response I sampled; on another LI.FI-backed API I measured a
0.286% divergence on one route, about $28 at that price. This PR unifies the price, not the
amount. Filing separately rather than folding in, because unifying on `route.toAmount`
touches the `execution?.toAmount` branch that serves executing routes.
