### PR TITLE
ci: run wrangler through npx so the preview deploy survives pnpm 12

### DIFF
--- a/.github/workflows/deploy-test-app.yaml
+++ b/.github/workflows/deploy-test-app.yaml
@@ -121,7 +121,11 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_PAGES_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
         run: |
-          pnpm dlx wrangler@4.90.1 pages deploy ./packages/widget-playground-vite/dist/ --project-name "$PROJECT_NAME" --branch "$BRANCH_NAME"
+          # npx, not `pnpm dlx`: pnpm 12 fails an install whose packages have ignored
+          # build scripts, and a dlx install runs outside the workspace, so the
+          # `allowBuilds` list in pnpm-workspace.yaml never reaches it. wrangler needs
+          # esbuild and workerd built.
+          npx -y wrangler@4.90.1 pages deploy ./packages/widget-playground-vite/dist/ --project-name "$PROJECT_NAME" --branch "$BRANCH_NAME"
 
       - name: Resolve preview URL
         id: preview-url


### PR DESCRIPTION
## Which Linear task is linked to this PR?

None — CI infrastructure, found while checking the checks on #874.

## Why was it implemented this way?

Every preview deploy has failed since #870 migrated the repo to pnpm 12:

```
Error: ERR_PNPM_IGNORED_BUILDS
  × adding a new package
  ╰─▶ Ignored build scripts: esbuild@0.28.2, workerd@1.20260508.1
  help: Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.
```

pnpm 12 fails an install whose packages have ignored build scripts. `pnpm dlx` installs into its own store outside the workspace, so the `allowBuilds` list in `pnpm-workspace.yaml` never reaches it — and wrangler needs `esbuild` and `workerd` built. The deploy step is the only `pnpm dlx` call in the workflows; `delete-test-app.yaml` talks to the Cloudflare API directly and is unaffected.

`npx` installs with npm, which has no build-script gate, and it is already how the Jumper fork resolved the same breakage after its own pnpm 12 migration.

### Alternatives considered

- **Add `esbuild`/`workerd` to `allowBuilds`** — does not help. The list lives in `pnpm-workspace.yaml` and a `pnpm dlx` install never reads it. It would also grant build scripts to the whole workspace to fix one throwaway CLI install.
- **`pnpm dlx --allow-build=esbuild,workerd`** — works, but pins the transitive build requirements of wrangler into our workflow. A wrangler bump that adds a third native dependency breaks the deploy again.
- **Add wrangler as a devDependency** — puts a deploy-only CLI and its native deps into every developer's install.

## Visual showcase (Screenshots or Videos)

n/a — no user-facing change.

## Checklist before requesting a review

- [x] I have performed a self-review and testing of my code.
- [x] This pull request is focused and addresses a single problem.
- [ ] If this PR modifies the Widget API or adds new features that require documentation, I have updated the documentation in the [public-docs](https://github.com/lifinance/public-docs) repository.

### Testing

Reproduced locally against the repo's own pnpm 12.3.4, which reproduces the CI error byte for byte:

```
$ pnpm dlx wrangler@4.90.1 --version
Error: ERR_PNPM_IGNORED_BUILDS
  ╰─▶ Ignored build scripts: esbuild@0.28.2, workerd@1.20260508.1

$ npx -y wrangler@4.90.1 --version
4.90.1
```

The deploy job is gated on the `testing` label, so this PR carries it to exercise the changed step in CI.

### Note for #874

That PR's red `Publish to Cloudflare Pages` is this bug, not its own change. Once this merges, its merge ref picks up the fixed workflow and a re-run should go green — nothing to change there.
