### PR TITLE
docs: add Stellar to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,12 @@
 
 [**LI.FI Widget**](https://docs.li.fi/widget/overview) features include:
 
-- **Provider-based architecture** - Modular blockchain support with separate packages for Ethereum, Bitcoin, Solana, Sui, and Tron
+- **Provider-based architecture** - Modular blockchain support with separate packages for Ethereum, Bitcoin, Solana, Sui, Tron, and Stellar
 - All ecosystems, chains, bridges, exchanges, and solvers that [LI.FI](https://docs.li.fi/introduction/chains) supports
 - Embeddable variants - compact, wide, and drawer
 - Options to allow or deny certain chains, tokens, bridges, and exchanges
 - Pre-configured themes and lots of customization options with dark mode support so you can match the look and feel of your web app
-- Built-in wallet management UI with support for external wallet providers ([Wagmi](https://wagmi.sh/), [Bigmi](https://github.com/lifinance/bigmi), [Wallet Standard](https://github.com/wallet-standard/wallet-standard), [@mysten/dapp-kit-react](https://sdk.mystenlabs.com/dapp-kit), and [TronWallet Adapters](https://github.com/tronweb3/tronwallet-adapter))
+- Built-in wallet management UI with support for external wallet providers ([Wagmi](https://wagmi.sh/), [Bigmi](https://github.com/lifinance/bigmi), [Wallet Standard](https://github.com/wallet-standard/wallet-standard), [@mysten/dapp-kit-react](https://sdk.mystenlabs.com/dapp-kit), [TronWallet Adapters](https://github.com/tronweb3/tronwallet-adapter), and [Stellar Wallets Kit](https://github.com/Creit-Tech/Stellar-Wallets-Kit))
 - Supports widely adopted industry standards, including [EIP-5792](https://eips.ethereum.org/EIPS/eip-5792), [ERC-2612](https://eips.ethereum.org/EIPS/eip-2612), [EIP-712](https://eips.ethereum.org/EIPS/eip-712), [EIP-6963](https://eips.ethereum.org/EIPS/eip-6963), and [Permit2](https://github.com/Uniswap/permit2)
 - View of transactions in progress and transaction history
 - Curated wallet lists and wallet bookmarks
@@ -159,6 +159,26 @@ npm install @lifi/widget-provider-tron @tronweb3/tronwallet-adapter-react-hooks
 yarn add @lifi/widget-provider-tron @tronweb3/tronwallet-adapter-react-hooks
 ```
 
+**Stellar:**
+
+**pnpm:**
+
+```sh
+pnpm add @lifi/widget-provider-stellar
+```
+
+**npm:**
+
+```sh
+npm install @lifi/widget-provider-stellar
+```
+
+**yarn:**
+
+```sh
+yarn add @lifi/widget-provider-stellar
+```
+
 **Note:** You only need to install the provider packages for the blockchains you want to support. Each provider package includes its required peer dependencies.
 
 ### LI.FI Wallet Management
@@ -218,6 +238,7 @@ The LI.FI Widget uses a **provider-based architecture** that allows you to selec
 - **`@lifi/widget-provider-solana`** - Solana support (requires [bs58](https://www.npmjs.com/package/bs58))
 - **`@lifi/widget-provider-sui`** - Sui support (requires [@mysten/dapp-kit-react](https://sdk.mystenlabs.com/dapp-kit))
 - **`@lifi/widget-provider-tron`** - Tron support (requires [@tronweb3/tronwallet-adapter-react-hooks](https://github.com/tronweb3/tronwallet-adapter))
+- **`@lifi/widget-provider-stellar`** - Stellar support (bundles [Stellar Wallets Kit](https://github.com/Creit-Tech/Stellar-Wallets-Kit); no extra install)
 - **`@lifi/wallet-management`** - Wallet management UI components
 - **`@lifi/widget-light`** - Lightweight iframe-based integration ([docs](https://docs.li.fi/widget/widget-light-overview))
 
@@ -254,13 +275,14 @@ export const WidgetPage = () => {
 };
 ```
 
-**Multi-chain example** (Ethereum, Solana, Bitcoin, Sui, and Tron):
+**Multi-chain example** (Ethereum, Solana, Bitcoin, Sui, Tron, and Stellar):
 
 ```tsx
 import { LiFiWidget, WidgetConfig } from '@lifi/widget';
 import { BitcoinProvider } from '@lifi/widget-provider-bitcoin';
 import { EthereumProvider } from '@lifi/widget-provider-ethereum';
 import { SolanaProvider } from '@lifi/widget-provider-solana';
+import { StellarProvider } from '@lifi/widget-provider-stellar';
 import { SuiProvider } from '@lifi/widget-provider-sui';
 import { TronProvider } from '@lifi/widget-provider-tron';
 
@@ -271,6 +293,7 @@ const widgetConfig: WidgetConfig = {
     BitcoinProvider(),
     SuiProvider(),
     TronProvider(),
+    StellarProvider(),
   ],
   theme: {
     container: {


### PR DESCRIPTION
## Which Linear task is linked to this PR?

_None — documentation gap found while auditing the SDK README._

## Why was it implemented this way?

`@lifi/widget-provider-stellar` is published (**4.2.0** on npm) and exports `StellarProvider`, but the README did not mention Stellar anywhere — `grep -i stellar README.md` returned nothing. Meanwhile [public-docs](https://docs.li.fi/widget/overview) already lists Stellar among the supported ecosystems, so the README was the odd one out.

Stellar is added in five places:

1. **Feature list** — "Ethereum, Bitcoin, Solana, Sui, Tron, and Stellar"
2. **Wallet-provider libraries** — adds [Stellar Wallets Kit](https://github.com/Creit-Tech/Stellar-Wallets-Kit), matching how the widget overview page words it
3. **Installation** — a Stellar block in the same pnpm/npm/yarn shape as the others
4. **Architecture** — a `@lifi/widget-provider-stellar` bullet
5. **Multi-chain example** — the import and the `StellarProvider()` entry

## The one thing that differs from the other providers

Every other provider's install command carries a companion library, because each declares a real peer dependency:

| Provider | Peer dependency |
|---|---|
| `-ethereum` | `wagmi`, `@wagmi/core` |
| `-bitcoin` | `@bigmi/react` |
| `-solana` | `bs58` |
| `-sui` | `@mysten/dapp-kit-react` |
| `-tron` | `@tronweb3/tronwallet-adapter-react-hooks` |
| **`-stellar`** | **none beyond `react`** |

`@creit.tech/stellar-wallets-kit` is a regular dependency that the provider drives internally and re-exposes via `useStellarWalletsKit`, so callers never import it. The install command is therefore just the package, and the architecture entry says "bundles Stellar Wallets Kit; no extra install" so the asymmetry does not read as an omission.

Verified rather than assumed:

```
$ pnpm add react react-dom @lifi/widget-provider-stellar
$ node -e "require.resolve('@lifi/widget-provider-stellar')"
OK
$ pnpm install   # unmet peer warnings?
(none)
```

## Visual showcase (Screenshots or Videos)

n/a

## Checklist before requesting a review
- [x] I have performed a self-review and testing of my code.
- [x] This pull request is focused and addresses a single problem.
- [x] If this PR modifies the widget API or adds new features that require documentation, I have updated the documentation in the [public-docs](https://github.com/lifinance/public-docs) repository. — docs-only; public-docs already covers Stellar for the widget.

---

**Note, not fixed here:** the install section ends with "Each provider package includes its required peer dependencies." That is the opposite of what a peer dependency is, and the commands just above it list those peers explicitly. It happens to work because pnpm auto-installs peers by default. Worth rewording, but left alone to keep this PR to the Stellar gap.

**Related:** the same Stellar audit produced lifinance/sdk#474 (SDK README) and a companion public-docs PR.
