### PR TITLE
fix(widget): keep a known token price when a route cannot price it

### DIFF
--- a/.changeset/known-price-beats-unknown.md
+++ b/.changeset/known-price-beats-unknown.md
@@ -1,0 +1,16 @@
+---
+'@lifi/widget': patch
+---
+
+fix(widget): keep a known token price when a route cannot price it
+
+A route that returns `priceUSD` `"0"` for its output token blanked the value on
+every quote card. `useRoutes` writes the route's tokens back into the token
+caches through `updateTokenInCache`, which spread that `"0"` over the price the
+cache already held. `Token`'s logo fallback then looked for a cached price to
+fall back to and found the same `"0"`, so the guard added in #866 had nothing
+left to read.
+
+`knownPriceUSD` now applies the rule where the value is written as well as where
+it is read: an incoming `'0'` or `''` never replaces a price the cache knows,
+and an empty `logoURI` no longer clears a cached logo.

--- a/packages/widget/src/components/AmountInputCard/ReceiveAmountCard.tsx
+++ b/packages/widget/src/components/AmountInputCard/ReceiveAmountCard.tsx
@@ -6,12 +6,14 @@ import { Box, Skeleton, Tooltip } from '@mui/material'
 import { type JSX, type ReactNode, useLayoutEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useRoutes } from '../../hooks/useRoutes.js'
+import { useToken } from '../../hooks/useToken.js'
 import { useWidgetConfig } from '../../providers/WidgetProvider/WidgetProvider.js'
 import { useFieldValues } from '../../stores/form/useFieldValues.js'
 import { useInputModeStore } from '../../stores/inputMode/useInputModeStore.js'
 import { formatTokenAmount, formatTokenPrice } from '../../utils/format.js'
 import { getPriceImpact } from '../../utils/getPriceImpact.js'
 import { fitInputText } from '../../utils/input.js'
+import { mergeFallbackToken } from '../../utils/token.js'
 import { CardTitle } from '../Card/CardTitle.js'
 import { ProgressToNextUpdate } from '../ProgressToNextUpdate.js'
 import { TokenPillButton } from '../TokenPillButton/TokenPillButton.js'
@@ -128,6 +130,17 @@ export const ReceiveAmountCard: React.FC<ReceiveCardProps> = (
   const priceImpact = useReceivePriceImpact(route)
   const showPriceImpact = !hiddenUI?.routeCardPriceImpact
 
+  // Value the amount the way a quote card does, so the two sides of the screen
+  // cannot disagree: the route's own price wins, and the cache fills only a gap
+  // the route leaves — a token it could not price arrives as '0' or ''.
+  const { token: cachedToken } = useToken(
+    route?.toToken.chainId,
+    route?.toToken.address
+  )
+  const pricedToken = route
+    ? mergeFallbackToken(route.toToken, cachedToken)
+    : undefined
+
   const receiveAmount = route?.toAmount
     ? formatTokenAmount(BigInt(route.toAmount), route.toToken.decimals)
     : undefined
@@ -135,10 +148,10 @@ export const ReceiveAmountCard: React.FC<ReceiveCardProps> = (
   const showSkeleton = isFetching && !receiveAmount
 
   const fiatValue =
-    receiveAmount && route?.toToken.priceUSD
-      ? formatTokenPrice(receiveAmount, route.toToken.priceUSD)
+    receiveAmount && pricedToken?.priceUSD
+      ? formatTokenPrice(receiveAmount, pricedToken.priceUSD)
       : 0
-  const canToggle = !!receiveAmount && !!route?.toToken.priceUSD
+  const canToggle = !!receiveAmount && !!pricedToken?.priceUSD
 
   const mainDisplay = showFiat
     ? t('format.currency', { value: fiatValue })

--- a/packages/widget/src/utils/token.test.ts
+++ b/packages/widget/src/utils/token.test.ts
@@ -380,6 +380,38 @@ describe('updateTokenInCache', () => {
     })
   })
 
+  it('should keep the cached price when the incoming price is zero', () => {
+    const updated = updateTokenInCache(cache, {
+      ...makeToken(4663, '0xe8ffd7e24187f72afb08d75b1bb13088a989a791'),
+      priceUSD: '0',
+    })
+    expect(updated?.[4663][0].priceUSD).toBe('1')
+  })
+
+  it('should keep the cached price when the incoming price is empty', () => {
+    const updated = updateTokenInCache(cache, {
+      ...makeToken(4663, '0xe8ffd7e24187f72afb08d75b1bb13088a989a791'),
+      priceUSD: '',
+    })
+    expect(updated?.[4663][0].priceUSD).toBe('1')
+  })
+
+  it('should keep the cached logo when the incoming logo is empty', () => {
+    const withLogo: TokensByChain = {
+      4663: [
+        {
+          ...makeToken(4663, '0xE8FFd7E24187F72AFB08D75B1bb13088A989A791'),
+          logoURI: 'https://example.test/delta.png',
+        },
+      ],
+    }
+    const updated = updateTokenInCache(withLogo, {
+      ...makeToken(4663, '0xe8ffd7e24187f72afb08d75b1bb13088a989a791'),
+      logoURI: '',
+    })
+    expect(updated?.[4663][0].logoURI).toBe('https://example.test/delta.png')
+  })
+
   it('should return the cache unchanged for a token that is not in it', () => {
     expect(updateTokenInCache(cache, makeToken(4663, '0xabc'))).toBe(cache)
   })

--- a/packages/widget/src/utils/token.ts
+++ b/packages/widget/src/utils/token.ts
@@ -73,13 +73,18 @@ export const mergeVerifiedWithSearchTokens = (
 }
 
 /**
+ * `priceUSD` is a required string, so an unknown price arrives as `'0'` or `''`
+ * rather than as an absent key — the same reading as in `useLimitMarketRate`. A
+ * known price must never lose to one, or a route that cannot price its output
+ * blanks a value the cache already knew.
+ */
+export const knownPriceUSD = (fresher: string, cached: string): string =>
+  Number(fresher) ? fresher : cached
+
+/**
  * Merges a cached token into a route token for display. The route wins on every
  * field it carries; the cache only fills gaps. Letting the cache win instead
  * swaps the quoted price for a stale feed price.
- *
- * `priceUSD` is a required string, so an unknown price arrives as `'0'` or `''`
- * rather than as an absent key, and a plain spread would let it beat a known
- * cached price. Treat both, and an empty `logoURI`, as gaps.
  */
 export const mergeFallbackToken = (
   routeToken: TokenAmount,
@@ -89,9 +94,7 @@ export const mergeFallbackToken = (
     ? {
         ...cachedToken,
         ...routeToken,
-        priceUSD: Number(routeToken.priceUSD)
-          ? routeToken.priceUSD
-          : cachedToken.priceUSD,
+        priceUSD: knownPriceUSD(routeToken.priceUSD, cachedToken.priceUSD),
         logoURI: routeToken.logoURI || cachedToken.logoURI,
       }
     : routeToken
@@ -100,7 +103,8 @@ export const mergeFallbackToken = (
  * Updates a token in the cache by chainId and address.
  * Returns a new cache object with the token updated, or the original if not found.
  * Addresses are compared case-insensitively: the token list and the route can
- * spell the same address differently.
+ * spell the same address differently. The incoming token only overwrites what it
+ * actually knows, so an unpriced or logo-less route cannot blank the cache.
  */
 export const updateTokenInCache = (
   data: TokensByChain | undefined,
@@ -123,8 +127,16 @@ export const updateTokenInCache = (
   return {
     ...data,
     [token.chainId]: chainTokens.map((t, i) =>
-      // Keep the cached address: other cache readers hold it as the identity.
-      i === index ? { ...t, ...token, address: t.address } : t
+      i === index
+        ? {
+            ...t,
+            ...token,
+            // Keep the cached address: other readers hold it as the identity.
+            address: t.address,
+            priceUSD: knownPriceUSD(token.priceUSD, t.priceUSD),
+            logoURI: token.logoURI || t.logoURI,
+          }
+        : t
     ),
   }
 }


### PR DESCRIPTION
## Which Linear task is linked to this PR?

JUMEMB-80 (Jumper tracker) — follow-up to #866, found by QA on the Jumper fork's
equivalent PR. The same defect is in this repo.

## Why was it implemented this way?

#866 stopped `Token`'s logo fallback from letting a **stale** cached price beat the route's,
and guarded against a route whose price is unknown (`priceUSD` is a required `string`, so
"no price" arrives as `'0'` or `''`, not as an absent key).

That guard is defeated one layer up. `useRoutes` writes the route's tokens back into the
token caches through `updateTokenInCache`, which spread the route's `'0'` over the price the
cache already held. By the time the fallback looked for a cached price, it found the same
`'0'` — so a route that cannot price its output token renders **$0.00 on every quote card**.

The rule was only on the read side. It belongs on the write side too, so `knownPriceUSD`
is now shared by both: an incoming `'0'` or `''` never replaces a price the cache knows, and
an empty `logoURI` no longer clears a cached logo.

### Alternatives considered

- **Sanitising route tokens before the cache write.** Same effect, but it puts the rule in
  the caller, so the next caller of `updateTokenInCache` reintroduces the bug. Keeping it in
  the function that performs the write makes it hold for every caller.
- **Not writing route prices to the cache at all.** That would undo the freshness the sync
  exists for — the token list and the send card would drift from the quote.

## Visual showcase (Screenshots or Videos)

Reproduced and fixed as unit tests rather than screenshots, since it needs an API response
that prices a token at `'0'`. QA reproduced the visual on the Jumper fork by rewriting the
routes response in the browser: every quote card showed `$0.00` with `-100%`, where the
pre-#866 build showed the token-list price.

Three tests, watched fail before the fix:

- `should keep the cached price when the incoming price is zero`
- `should keep the cached price when the incoming price is empty`
- `should keep the cached logo when the incoming logo is empty`

148 tests pass. Biome and `tsc --noEmit` clean.

## Checklist before requesting a review

- [x] I have performed a self-review and testing of my code.
- [x] This pull request is focused and addresses a single problem.
- [x] If this PR modifies the Widget API or adds new features that require documentation, I have updated the documentation in the [public-docs](https://github.com/lifinance/public-docs) repository.

## One remaining site, not fixed here

The `token-balances` write is inline in `useRoutes.ts` and still does a plain
`{ ...clonedData[index], ...token }`, so it can take an unknown price into the balances
cache, and it still matches addresses case-sensitively. That cache feeds the token list, not
the quote cards, so it is not part of the `$0.00` symptom. It has no test seam here without
extracting the sync — the Jumper fork extracted it as `syncRouteTokenPrices` and fixed both
there. Worth the same treatment in a separate PR.
