### PR TITLE
fix(widget): scope ethereum query keys

### DIFF
--- a/.changeset/scope-ethereum-query-keys.md
+++ b/.changeset/scope-ethereum-query-keys.md
@@ -1,0 +1,5 @@
+---
+'@lifi/widget': patch
+---
+
+Namespace address-activity and contract-code React Query keys with the widget key prefix so they cannot collide with integrator queries when a host QueryClient is reused.

--- a/packages/widget/src/hooks/useAddressActivity.ts
+++ b/packages/widget/src/hooks/useAddressActivity.ts
@@ -1,7 +1,9 @@
 import { ChainType } from '@lifi/sdk'
 import { useEthereumContext } from '@lifi/widget-provider'
 import { useQuery } from '@tanstack/react-query'
+import { useWidgetConfig } from '../providers/WidgetProvider/WidgetProvider.js'
 import { useFieldValues } from '../stores/form/useFieldValues.js'
+import { getQueryKey } from '../utils/queries.js'
 import { useAvailableChains } from './useAvailableChains.js'
 
 interface AddressActivity {
@@ -14,6 +16,7 @@ export const useAddressActivity = (chainId?: number): AddressActivity => {
   const { getChainById } = useAvailableChains()
   const [toAddress, toChainId] = useFieldValues('toAddress', 'toChain')
   const { getTransactionCount } = useEthereumContext()
+  const { keyPrefix } = useWidgetConfig()
 
   const destinationChainId = chainId ?? toChainId
   const toChain = getChainById(destinationChainId)
@@ -24,7 +27,11 @@ export const useAddressActivity = (chainId?: number): AddressActivity => {
     isFetched,
     error,
   } = useQuery({
-    queryKey: ['getTransactionCount', toAddress, destinationChainId],
+    queryKey: [
+      getQueryKey('getTransactionCount', keyPrefix),
+      toAddress,
+      destinationChainId,
+    ],
     queryFn: async () => {
       const count = await getTransactionCount?.(destinationChainId!, toAddress!)
       return count ?? null

--- a/packages/widget/src/hooks/useIsContractAddress.ts
+++ b/packages/widget/src/hooks/useIsContractAddress.ts
@@ -1,6 +1,8 @@
 import { ChainType } from '@lifi/sdk'
 import { useEthereumContext } from '@lifi/widget-provider'
 import { useQuery } from '@tanstack/react-query'
+import { useWidgetConfig } from '../providers/WidgetProvider/WidgetProvider.js'
+import { getQueryKey } from '../utils/queries.js'
 
 export const useIsContractAddress = (
   address?: string,
@@ -13,13 +15,14 @@ export const useIsContractAddress = (
   isFetched: boolean
 } => {
   const { getBytecode } = useEthereumContext()
+  const { keyPrefix } = useWidgetConfig()
 
   const {
     data: contractCode,
     isLoading,
     isFetched,
   } = useQuery({
-    queryKey: ['getBytecode', address, chainId],
+    queryKey: [getQueryKey('getBytecode', keyPrefix), address, chainId],
     queryFn: async () => {
       const code = await getBytecode?.(chainId!, address!)
       return code ?? null


### PR DESCRIPTION
## Which Linear task is linked to this PR?

None.

## Why was it implemented this way?

The widget reuses an existing React Query client when the host app already has one. Most widget queries are prefixed to keep them separate from the host app's cache, but the transaction-count and bytecode checks were still using generic keys.

That means a host app using the same keys could accidentally share cached data with the widget.

This updates both queries to use the widget query prefix, matching the rest of the query hooks.

## Testing

Ran the fork PR through the repository CI successfully:

- E2E Playground (dev mode)
- E2E Examples
- E2E Playground build
- all 4 Playwright shards

Also reproduced the cache collision separately by pre-populating the host QueryClient with the old keys and confirming the widget query is skipped until the key is scoped.

## Visual showcase (Screenshots or Videos)

N/A.

## Checklist before requesting a review

- [x] I have performed a self-review and testing of my code.
- [x] This pull request is focused and addresses a single problem.
- [x] No public API or documentation changes are required.
