### PR TITLE
fix(widget): match only the contract address when one is pasted (JUMEMB-97)

### DIFF
--- a/.changeset/address-search-matches-address-only.md
+++ b/.changeset/address-search-matches-address-only.md
@@ -1,0 +1,8 @@
+---
+'@lifi/widget': patch
+'@lifi/widget-provider': minor
+---
+
+Token search: a pasted contract address now matches only the token at that address, so impersonators that embed a real address in their name or symbol no longer appear. A query with surrounding whitespace resolves as well, instead of returning nothing — that held for an address and now holds for a name or symbol too.
+
+`useChainTypeFromAddress` also returns `getChainTypeFromTokenAddress`, which asks each configured provider's `SDKProvider.isTokenAddress`. A token identifier is not always shaped like a wallet address — Stellar tokens are `C…` contract ids and Sui tokens are `0x…::module::TYPE` coin types — so the widget no longer carries its own patterns for them. Bitcoin implements no token check, because the token list names its native coin `bitcoin`, so a `bitcoin` query stays a name search.

--- a/packages/widget-provider/src/hooks/useChainTypeFromAddress.test.ts
+++ b/packages/widget-provider/src/hooks/useChainTypeFromAddress.test.ts
@@ -1,0 +1,102 @@
+import { ChainType } from '@lifi/sdk'
+import { describe, expect, it, vi } from 'vitest'
+import { useChainTypeFromAddress } from './useChainTypeFromAddress.js'
+
+/**
+ * One provider per ecosystem, each recognizing only its own two fixtures, so a
+ * context bound to the wrong `ChainType` answers with the wrong one.
+ */
+const mocks = vi.hoisted(() => {
+  const provider = (wallet: string, token: string) => ({
+    sdkProvider: {
+      isAddress: (value: string) => value === wallet,
+      isTokenAddress: (value: string) => value === token,
+    },
+  })
+  return {
+    wallets: {
+      evm: '0x1111111111111111111111111111111111111111',
+      svm: 'SVMwallet11111111111111111111111111111111111',
+      utxo: '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa',
+      mvm: '0xmvmwallet',
+      tvm: 'TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t',
+      stl: 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
+    },
+    tokens: {
+      evm: '0x2222222222222222222222222222222222222222',
+      svm: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+      mvm: '0x2::sui::SUI',
+      tvm: 'TXLAQ63Xg1NAzckPwKHvzw7CSEmLMEqcdj',
+      stl: 'CCW67TSZV3SSS2HXMBQ5JFGCKJNXKZM7UQUWUZPUTHXSTZLEO7SJMI75',
+    },
+    provider,
+  }
+})
+
+vi.mock('react', () => ({
+  useMemo: <T>(factory: () => T) => factory(),
+  useCallback: <T>(callback: T) => callback,
+}))
+
+vi.mock('../contexts/EthereumContext.js', () => ({
+  useEthereumContext: () => mocks.provider(mocks.wallets.evm, mocks.tokens.evm),
+}))
+vi.mock('../contexts/SolanaContext.js', () => ({
+  useSolanaContext: () => mocks.provider(mocks.wallets.svm, mocks.tokens.svm),
+}))
+vi.mock('../contexts/SuiContext.js', () => ({
+  useSuiContext: () => mocks.provider(mocks.wallets.mvm, mocks.tokens.mvm),
+}))
+vi.mock('../contexts/TronContext.js', () => ({
+  useTronContext: () => mocks.provider(mocks.wallets.tvm, mocks.tokens.tvm),
+}))
+vi.mock('../contexts/StellarContext.js', () => ({
+  useStellarContext: () => mocks.provider(mocks.wallets.stl, mocks.tokens.stl),
+}))
+// BitcoinProvider ships no `isTokenAddress`, so the fake must not have one.
+vi.mock('../contexts/BitcoinContext.js', () => ({
+  useBitcoinContext: () => ({
+    sdkProvider: {
+      isAddress: (value: string) => value === mocks.wallets.utxo,
+    },
+  }),
+}))
+
+describe('useChainTypeFromAddress', () => {
+  it('maps each ecosystem to its own chain type by wallet address', () => {
+    const { getChainTypeFromAddress } = useChainTypeFromAddress()
+
+    expect(getChainTypeFromAddress(mocks.wallets.evm)).toBe(ChainType.EVM)
+    expect(getChainTypeFromAddress(mocks.wallets.svm)).toBe(ChainType.SVM)
+    expect(getChainTypeFromAddress(mocks.wallets.utxo)).toBe(ChainType.UTXO)
+    expect(getChainTypeFromAddress(mocks.wallets.mvm)).toBe(ChainType.MVM)
+    expect(getChainTypeFromAddress(mocks.wallets.tvm)).toBe(ChainType.TVM)
+    expect(getChainTypeFromAddress(mocks.wallets.stl)).toBe(ChainType.STL)
+  })
+
+  it('maps each ecosystem to its own chain type by token address', () => {
+    const { getChainTypeFromTokenAddress } = useChainTypeFromAddress()
+
+    expect(getChainTypeFromTokenAddress(mocks.tokens.evm)).toBe(ChainType.EVM)
+    expect(getChainTypeFromTokenAddress(mocks.tokens.svm)).toBe(ChainType.SVM)
+    expect(getChainTypeFromTokenAddress(mocks.tokens.mvm)).toBe(ChainType.MVM)
+    expect(getChainTypeFromTokenAddress(mocks.tokens.tvm)).toBe(ChainType.TVM)
+    expect(getChainTypeFromTokenAddress(mocks.tokens.stl)).toBe(ChainType.STL)
+  })
+
+  it('does not treat a wallet address as a token address', () => {
+    const { getChainTypeFromTokenAddress } = useChainTypeFromAddress()
+
+    expect(getChainTypeFromTokenAddress(mocks.wallets.stl)).toBeUndefined()
+    expect(getChainTypeFromTokenAddress(mocks.wallets.evm)).toBeUndefined()
+  })
+
+  it('finds no token chain type for Bitcoin, which implements no check', () => {
+    const { getChainTypeFromAddress, getChainTypeFromTokenAddress } =
+      useChainTypeFromAddress()
+
+    expect(getChainTypeFromAddress(mocks.wallets.utxo)).toBe(ChainType.UTXO)
+    expect(getChainTypeFromTokenAddress(mocks.wallets.utxo)).toBeUndefined()
+    expect(getChainTypeFromTokenAddress('bitcoin')).toBeUndefined()
+  })
+})

--- a/packages/widget-provider/src/hooks/useChainTypeFromAddress.ts
+++ b/packages/widget-provider/src/hooks/useChainTypeFromAddress.ts
@@ -1,14 +1,21 @@
 import { ChainType } from '@lifi/sdk'
-import { useCallback } from 'react'
+import { useCallback, useMemo } from 'react'
 import { useBitcoinContext } from '../contexts/BitcoinContext.js'
 import { useEthereumContext } from '../contexts/EthereumContext.js'
 import { useSolanaContext } from '../contexts/SolanaContext.js'
 import { useStellarContext } from '../contexts/StellarContext.js'
 import { useSuiContext } from '../contexts/SuiContext.js'
 import { useTronContext } from '../contexts/TronContext.js'
+import {
+  chainTypeFromAddress,
+  chainTypeFromTokenAddress,
+  type ProvidersByChainType,
+} from '../utils/chainTypeFromAddress.js'
 
 export const useChainTypeFromAddress = (): {
   getChainTypeFromAddress: (address: string) => ChainType | undefined
+  /** A token identifier, which several ecosystems shape unlike a wallet address. */
+  getChainTypeFromTokenAddress: (address: string) => ChainType | undefined
 } => {
   const { sdkProvider: ethereumProvider } = useEthereumContext()
   const { sdkProvider: solanaProvider } = useSolanaContext()
@@ -17,27 +24,15 @@ export const useChainTypeFromAddress = (): {
   const { sdkProvider: tronProvider } = useTronContext()
   const { sdkProvider: stellarProvider } = useStellarContext()
 
-  const getChainTypeFromAddress = useCallback(
-    (address: string): ChainType | undefined => {
-      if (ethereumProvider?.isAddress(address)) {
-        return ChainType.EVM
-      }
-      if (solanaProvider?.isAddress(address)) {
-        return ChainType.SVM
-      }
-      if (bitcoinProvider?.isAddress(address)) {
-        return ChainType.UTXO
-      }
-      if (suiProvider?.isAddress(address)) {
-        return ChainType.MVM
-      }
-      if (tronProvider?.isAddress(address)) {
-        return ChainType.TVM
-      }
-      if (stellarProvider?.isAddress(address)) {
-        return ChainType.STL
-      }
-    },
+  const providers = useMemo<ProvidersByChainType>(
+    () => ({
+      [ChainType.EVM]: ethereumProvider,
+      [ChainType.SVM]: solanaProvider,
+      [ChainType.UTXO]: bitcoinProvider,
+      [ChainType.MVM]: suiProvider,
+      [ChainType.TVM]: tronProvider,
+      [ChainType.STL]: stellarProvider,
+    }),
     [
       ethereumProvider,
       solanaProvider,
@@ -47,5 +42,18 @@ export const useChainTypeFromAddress = (): {
       stellarProvider,
     ]
   )
-  return { getChainTypeFromAddress: getChainTypeFromAddress }
+
+  const getChainTypeFromAddress = useCallback(
+    (address: string): ChainType | undefined =>
+      chainTypeFromAddress(providers, address),
+    [providers]
+  )
+
+  const getChainTypeFromTokenAddress = useCallback(
+    (address: string): ChainType | undefined =>
+      chainTypeFromTokenAddress(providers, address),
+    [providers]
+  )
+
+  return { getChainTypeFromAddress, getChainTypeFromTokenAddress }
 }

--- a/packages/widget-provider/src/utils/chainTypeFromAddress.test.ts
+++ b/packages/widget-provider/src/utils/chainTypeFromAddress.test.ts
@@ -1,0 +1,87 @@
+import { ChainType } from '@lifi/sdk'
+import { describe, expect, it } from 'vitest'
+import {
+  type AddressChecks,
+  chainTypeFromAddress,
+  chainTypeFromTokenAddress,
+  type ProvidersByChainType,
+} from './chainTypeFromAddress.js'
+
+const evmAddress = '0xB095274743941e953c746F9C228DA9c18Bb6ec29'
+const stellarContract =
+  'CCW67TSZV3SSS2HXMBQ5JFGCKJNXKZM7UQUWUZPUTHXSTZLEO7SJMI75'
+const stellarAccount =
+  'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN'
+
+/** Answers for the values it is given, as a provider does for its ecosystem. */
+const provider = (
+  addresses: string[],
+  tokenAddresses?: string[]
+): AddressChecks => ({
+  isAddress: (address) => addresses.includes(address),
+  ...(tokenAddresses && {
+    isTokenAddress: (address) => tokenAddresses.includes(address),
+  }),
+})
+
+describe('chainTypeFromAddress', () => {
+  it('returns the chain type of the provider that accepts the address', () => {
+    const providers: ProvidersByChainType = {
+      [ChainType.EVM]: provider([evmAddress]),
+      [ChainType.STL]: provider([stellarAccount]),
+    }
+
+    expect(chainTypeFromAddress(providers, stellarAccount)).toBe(ChainType.STL)
+  })
+
+  it('returns nothing when no configured provider accepts the address', () => {
+    const providers: ProvidersByChainType = {
+      [ChainType.EVM]: provider([evmAddress]),
+      [ChainType.STL]: undefined,
+    }
+
+    expect(chainTypeFromAddress(providers, stellarAccount)).toBeUndefined()
+  })
+})
+
+describe('chainTypeFromTokenAddress', () => {
+  it('asks the token check, not the wallet check', () => {
+    // A Stellar account holds a balance, and it names no token.
+    const providers: ProvidersByChainType = {
+      [ChainType.STL]: provider([stellarAccount], [stellarContract]),
+    }
+
+    expect(chainTypeFromTokenAddress(providers, stellarContract)).toBe(
+      ChainType.STL
+    )
+    expect(chainTypeFromTokenAddress(providers, stellarAccount)).toBeUndefined()
+  })
+
+  it('never matches a provider that implements no token check', () => {
+    // BitcoinProvider omits it: the token list names the native coin
+    // `bitcoin`, so UTXO has no token address format.
+    const providers: ProvidersByChainType = {
+      [ChainType.UTXO]: provider(['1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa']),
+    }
+
+    expect(chainTypeFromTokenAddress(providers, 'bitcoin')).toBeUndefined()
+    expect(
+      chainTypeFromTokenAddress(providers, '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa')
+    ).toBeUndefined()
+  })
+
+  it('returns the first chain type in detection order', () => {
+    const providers: ProvidersByChainType = {
+      [ChainType.EVM]: provider([], [evmAddress]),
+      [ChainType.TVM]: provider([], [evmAddress]),
+    }
+
+    expect(chainTypeFromTokenAddress(providers, evmAddress)).toBe(ChainType.EVM)
+  })
+
+  it('skips a provider that is not configured', () => {
+    expect(
+      chainTypeFromTokenAddress({ [ChainType.STL]: undefined }, stellarContract)
+    ).toBeUndefined()
+  })
+})

--- a/packages/widget-provider/src/utils/chainTypeFromAddress.ts
+++ b/packages/widget-provider/src/utils/chainTypeFromAddress.ts
@@ -1,0 +1,38 @@
+import { ChainType, type SDKProvider } from '@lifi/sdk'
+
+/** A provider is asked for its address checks only. */
+export type AddressChecks = Pick<SDKProvider, 'isAddress' | 'isTokenAddress'>
+
+export type ProvidersByChainType = Partial<Record<ChainType, AddressChecks>>
+
+// The first match wins, so this order decides a value two ecosystems accept.
+const detectionOrder = [
+  ChainType.EVM,
+  ChainType.SVM,
+  ChainType.UTXO,
+  ChainType.MVM,
+  ChainType.TVM,
+  ChainType.STL,
+]
+
+/** The chain type of the provider that accepts `address` as a wallet address. */
+export const chainTypeFromAddress = (
+  providers: ProvidersByChainType,
+  address: string
+): ChainType | undefined =>
+  detectionOrder.find((chainType) => providers[chainType]?.isAddress(address))
+
+/**
+ * The chain type of the provider that accepts `address` as a token identifier.
+ * A provider that implements no `isTokenAddress` has no token address format,
+ * so it never matches: `BitcoinProvider` omits the method because the token
+ * list names its native coin `bitcoin`. `isAddress` is never a fallback, since
+ * it accepts wallet addresses that name no token.
+ */
+export const chainTypeFromTokenAddress = (
+  providers: ProvidersByChainType,
+  address: string
+): ChainType | undefined =>
+  detectionOrder.find((chainType) =>
+    providers[chainType]?.isTokenAddress?.(address)
+  )

--- a/packages/widget/src/hooks/useDisplayedTokens.ts
+++ b/packages/widget/src/hooks/useDisplayedTokens.ts
@@ -2,10 +2,12 @@ import type { TokenExtended } from '@lifi/sdk'
 import { useMemo } from 'react'
 import type { FormType } from '../stores/form/types.js'
 import { usePinnedTokensStore } from '../stores/pinnedTokens/PinnedTokensStore.js'
-import { isSearchMatch } from '../utils/tokenList.js'
+import { createSearchMatcher } from '../utils/tokenList.js'
 import { useTokens } from './useTokens.js'
 
 export type IsPinnedToken = (chainId: number, tokenAddress: string) => boolean
+
+export type MatchesSearch = ReturnType<typeof createSearchMatcher>
 
 // Balance-free core shared by useTokenList and useTokenBalances.
 export const useDisplayedTokens = (
@@ -17,6 +19,11 @@ export const useDisplayedTokens = (
   allTokens: Record<number, TokenExtended[]> | undefined
   displayedTokensList: TokenExtended[]
   isPinnedToken: IsPinnedToken | undefined
+  /**
+   * The filter this search applies, built once here so every list that shows
+   * the same search — with balances or without — cannot disagree with it.
+   */
+  matchesSearch: MatchesSearch
   isTokensLoading: boolean
   isSearchLoading: boolean
 } => {
@@ -24,6 +31,7 @@ export const useDisplayedTokens = (
     allTokens,
     isLoading: isTokensLoading,
     isSearchLoading,
+    isAddressSearch,
   } = useTokens(formType, search, isAllNetworks ? undefined : selectedChainId)
 
   const pinnedTokens = usePinnedTokensStore((state) => state.pinnedTokens)
@@ -51,19 +59,25 @@ export const useDisplayedTokens = (
     return undefined
   }, [isAllNetworks, selectedChainId, pinnedTokens])
 
+  const matchesSearch = useMemo<MatchesSearch>(
+    () => createSearchMatcher(search, isAddressSearch),
+    [search, isAddressSearch]
+  )
+
   const displayedTokensList = useMemo(() => {
     const tokensByChain = isAllNetworks
       ? Object.values(allTokens ?? {}).flat()
       : selectedChainId
         ? allTokens?.[selectedChainId]
         : undefined
-    return tokensByChain?.filter((t) => isSearchMatch(t, search)) ?? []
-  }, [allTokens, isAllNetworks, selectedChainId, search])
+    return tokensByChain?.filter(matchesSearch) ?? []
+  }, [allTokens, isAllNetworks, selectedChainId, matchesSearch])
 
   return {
     allTokens,
     displayedTokensList,
     isPinnedToken,
+    matchesSearch,
     isTokensLoading,
     isSearchLoading,
   }

--- a/packages/widget/src/hooks/useTokenBalances.test.ts
+++ b/packages/widget/src/hooks/useTokenBalances.test.ts
@@ -1,0 +1,128 @@
+import type { TokenExtended } from '@lifi/sdk'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useTokenBalances } from './useTokenBalances.js'
+
+const mocks = vi.hoisted(() => ({
+  useTokens: vi.fn(),
+  useTokenBalancesQueries: vi.fn(),
+}))
+
+vi.mock('react', () => ({
+  useMemo: <T>(factory: () => T) => factory(),
+}))
+
+vi.mock('../providers/WidgetProvider/WidgetProvider.js', () => ({
+  useWidgetConfig: () => ({}),
+}))
+
+vi.mock('../stores/pinnedTokens/PinnedTokensStore.js', () => ({
+  usePinnedTokensStore: <T>(
+    selector: (state: { pinnedTokens: Record<number, string[]> }) => T
+  ) => selector({ pinnedTokens: {} }),
+}))
+
+vi.mock('../stores/settings/useSettings.js', () => ({
+  useSettings: () => ({ smallBalanceThreshold: undefined }),
+}))
+
+vi.mock('./useAccountsBalancesData.js', () => ({
+  useAccountsBalancesData: () => ({ data: undefined, isLoading: false }),
+}))
+
+vi.mock('./useTokenBalancesQueries.js', () => ({
+  useTokenBalancesQueries: mocks.useTokenBalancesQueries,
+}))
+
+vi.mock('./useTokens.js', () => ({
+  useTokens: mocks.useTokens,
+}))
+
+const baseChainId = 8453
+const laptopAddress = '0xB095274743941e953c746F9C228DA9c18Bb6ec29'
+const laptop: TokenExtended = {
+  chainId: baseChainId,
+  address: laptopAddress,
+  symbol: 'LAPTOP',
+  name: 'LAPTOP',
+  decimals: 18,
+  priceUSD: '0.001',
+}
+// An impersonator from the search index: the real address sits in its name.
+const impersonator: TokenExtended = {
+  chainId: baseChainId,
+  address: '0x7DAAad2659eb9Cd4e78985117F218a58992a2eEa',
+  symbol: 'LAPTOP',
+  name: `Hunter Biden's Laptop ${laptopAddress}`,
+  decimals: 18,
+  priceUSD: '0',
+}
+const usdc: TokenExtended = {
+  chainId: baseChainId,
+  address: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+  symbol: 'USDC',
+  name: 'USD Coin',
+  decimals: 6,
+  priceUSD: '1',
+}
+
+const addressesOf = (tokens: { address: string }[]) =>
+  tokens.map((token) => token.address)
+
+describe('useTokenBalances search', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.useTokenBalancesQueries.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: false,
+    })
+    mocks.useTokens.mockReturnValue({
+      allTokens: { [baseChainId]: [usdc, impersonator, laptop] },
+      isLoading: false,
+      isSearchLoading: false,
+      isAddressSearch: false,
+    })
+  })
+
+  it('lists only the token at the searched address', () => {
+    mocks.useTokens.mockReturnValue({
+      allTokens: { [baseChainId]: [usdc, impersonator, laptop] },
+      isLoading: false,
+      isSearchLoading: false,
+      isAddressSearch: true,
+    })
+
+    const { tokens } = useTokenBalances(baseChainId, 'to', false, laptopAddress)
+
+    expect(addressesOf(tokens)).toEqual([laptopAddress])
+  })
+
+  it('hides an impersonator at the searched address even when the wallet holds it', () => {
+    mocks.useTokens.mockReturnValue({
+      allTokens: { [baseChainId]: [usdc, impersonator, laptop] },
+      isLoading: false,
+      isSearchLoading: false,
+      isAddressSearch: true,
+    })
+    mocks.useTokenBalancesQueries.mockReturnValue({
+      data: [
+        { ...impersonator, amount: 5_000_000_000_000_000_000n },
+        { ...laptop, amount: 1_000_000_000_000_000_000n },
+      ],
+      isLoading: false,
+      isError: false,
+    })
+
+    const { tokens } = useTokenBalances(baseChainId, 'to', false, laptopAddress)
+
+    expect(addressesOf(tokens)).toEqual([laptopAddress])
+  })
+
+  it('keeps name and symbol matches for a text search', () => {
+    const { tokens } = useTokenBalances(baseChainId, 'to', false, 'laptop')
+
+    expect(new Set(addressesOf(tokens))).toEqual(
+      new Set([impersonator.address, laptopAddress])
+    )
+  })
+})

--- a/packages/widget/src/hooks/useTokenBalances.ts
+++ b/packages/widget/src/hooks/useTokenBalances.ts
@@ -4,11 +4,7 @@ import type { FormType } from '../stores/form/types.js'
 import { useSettings } from '../stores/settings/useSettings.js'
 import type { TokenAmount } from '../types/token.js'
 import { formatTokenPrice } from '../utils/format.js'
-import {
-  hoistNativeToken,
-  isSearchMatch,
-  processTokenList,
-} from '../utils/tokenList.js'
+import { hoistNativeToken, processTokenList } from '../utils/tokenList.js'
 import { useAccountsBalancesData } from './useAccountsBalancesData.js'
 import { useDisplayedTokens } from './useDisplayedTokens.js'
 import { useTokenBalancesQueries } from './useTokenBalancesQueries.js'
@@ -31,6 +27,7 @@ export const useTokenBalances = (
     allTokens,
     displayedTokensList,
     isPinnedToken,
+    matchesSearch,
     isTokensLoading,
     isSearchLoading,
   } = useDisplayedTokens(selectedChainId, formType, isAllNetworks, search)
@@ -77,10 +74,10 @@ export const useTokenBalances = (
       // Check if token is in displayed list and has amount
       const isInDisplayedList = displayedTokensSet.has(tokenKey) && token.amount
       // Check if it matches search (for cached appended tokens)
-      const matchesSearch = isSearchMatch(token, search)
+      const matchesTheSearch = matchesSearch(token)
 
       // Filter: only include tokens that match our criteria
-      if (!isInDisplayedList && !matchesSearch) {
+      if (!isInDisplayedList && !matchesTheSearch) {
         return acc
       }
 
@@ -111,7 +108,7 @@ export const useTokenBalances = (
   }, [
     allTokensWithBalances,
     displayedTokensList,
-    search,
+    matchesSearch,
     selectedChainId,
     isAllNetworks,
     smallBalanceThreshold,

--- a/packages/widget/src/hooks/useTokens.test.ts
+++ b/packages/widget/src/hooks/useTokens.test.ts
@@ -1,0 +1,232 @@
+import { ChainId, ChainType, type TokenExtended } from '@lifi/sdk'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useTokens } from './useTokens.js'
+
+const mocks = vi.hoisted(() => ({
+  getTokens: vi.fn(),
+  getToken: vi.fn(),
+  getChainTypeFromTokenAddress: vi.fn(),
+  useQuery: vi.fn(),
+}))
+
+vi.mock('@lifi/sdk', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@lifi/sdk')>()),
+  getTokens: mocks.getTokens,
+  getToken: mocks.getToken,
+}))
+
+vi.mock('@tanstack/react-query', () => ({
+  useQuery: mocks.useQuery,
+}))
+
+vi.mock('react', () => ({
+  useMemo: <T>(factory: () => T) => factory(),
+}))
+
+vi.mock('@lifi/widget-provider', () => ({
+  useChainTypeFromAddress: () => ({
+    getChainTypeFromTokenAddress: mocks.getChainTypeFromTokenAddress,
+  }),
+}))
+
+vi.mock('../providers/SDKClientProvider.js', () => ({
+  useSDKClient: () => sdkClient,
+}))
+
+vi.mock('../providers/WidgetProvider/WidgetProvider.js', () => ({
+  useWidgetConfig: () => ({}),
+}))
+
+vi.mock('./useAvailableChains.js', () => ({
+  useAvailableChains: () => ({ chains: [] }),
+}))
+
+const sdkClient = { name: 'sdk-client' }
+const baseChainId = 8453
+const laptopAddress = '0xB095274743941e953c746F9C228DA9c18Bb6ec29'
+const laptop: TokenExtended = {
+  chainId: baseChainId,
+  address: laptopAddress,
+  symbol: 'LAPTOP',
+  name: 'LAPTOP',
+  decimals: 18,
+  priceUSD: '0.001',
+}
+// The search index matches names too, so a token that embeds the real
+// address in its name comes back for an address query.
+const impersonator: TokenExtended = {
+  chainId: baseChainId,
+  address: '0x7DAAad2659eb9Cd4e78985117F218a58992a2eEa',
+  symbol: 'LAPTOP',
+  name: `Hunter Biden's Laptop ${laptopAddress}`,
+  decimals: 18,
+  priceUSD: '0',
+}
+
+/** The options of the search query, picked by its key rather than its call order. */
+const searchQueryOptions = () =>
+  mocks.useQuery.mock.calls
+    .map(([options]) => options)
+    .find((options) => String(options.queryKey[0]).includes('tokens-search'))
+
+/** Renders the hook and runs the search query's fetcher. */
+const runSearch = async (
+  search: string,
+  chainId?: number,
+  signal: AbortSignal = new AbortController().signal
+) => {
+  const result = useTokens('to', search, chainId)
+  const options = searchQueryOptions()
+  const tokens = await options.queryFn({ queryKey: options.queryKey, signal })
+  return { ...result, tokens }
+}
+
+describe('useTokens search', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.useQuery.mockReturnValue({ data: undefined, isLoading: false })
+    mocks.getChainTypeFromTokenAddress.mockImplementation((address: string) =>
+      // The Ethereum provider accepts a token address in any letter case.
+      address.toLowerCase() === laptopAddress.toLowerCase()
+        ? ChainType.EVM
+        : undefined
+    )
+    mocks.getToken.mockResolvedValue(laptop)
+  })
+
+  it('flags an address query for the list filter', () => {
+    expect(useTokens('to', laptopAddress, baseChainId).isAddressSearch).toBe(
+      true
+    )
+    expect(useTokens('to', 'laptop', baseChainId).isAddressSearch).toBe(false)
+  })
+
+  describe('with a selected chain', () => {
+    it('fetches the token by address when the index returns only name matches', async () => {
+      mocks.getTokens.mockResolvedValue({
+        tokens: { [baseChainId]: [impersonator] },
+      })
+
+      const { tokens } = await runSearch(laptopAddress, baseChainId)
+
+      expect(mocks.getToken).toHaveBeenCalledWith(
+        sdkClient,
+        baseChainId,
+        laptopAddress,
+        expect.anything()
+      )
+      // Appended, not replacing: the impersonators stay in the response and
+      // the address filter is what hides them.
+      expect(tokens[baseChainId]).toEqual([impersonator, laptop])
+    })
+
+    it('finds the index token when the pasted address differs in letter case', async () => {
+      // The index answers with the checksummed address; a paste often is not.
+      mocks.getTokens.mockResolvedValue({
+        tokens: { [baseChainId]: [impersonator, laptop] },
+      })
+
+      await runSearch(laptopAddress.toLowerCase(), baseChainId)
+
+      expect(mocks.getToken).not.toHaveBeenCalled()
+    })
+
+    it('does not fetch by address when the index has the token at that address', async () => {
+      mocks.getTokens.mockResolvedValue({
+        tokens: { [baseChainId]: [impersonator, laptop] },
+      })
+
+      const { tokens } = await runSearch(laptopAddress, baseChainId)
+
+      expect(mocks.getToken).not.toHaveBeenCalled()
+      expect(tokens[baseChainId]).toEqual([impersonator, laptop])
+    })
+
+    it('does not fetch by address for a text query with results', async () => {
+      mocks.getTokens.mockResolvedValue({
+        tokens: { [baseChainId]: [impersonator] },
+      })
+
+      await runSearch('laptop', baseChainId)
+
+      expect(mocks.getToken).not.toHaveBeenCalled()
+    })
+
+    it('fetches by address when the index returns nothing for the chain', async () => {
+      mocks.getTokens.mockResolvedValue({ tokens: {} })
+
+      const { tokens } = await runSearch(laptopAddress, baseChainId)
+
+      expect(tokens[baseChainId]).toEqual([laptop])
+    })
+  })
+
+  describe('in all networks', () => {
+    it('keeps the token the index found on another chain without a lookup', async () => {
+      mocks.getTokens.mockResolvedValue({
+        tokens: { [baseChainId]: [impersonator, laptop] },
+      })
+
+      const { tokens } = await runSearch(laptopAddress)
+
+      expect(mocks.getToken).not.toHaveBeenCalled()
+      expect(tokens).toEqual({ [baseChainId]: [impersonator, laptop] })
+    })
+
+    it('keeps the index results when the lookup on the guessed chain fails', async () => {
+      mocks.getTokens.mockResolvedValue({
+        tokens: { [baseChainId]: [impersonator] },
+      })
+      mocks.getToken.mockRejectedValue(new Error('HTTP 400'))
+
+      const { tokens } = await runSearch(laptopAddress)
+
+      expect(mocks.getToken).toHaveBeenCalledWith(
+        sdkClient,
+        ChainId.ETH,
+        laptopAddress,
+        expect.anything()
+      )
+      expect(tokens).toEqual({ [baseChainId]: [impersonator] })
+    })
+
+    it('rethrows when the lookup is aborted', async () => {
+      mocks.getTokens.mockResolvedValue({ tokens: {} })
+      mocks.getToken.mockRejectedValue(new Error('aborted'))
+      const controller = new AbortController()
+      controller.abort()
+
+      await expect(
+        runSearch(laptopAddress, undefined, controller.signal)
+      ).rejects.toThrow('aborted')
+    })
+  })
+
+  describe('query text', () => {
+    it('trims the query before it reaches the API', async () => {
+      mocks.getTokens.mockResolvedValue({
+        tokens: { [baseChainId]: [laptop] },
+      })
+
+      useTokens('to', `  ${laptopAddress}\n`, baseChainId)
+      const options = searchQueryOptions()
+      await options.queryFn({
+        queryKey: options.queryKey,
+        signal: new AbortController().signal,
+      })
+
+      expect(options.queryKey[1]).toBe(laptopAddress)
+      expect(mocks.getTokens).toHaveBeenCalledWith(
+        sdkClient,
+        expect.objectContaining({ search: laptopAddress }),
+        expect.anything()
+      )
+    })
+
+    it('does not query for a whitespace-only search', () => {
+      useTokens('to', '   ', baseChainId)
+
+      expect(searchQueryOptions().enabled).toBe(false)
+    })
+  })
+})

--- a/packages/widget/src/hooks/useTokens.ts
+++ b/packages/widget/src/hooks/useTokens.ts
@@ -12,6 +12,7 @@ import { useSDKClient } from '../providers/SDKClientProvider.js'
 import { useWidgetConfig } from '../providers/WidgetProvider/WidgetProvider.js'
 import type { FormType } from '../stores/form/types.js'
 import type { TokensByChain } from '../types/token.js'
+import { isAddressQuery } from '../utils/address.js'
 import { defaultChainIdsByType } from '../utils/chainType.js'
 import { isItemAllowed } from '../utils/item.js'
 import { getQueryKey } from '../utils/queries.js'
@@ -32,6 +33,8 @@ export const useTokens = (
   allTokens: Record<number, TokenExtended[]> | undefined
   isLoading: boolean
   isSearchLoading: boolean
+  /** The search is a contract address, so only the token at that address matches. */
+  isAddressSearch: boolean
 } => {
   const {
     tokens: configTokens,
@@ -39,7 +42,16 @@ export const useTokens = (
     keyPrefix,
   } = useWidgetConfig()
   const sdkClient = useSDKClient()
-  const { getChainTypeFromAddress } = useChainTypeFromAddress()
+  const { getChainTypeFromTokenAddress } = useChainTypeFromAddress()
+  // A pasted address often carries a trailing space or newline, which the
+  // API rejects. Trim once so the key, the requests and the checks agree.
+  const trimmedSearch = search?.trim()
+  // Keep this memoized, and out of any per-token loop: a provider validates by
+  // parsing, which costs microseconds per call rather than nanoseconds.
+  const isAddressSearch = useMemo(
+    () => isAddressQuery(trimmedSearch, getChainTypeFromTokenAddress),
+    [trimmedSearch, getChainTypeFromTokenAddress]
+  )
 
   // Main tokens cache - verified tokens from API
   const { data: verifiedTokens, isLoading } = useQuery({
@@ -82,13 +94,14 @@ export const useTokens = (
 
   // Search tokens cache - unverified tokens from search
   const { data: searchTokens, isLoading: isSearchLoading } = useQuery({
-    queryKey: [getQueryKey('tokens-search', keyPrefix), search, chainId],
+    queryKey: [
+      getQueryKey('tokens-search', keyPrefix),
+      trimmedSearch,
+      chainId,
+      isAddressSearch,
+    ] as const,
     queryFn: async ({ queryKey, signal }) => {
-      const [, searchQuery, searchChainId] = queryKey as [
-        string,
-        string,
-        number,
-      ]
+      const [, searchQuery, searchChainId, addressSearch] = queryKey
       const chainTypes = [
         ChainType.EVM,
         ChainType.SVM,
@@ -111,32 +124,60 @@ export const useTokens = (
         { signal }
       )
 
-      // If the chainId is not provided, try to get it from the search query
-      let _chainId = searchChainId
-      if (!_chainId) {
-        const chainType = getChainTypeFromAddress(searchQuery)
-        if (chainType && chainType in defaultChainIdsByType) {
-          _chainId = defaultChainIdsByType[chainType]
-        }
-      }
-
-      // Fallback: If the main search returned no tokens for the specific chainId,
-      // fetch a single token using the /token endpoint
-      if (_chainId && searchQuery) {
-        const existingTokens = tokensResponse.tokens[_chainId] || []
-        if (!existingTokens.length) {
-          const token = await getToken(sdkClient, _chainId, searchQuery, {
-            signal,
-          })
-          if (token) {
-            tokensResponse.tokens[_chainId] = [token]
+      // Fallback: fetch a single token from the /token endpoint when the
+      // search did not deliver one. Look it up on the selected chain, or
+      // without one on the default chain of the address format.
+      if (searchQuery) {
+        const chainType = getChainTypeFromTokenAddress(searchQuery)
+        const lookupChainId =
+          searchChainId ??
+          (chainType ? defaultChainIdsByType[chainType] : undefined)
+        if (lookupChainId) {
+          const existingTokens = tokensResponse.tokens[lookupChainId] ?? []
+          // The search index also matches names, so for an address query
+          // impersonators that embed the address can fill the list while the
+          // token at that address is missing. Without a selected chain the
+          // token can sit on any chain of the response.
+          const hasTokenAtAddress = () => {
+            const address = searchQuery.toLowerCase()
+            const candidates = searchChainId
+              ? [existingTokens]
+              : Object.values(tokensResponse.tokens)
+            return candidates.some((tokens) =>
+              tokens.some((token) => token.address?.toLowerCase() === address)
+            )
+          }
+          const isTokenMissing = addressSearch
+            ? !hasTokenAtAddress()
+            : !existingTokens.length
+          if (isTokenMissing) {
+            try {
+              const token = await getToken(
+                sdkClient,
+                lookupChainId,
+                searchQuery,
+                { signal }
+              )
+              if (token) {
+                tokensResponse.tokens[lookupChainId] = [
+                  ...existingTokens,
+                  token,
+                ]
+              }
+            } catch (error) {
+              // A guessed chain may not hold the token (HTTP 400). Keep the
+              // search results instead of failing the whole query.
+              if (signal.aborted) {
+                throw error
+              }
+            }
           }
         }
       }
 
       return tokensResponse.tokens as TokensByChain
     },
-    enabled: !!search,
+    enabled: !!trimmedSearch,
     refetchInterval,
     staleTime: refetchInterval,
   })
@@ -170,5 +211,6 @@ export const useTokens = (
     allTokens,
     isLoading,
     isSearchLoading,
+    isAddressSearch,
   }
 }

--- a/packages/widget/src/utils/address.test.ts
+++ b/packages/widget/src/utils/address.test.ts
@@ -1,0 +1,69 @@
+import { ChainType } from '@lifi/sdk'
+import { describe, expect, it } from 'vitest'
+import { isAddressQuery } from './address.js'
+
+const evmAddress = '0xB095274743941e953c746F9C228DA9c18Bb6ec29'
+const solanaMint = 'LAPvT8fzcPt7WzcrEvdQVYWWJMvCZz2yLJ25b1SwTtC'
+const stellarContract =
+  'CCW67TSZV3SSS2HXMBQ5JFGCKJNXKZM7UQUWUZPUTHXSTZLEO7SJMI75'
+
+/**
+ * Stands in for the providers' token check. It recognizes the values the
+ * Ethereum, Solana and Stellar providers accept as token identifiers, as
+ * `getChainTypeFromTokenAddress` does. `bitcoin` is absent: the Bitcoin
+ * provider implements no token check.
+ */
+const getChainTypeFromTokenAddress = (
+  address: string
+): ChainType | undefined => {
+  // A provider validates by parsing, so it can throw on a value it cannot
+  // read: `@solana/kit` does for `undefined`. The guard in `isAddressQuery`
+  // is what keeps one from ever seeing such a value.
+  if (!address.trim()) {
+    throw new Error('empty address')
+  }
+  if (address === evmAddress) {
+    return ChainType.EVM
+  }
+  if (address === solanaMint) {
+    return ChainType.SVM
+  }
+  if (address === stellarContract) {
+    return ChainType.STL
+  }
+  return undefined
+}
+
+describe('isAddressQuery', () => {
+  it('accepts a value the token check recognizes', () => {
+    expect(isAddressQuery(solanaMint, getChainTypeFromTokenAddress)).toBe(true)
+    expect(isAddressQuery(stellarContract, getChainTypeFromTokenAddress)).toBe(
+      true
+    )
+  })
+
+  it('rejects free text', () => {
+    expect(isAddressQuery('laptop', getChainTypeFromTokenAddress)).toBe(false)
+    expect(isAddressQuery('Hunter Biden', getChainTypeFromTokenAddress)).toBe(
+      false
+    )
+  })
+
+  it('rejects the Bitcoin native token identifier, which is a name', () => {
+    // A text search for `bitcoin` returns every token named after it, so the
+    // list must keep matching names and symbols.
+    expect(isAddressQuery('bitcoin', getChainTypeFromTokenAddress)).toBe(false)
+  })
+
+  it('ignores surrounding whitespace', () => {
+    expect(
+      isAddressQuery(`  ${evmAddress}\n`, getChainTypeFromTokenAddress)
+    ).toBe(true)
+  })
+
+  it('rejects an empty query', () => {
+    expect(isAddressQuery('', getChainTypeFromTokenAddress)).toBe(false)
+    expect(isAddressQuery('   ', getChainTypeFromTokenAddress)).toBe(false)
+    expect(isAddressQuery(undefined, getChainTypeFromTokenAddress)).toBe(false)
+  })
+})

--- a/packages/widget/src/utils/address.ts
+++ b/packages/widget/src/utils/address.ts
@@ -1,0 +1,21 @@
+import type { ChainType } from '@lifi/sdk'
+
+/**
+ * True when a token search query is a contract address rather than free text.
+ * `getChainTypeFromTokenAddress` asks the configured providers' own
+ * `isTokenAddress` (see `useChainTypeFromAddress`), so it covers the token
+ * identifier of every ecosystem. Two consequences follow. `bitcoin` stays a
+ * name search, because the Bitcoin provider implements no token check. And an
+ * ecosystem is not detected unless the host configures its provider from
+ * `@lifi/sdk` 4.7.0 or later, even when its chains are listed.
+ */
+export const isAddressQuery = (
+  query: string | undefined,
+  getChainTypeFromTokenAddress: (address: string) => ChainType | undefined
+): boolean => {
+  const value = query?.trim()
+  if (!value) {
+    return false
+  }
+  return getChainTypeFromTokenAddress(value) !== undefined
+}

--- a/packages/widget/src/utils/tokenList.test.ts
+++ b/packages/widget/src/utils/tokenList.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import type { TokenAmount } from '../types/token.js'
-import { hoistNativeToken } from './tokenList.js'
+import { createSearchMatcher, hoistNativeToken } from './tokenList.js'
 
 const makeToken = (
   address: string,
@@ -66,5 +66,96 @@ describe('hoistNativeToken', () => {
     const result = hoistNativeToken(tokens, 1)
     expect(result).toHaveLength(2)
     expect(result.filter((t) => t.address === '0xBBB')).toHaveLength(1)
+  })
+})
+
+describe('createSearchMatcher', () => {
+  const laptopAddress = '0xB095274743941e953c746F9C228DA9c18Bb6ec29'
+  const laptop = makeToken(laptopAddress, {
+    chainId: 8453,
+    symbol: 'LAPTOP',
+    name: 'LAPTOP',
+  })
+  // Impersonators seen in the search index: the real address embedded in the
+  // name or used as the symbol.
+  const nameImpersonator = makeToken(
+    '0x7DAAad2659eb9Cd4e78985117F218a58992a2eEa',
+    {
+      chainId: 8453,
+      symbol: 'LAPTOP',
+      name: `Hunter Biden's Laptop ${laptopAddress}`,
+    }
+  )
+  const symbolImpersonator = makeToken(
+    '5doEMYL3x1USgYeU54JVGyw7Ue8LSRmtj2bXVQAec29',
+    {
+      chainId: 1151111081099710,
+      symbol: laptopAddress,
+      name: 'LAPTOP',
+    }
+  )
+
+  it('matches every token without a search', () => {
+    expect(createSearchMatcher(undefined, false)(nameImpersonator)).toBe(true)
+    expect(createSearchMatcher('', false)(nameImpersonator)).toBe(true)
+  })
+
+  describe('text search', () => {
+    it('matches a name, symbol, or address fragment in any letter case', () => {
+      expect(createSearchMatcher('hunter', false)(nameImpersonator)).toBe(true)
+      expect(createSearchMatcher('laptop', false)(laptop)).toBe(true)
+      expect(createSearchMatcher('0xb095', false)(laptop)).toBe(true)
+    })
+
+    it('rejects a token that matches nothing', () => {
+      expect(createSearchMatcher('usdc', false)(laptop)).toBe(false)
+    })
+
+    it('ignores surrounding whitespace, as the address search does', () => {
+      // `useTokens` trims before it asks the API, so an untrimmed filter
+      // discards the results the trimmed request just returned.
+      expect(createSearchMatcher('  laptop  ', false)(laptop)).toBe(true)
+      expect(createSearchMatcher('laptop\n', false)(laptop)).toBe(true)
+    })
+
+    it('matches every token when the query is only whitespace', () => {
+      expect(createSearchMatcher('   ', false)(laptop)).toBe(true)
+    })
+  })
+
+  describe('address search', () => {
+    it('matches only the token at that address', () => {
+      expect(createSearchMatcher(laptopAddress, true)(laptop)).toBe(true)
+      expect(createSearchMatcher(laptopAddress, true)(nameImpersonator)).toBe(
+        false
+      )
+      expect(createSearchMatcher(laptopAddress, true)(symbolImpersonator)).toBe(
+        false
+      )
+    })
+
+    it('ignores the letter case of the address', () => {
+      expect(
+        createSearchMatcher(laptopAddress.toLowerCase(), true)(laptop)
+      ).toBe(true)
+      expect(
+        createSearchMatcher(
+          laptopAddress,
+          true
+        )(makeToken(laptopAddress.toLowerCase(), { chainId: 8453 }))
+      ).toBe(true)
+    })
+
+    it('ignores surrounding whitespace', () => {
+      expect(createSearchMatcher(`  ${laptopAddress}\n`, true)(laptop)).toBe(
+        true
+      )
+    })
+
+    it('does not match an address prefix', () => {
+      expect(
+        createSearchMatcher(laptopAddress.slice(0, -1), true)(laptop)
+      ).toBe(false)
+    })
   })
 })

--- a/packages/widget/src/utils/tokenList.ts
+++ b/packages/widget/src/utils/tokenList.ts
@@ -256,23 +256,36 @@ const processedTypedTokens = (
   }
 }
 
-export const isSearchMatch = (
-  token: TokenExtended | TokenAmountExtended,
-  search?: string
-): boolean => {
-  if (!search) {
-    return true
+/**
+ * Builds the filter for one search, so the query is normalized once instead of
+ * once per token: an all-networks list holds tens of thousands of rows, where
+ * normalizing per row costs more than the matching itself. Binding the mode
+ * here also keeps every call site of one search on the same rule.
+ *
+ * An address search matches the token at that address only. Impersonators
+ * embed a real address in their name or symbol, so a substring match on
+ * those fields would surface them for the very query meant to avoid them.
+ */
+export const createSearchMatcher = (
+  search: string | undefined,
+  isAddressSearch: boolean
+): ((token: TokenExtended | TokenAmountExtended) => boolean) => {
+  const searchTerm = search?.trim().toLowerCase()
+
+  if (!searchTerm) {
+    return () => true
   }
 
-  const searchLowerCase = search.toLowerCase()
-  return (
-    token.name?.toLowerCase().includes(searchLowerCase) ||
-    token.symbol
-      ?.replaceAll('₮', 'T')
-      .toLowerCase()
-      .includes(searchLowerCase) ||
-    token.address?.toLowerCase().includes(searchLowerCase)
-  )
+  if (isAddressSearch) {
+    return (token) => token.address?.toLowerCase() === searchTerm
+  }
+
+  return (token) =>
+    Boolean(
+      token.name?.toLowerCase().includes(searchTerm) ||
+        token.symbol?.replaceAll('₮', 'T').toLowerCase().includes(searchTerm) ||
+        token.address?.toLowerCase().includes(searchTerm)
+    )
 }
 
 /**


### PR DESCRIPTION
## Which Linear task is linked to this PR?

[JUMEMB-97 — Search: when a contract address (CA) is entered, match only on the CA — not on token name or symbol](https://linear.app/lifi-linear/issue/JUMEMB-97/search-when-a-contract-address-ca-is-entered-match-only-on-the-ca-not)

Ported from the Jumper fork's [jumperexchange/jumper-widget#112](https://github.com/jumperexchange/jumper-widget/pull/112). The same defect is in this repo.

## Why was it implemented this way?

**The scam surface.** `isSearchMatch` matched the query as a substring of a token's name, symbol *and* address. Attackers exploit that by minting tokens whose name embeds a legitimate contract address, so the impersonator ranks alongside — or instead of — the token the user actually asked for. The API matches names too, so it hands us the look-alikes: a search for `0xB095…ec29` (LAPTOP on Base) returns the real token plus **fourteen** impersonators across Base and Solana, several with the pasted address as their entire name.

**Detection asks the SDK providers.** `SDKProvider.isAddress` validates a *wallet*, and several ecosystems shape a token identifier differently. Rather than carry a second copy of rules that belong to each ecosystem's library, the check lives in the SDK as `SDKProvider.isTokenAddress` ([lifinance/sdk#471](https://github.com/lifinance/sdk/pull/471), released in `@lifi/sdk@4.7.0`, which `main` already depends on since #870), and this PR asks for it:

| Provider | Answers with | Relation to `isAddress` |
| --- | --- | --- |
| ethereum | viem `isAddress`, `strict: false` | wider — a pasted address keeps whatever letter case its source used, and EIP-55 rejects the wrong one |
| solana | `isAddress` from `@solana/kit` | identical — a mint uses the wallet format |
| tron | `TronWeb.isAddress` | identical |
| stellar | `StrKey.isValidContract` | disjoint — tokens are `C…` Soroban contracts, and `isAddress` takes only `G…` accounts |
| sui | `isValidStructTag` | disjoint — tokens are `0x…::module::TYPE` coin types |
| bitcoin | nothing; the method is deliberately absent | the token list names the native coin `bitcoin` rather than giving it an address |

So `packages/widget` holds no address format at all, and it never falls back to `isAddress`: for Bitcoin that would accept wallet addresses which name no token, and reject `bitcoin`, the one real token identifier on that chain. A `bitcoin` query therefore stays a name search, which matters — a text search for it returns over a thousand tokens.

`useChainTypeFromAddress` gains `getChainTypeFromTokenAddress` beside the wallet resolver it already exposed. Both come from one `chainTypeFromAddress.ts` with a single detection order, so the two cannot drift apart, and the hook keeps one subscription to the six provider contexts rather than two.

**One matcher per search, owned by `useDisplayedTokens`.** `isSearchMatch(token, search)` becomes `createSearchMatcher(search, isAddressSearch)`, which normalizes the query once and returns the predicate. Measured over 30k rows on the fork, normalizing per token cost 3.42 ms against 1.71 ms for the matching itself, so the query was the more expensive half of the filter. `useDisplayedTokens` builds the one matcher and returns it, so the displayed list and the balances reduce in `useTokenBalances` cannot disagree — a wallet that holds an impersonator does not smuggle it back in. The mode parameter is required, so no future caller can fall back to the substring behaviour this ticket removes.

**The `/token` fallback had to be fixed for any of this to be usable.** Two pre-existing problems, both of which address-only matching would otherwise have exposed as an empty list:

1. It ran only when the search returned *nothing* for the chain. Impersonators make the array non-empty, so a token outside the top-1000 main list would never be looked up. It now runs whenever no returned token carries the pasted address.
2. Without a selected chain ("All networks") it looked the address up on the default chain of the address format — Ethereum for an EVM address. `GET /v1/token?chain=1&token=0xB095…` answers HTTP 400 (`"is invalid or in deny list"`), the SDK throws, and the rejection discarded the `/tokens` response that already held the token on Base. It now scans every chain of the response before looking anything up, and a failed lookup keeps those results unless the request was aborted.

**Trimming happens once,** in `useTokens`, so the query key, both requests and the pure helpers agree. A pasted address carrying a trailing space or newline previously produced zero results from the search and an HTTP 400 from the lookup. A text query with surrounding whitespace fetched results and then discarded every one of them: `"  usdc  "` answered "we couldn't find any tokens" while the request behind it returned the whole USDC set.

### Differences from the fork's PR

- **`useDisplayedTokens` owns the matcher.** This repo splits the balance-free list into that hook, where the fork keeps it inside `useTokenBalances`. Putting the matcher there preserves the rule that both filter sites share one predicate; `useTokenList` inherits it too.
- **The fallback uses `defaultChainIdsByType`.** The fork resolves the guessed chain through `getAllowedDefaultChainId`, which also drops a chain type the host disallows. This repo has no such helper, and the previous code did not restrict the guess either, so the port keeps that behaviour rather than widening the change.
- `utils/address.ts` holds `isAddressQuery` alone. `sameAddress` is fork-only, and `shortenAddress` lives in `utils/wallet.ts` here.
- The fork's PR also carried a CI fix that calls wrangler through `npx`. It is not needed here: that failure starts at pnpm 12, and this repo runs pnpm 11.

**Deliberately out of scope**

- **Partial addresses.** A truncated paste keeps substring matching, per the ticket's full-format detection rule.
- **The backend.** The API still returns name matches for a full address, which affects every consumer. That deserves its own ticket.
- Two known gaps, neither a regression. A short-form Sui coin type such as `0x2::sui::SUI` still finds nothing: `isValidStructTag` accepts it, so address mode turns on, but the token list stores the padded 32-byte package address and the comparison is exact. Fixing it needs an identifier-equality helper in the SDK, or a decision to treat the short spelling as a name query. And detection now follows the *configured* providers, so a host that lists an ecosystem's chains without registering its provider loses address-only matching for it.
- A whitespace-only query now shows the full list rather than "no tokens found", because no request goes out and the matcher accepts everything. `processTokenList` still reads the untrimmed value, so that list renders without categories and without the native-token hoist. The fork's merged code has the same two untrimmed flags, so this PR keeps parity instead of diverging; worth its own follow-up in both repos.

**Note for analytics consumers:** the `WidgetEvent.TokenSearch` payload now carries the filtered list, so an address search emits one token where it previously emitted many.

## Visual showcase (Screenshots or Videos)

No screenshots. The fork's PR verified this matrix manually in the playground against the released `@lifi/sdk@4.7.0` and the six released providers, "All networks" selected:

| Search | Result |
| --- | --- |
| `0xB095274743941e953c746F9C228DA9c18Bb6ec29` | one row, the real LAPTOP token — the `/tokens` response behind it carried 15 tokens |
| the same address with the hex upper-cased | one row, the same token. Only `strict: false` accepts it |
| `CCW67TSZ…MI75`, Stellar USDC | one row, USDC. `isAddress` rejects a `C…` id, so this row can only come from `StrKey.isValidContract` |
| `0xdba346…::usdc::USDC`, Sui USDC | one row, USDC |
| `bitcoin` | fourteen rows: BTC, BTC.b, WBTC and every token named after it — name and symbol matching is untouched |
| `laptop` | twelve rows, including "Hunter Biden's Laptop" |
| `0x657e19952a2c093bBf34b588df7F42c107bF44e0` | one row, the token at exactly that address, which happens to be one of the impersonators. It is outside the top-1000 main list, so this is the row that exercises the fallback fix; on `main` the same search yields nothing |

**Because every ported test mocks the providers, a green suite proves nothing about the detection itself.** So the twelve fixtures above were also run against the *real* provider factories installed in this workspace, through `chainTypeFromTokenAddress`. All twelve answer as documented, including the three cases that separate the token check from the wallet check: an upper-cased EVM address is a token address but not a wallet address, a Stellar `C…` contract is a token address while a `G…` account is not, and a Bitcoin wallet address is a wallet address but never a token address.

**Automated:** 34 new cases, 203 tests total — `@lifi/widget` at 176 across 14 files, `@lifi/widget-provider` at 27 across 4. They cover address-only matching, the impersonator fixtures from the ticket, the "All networks" chain resolution, a rejected lookup, the trim, and the resolver itself — including that it asks the token check rather than the wallet check, and that a provider which implements no token check never matches.

Three mutations were checked, each failing the tests that should catch it: ignoring the address branch in `createSearchMatcher`, unwiring `isAddressSearch` from the matcher, and removing the trim in `useTokens`.

`pnpm check`, `check:types`, `check:circular-deps` and `knip:check` all pass. No e2e test types an address into the search box.

## Checklist before requesting a review

- [x] I have performed a self-review and testing of my code.
- [x] This pull request is focused and addresses a single problem.
- [x] If this PR modifies the Widget API or adds new features that require documentation, I have updated the documentation in the [public-docs](https://github.com/lifinance/public-docs) repository.
