### PR TITLE
fix(widget): isolate configurable settings defaults

### DIFF
--- a/.changeset/isolate-widget-setting-defaults.md
+++ b/.changeset/isolate-widget-setting-defaults.md
@@ -1,0 +1,5 @@
+---
+'@lifi/widget': patch
+---
+
+Keep configurable route defaults isolated between widget instances.

--- a/packages/widget/src/hooks/useSettingMonitor.ts
+++ b/packages/widget/src/hooks/useSettingMonitor.ts
@@ -32,7 +32,7 @@ export const useSettingMonitor = (): {
   ])
   const { tools } = useTools()
   const config = useWidgetConfig()
-  const { setDefaultSettings, resetSettings } = useSettingsActions()
+  const { resetSettings } = useSettingsActions()
 
   const isSlippageChanged = config.slippage
     ? Number(slippage) !== config.slippage * 100
@@ -70,10 +70,9 @@ export const useSettingMonitor = (): {
     if (tools) {
       resetSettings(
         tools.bridges.map((tool) => tool.key),
-        tools.exchanges.map((tool) => tool.key)
+        tools.exchanges.map((tool) => tool.key),
+        config
       )
-
-      setDefaultSettings(config)
     }
   }
 

--- a/packages/widget/src/stores/settings/createSettingsStore.ts
+++ b/packages/widget/src/stores/settings/createSettingsStore.ts
@@ -22,6 +22,21 @@ export const defaultConfigurableSettings: Pick<
   gasPrice: 'normal',
 }
 
+export const getDefaultConfigurableSettings = (
+  config?: WidgetConfig
+): Pick<SettingsState, 'routePriority' | 'slippage' | 'gasPrice'> => {
+  const configuredSlippage = (config?.slippage || 0) * 100
+
+  return {
+    routePriority:
+      config?.routePriority || defaultConfigurableSettings.routePriority,
+    slippage: (
+      configuredSlippage || defaultConfigurableSettings.slippage
+    )?.toString(),
+    gasPrice: defaultConfigurableSettings.gasPrice,
+  }
+}
+
 const defaultSettings: SettingsProps = {
   gasPrice: 'normal',
   enabledAutoRefuel: true,
@@ -65,8 +80,10 @@ export const createSettingsStore = (
   const toEnabledMap = (keys: string[] = []): Record<string, boolean> =>
     Object.fromEntries(keys.map((key) => [key, true] as const))
   // Deny-only configs can't be seeded; the tool universe is unknown until /tools.
+  const initialConfigurableSettings = getDefaultConfigurableSettings(config)
   const initialSettings: SettingsProps = {
     ...defaultSettings,
+    ...initialConfigurableSettings,
     ...buildToolState('Bridges', toEnabledMap(config.bridges?.allow)),
     ...buildToolState('Exchanges', toEnabledMap(config.exchanges?.allow)),
   }
@@ -171,10 +188,14 @@ export const createSettingsStore = (
               [`disabled${toolType}`]: disabledKeys,
             }
           }),
-        reset: (bridges, exchanges) => {
+        reset: (
+          bridges,
+          exchanges,
+          configurableSettings = initialConfigurableSettings
+        ) => {
           set(() => ({
             ...defaultSettings,
-            ...defaultConfigurableSettings,
+            ...configurableSettings,
           }))
           get().initializeTools('Bridges', bridges, true)
           get().initializeTools('Exchanges', exchanges, true)

--- a/packages/widget/src/stores/settings/types.ts
+++ b/packages/widget/src/stores/settings/types.ts
@@ -41,7 +41,14 @@ export interface SettingsActions {
   ): void
   setToolValue(toolType: SettingsToolType, tool: string, value: boolean): void
   toggleToolKeys(toolType: SettingsToolType, toolKeys: string[]): void
-  reset(bridges: string[], exchanges: string[]): void
+  reset(
+    bridges: string[],
+    exchanges: string[],
+    configurableSettings?: Pick<
+      SettingsProps,
+      'routePriority' | 'slippage' | 'gasPrice'
+    >
+  ): void
 }
 
 export type SettingsState = SettingsProps & SettingsActions

--- a/packages/widget/src/stores/settings/useSettingsActions.test.tsx
+++ b/packages/widget/src/stores/settings/useSettingsActions.test.tsx
@@ -1,0 +1,116 @@
+import { renderToString } from 'react-dom/server'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { WidgetProvider } from '../../providers/WidgetProvider/WidgetProvider.js'
+import type { WidgetConfig } from '../../types/widget.js'
+import {
+  createSettingsStore,
+  defaultConfigurableSettings,
+  getDefaultConfigurableSettings,
+} from './createSettingsStore.js'
+import { SettingsStoreProvider } from './SettingsStore.js'
+
+const createLocalStorageMock = (): Storage => {
+  let store: Record<string, string> = {}
+  return {
+    getItem: (key) => (key in store ? store[key] : null),
+    setItem: (key, value) => {
+      store[key] = value
+    },
+    removeItem: (key) => {
+      delete store[key]
+    },
+    clear: () => {
+      store = {}
+    },
+    key: (index) => Object.keys(store)[index] ?? null,
+    get length() {
+      return Object.keys(store).length
+    },
+  }
+}
+
+const renderWidget = (config: WidgetConfig) =>
+  renderToString(
+    <SettingsStoreProvider config={config}>
+      <WidgetProvider config={config}>
+        <span />
+      </WidgetProvider>
+    </SettingsStoreProvider>
+  )
+
+describe('widget configurable defaults', () => {
+  const originalLocalStorageDescriptor = Object.getOwnPropertyDescriptor(
+    globalThis,
+    'localStorage'
+  )
+
+  beforeEach(() => {
+    Object.defineProperty(globalThis, 'localStorage', {
+      value: createLocalStorageMock(),
+      configurable: true,
+      writable: true,
+    })
+    defaultConfigurableSettings.slippage = undefined
+    defaultConfigurableSettings.routePriority = 'CHEAPEST'
+    defaultConfigurableSettings.gasPrice = 'normal'
+  })
+
+  afterEach(() => {
+    if (originalLocalStorageDescriptor) {
+      Object.defineProperty(
+        globalThis,
+        'localStorage',
+        originalLocalStorageDescriptor
+      )
+    } else {
+      Reflect.deleteProperty(globalThis, 'localStorage')
+    }
+  })
+
+  it('does not mutate defaults shared by other widget instances', () => {
+    renderWidget({
+      integrator: 'first-widget',
+      slippage: 0.01,
+      routePriority: 'FASTEST',
+    })
+
+    expect(defaultConfigurableSettings.slippage).toBeUndefined()
+    expect(defaultConfigurableSettings.routePriority).toBe('CHEAPEST')
+  })
+
+  it('keeps configurable defaults isolated between settings stores', () => {
+    const firstStore = createSettingsStore({
+      integrator: 'first-widget',
+      slippage: 0.01,
+      routePriority: 'FASTEST',
+    })
+    globalThis.localStorage.clear()
+    const secondStore = createSettingsStore({
+      integrator: 'second-widget',
+    })
+
+    expect(firstStore.getState().slippage).toBe('1')
+    expect(firstStore.getState().routePriority).toBe('FASTEST')
+    expect(secondStore.getState().slippage).toBeUndefined()
+    expect(secondStore.getState().routePriority).toBe('CHEAPEST')
+  })
+
+  it('resets with defaults from the current widget config', () => {
+    const store = createSettingsStore({
+      integrator: 'widget',
+    })
+
+    store.getState().reset(
+      [],
+      [],
+      getDefaultConfigurableSettings({
+        integrator: 'widget',
+        slippage: 0.02,
+        routePriority: 'FASTEST',
+      })
+    )
+
+    expect(store.getState().slippage).toBe('2')
+    expect(store.getState().routePriority).toBe('FASTEST')
+  })
+})

--- a/packages/widget/src/stores/settings/useSettingsActions.ts
+++ b/packages/widget/src/stores/settings/useSettingsActions.ts
@@ -4,7 +4,7 @@ import { useWidgetEvents } from '../../hooks/useWidgetEvents.js'
 import { WidgetEvent } from '../../types/events.js'
 import type { WidgetConfig } from '../../types/widget.js'
 import { deepEqual } from '../../utils/deepEqual.js'
-import { defaultConfigurableSettings } from './createSettingsStore.js'
+import { getDefaultConfigurableSettings } from './createSettingsStore.js'
 import { useSettingsStore } from './SettingsStore.js'
 import type {
   SettingsActions,
@@ -46,7 +46,11 @@ export const useSettingsActions = (): {
   setValue: ValueSetter<SettingsProps>
   setValues: (values: Partial<SettingsProps>) => void
   setDefaultSettings: (config?: WidgetConfig) => void
-  resetSettings: (bridges: string[], exchanges: string[]) => void
+  resetSettings: (
+    bridges: string[],
+    exchanges: string[],
+    config?: WidgetConfig
+  ) => void
   setToolValue: (
     toolType: SettingsToolType,
     tool: string,
@@ -88,41 +92,34 @@ export const useSettingsActions = (): {
       const routePriority = actions.getValue('routePriority')
       const gasPrice = actions.getValue('gasPrice')
 
-      const defaultSlippage = (config?.slippage || 0) * 100
-      const defaultRoutePriority = config?.routePriority
-
-      defaultConfigurableSettings.slippage = (
-        defaultSlippage || defaultConfigurableSettings.slippage
-      )?.toString()
-
-      defaultConfigurableSettings.routePriority =
-        defaultRoutePriority || defaultConfigurableSettings.routePriority
+      const configurableSettings = getDefaultConfigurableSettings(config)
 
       if (!slippage) {
-        setValueWithEmittedEvent(
-          'slippage',
-          defaultConfigurableSettings.slippage
-        )
+        setValueWithEmittedEvent('slippage', configurableSettings.slippage)
       }
       if (!routePriority) {
         setValueWithEmittedEvent(
           'routePriority',
-          defaultConfigurableSettings.routePriority
+          configurableSettings.routePriority
         )
       }
       if (!gasPrice) {
-        setValueWithEmittedEvent(
-          'gasPrice',
-          defaultConfigurableSettings.gasPrice
-        )
+        setValueWithEmittedEvent('gasPrice', configurableSettings.gasPrice)
       }
     },
     [actions, setValueWithEmittedEvent]
   )
 
   const resetWithEmittedEvents = useCallback(
-    (bridges: string[], exchanges: string[]) => {
-      emitEventOnChange(emitter, actions, actions.reset, bridges, exchanges)
+    (bridges: string[], exchanges: string[], config?: WidgetConfig) => {
+      emitEventOnChange(
+        emitter,
+        actions,
+        actions.reset,
+        bridges,
+        exchanges,
+        getDefaultConfigurableSettings(config)
+      )
     },
     [emitter, actions]
   )


### PR DESCRIPTION
## Which Linear task is linked to this PR?

None.

## Why was it implemented this way?

Configurable defaults like slippage and route priority were stored in a module-level object and updated when a widget config was applied.

That makes those defaults shared across widget instances. For example, rendering one widget with a 1% slippage default could leave that value behind for another widget that did not set one.

This change derives the configurable defaults per settings store instead of mutating the shared defaults. Reset also uses the current widget config, so runtime config changes keep the expected reset behavior.

## Testing

Added regression coverage for:

- keeping slippage and route priority defaults isolated between widget instances
- resetting with defaults from the current widget config

Validation passed with:

- widget regression tests
- `pnpm check`
- full workspace build
- `pnpm check:types`
- circular dependency check
- E2E Playground (dev mode)
- E2E Examples (20/20)
- E2E Playground (4/4 Playwright shards)

## Visual showcase (Screenshots or Videos)

N/A.

## Checklist before requesting a review

- [x] I have performed a self-review and testing of my code.
- [x] This pull request is focused and addresses a single problem.
- [x] No public API or documentation changes are required.
